### PR TITLE
fix(release): align semantic-release with protected branch rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,47 @@
+# Copilot Instructions For kleym
+
+Use these rules whenever you generate commit messages for this repository.
+
+## Commit Format
+
+- Follow Conventional Commits: `<type>(<scope>): <subject>`
+- `scope` is optional, but preferred when it improves clarity.
+- Write a specific, imperative subject line based on the staged diff.
+- Avoid vague subjects like `update`, `changes`, `cleanup`, or `misc fixes`.
+
+## Allowed Types
+
+- `feat`
+- `fix`
+- `perf`
+- `refactor`
+- `revert`
+- `docs`
+- `style`
+- `test`
+- `build`
+- `ci`
+- `chore`
+
+## Release Semantics
+
+- `feat` triggers a **minor** release.
+- `fix`, `perf`, `refactor`, and `revert` trigger a **patch** release.
+- `docs`, `style`, `test`, `build`, `ci`, and `chore` trigger **no release**.
+- Breaking changes must include a `BREAKING CHANGE:` footer and should use `!` in the header when appropriate.
+
+## Preferred Scopes
+
+Use these when they match the change:
+
+- `api`
+- `controller`
+- `config`
+- `deps`
+
+## Source Of Truth
+
+These rules must stay aligned with:
+
+- [`SEMANTIC_VERSIONING.md`](../SEMANTIC_VERSIONING.md)
+- [`.releaserc.json`](../.releaserc.json)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,11 @@
 name: Release
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
     branches:
       - main
 
@@ -11,6 +15,7 @@ permissions:
 jobs:
   release:
     name: Release
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # to be able to publish a GitHub release
@@ -23,6 +28,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -43,22 +43,9 @@
       }
     ],
     [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md"
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         "assets": []
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]
   ]

--- a/SEMANTIC_VERSIONING.md
+++ b/SEMANTIC_VERSIONING.md
@@ -4,12 +4,11 @@ This project uses automated semantic versioning with [semantic-release](https://
 
 ## How It Works
 
-When code is merged to the `main` branch, a GitHub Action automatically:
+After CI succeeds on `main`, a GitHub Action automatically:
 1. Analyzes commit messages since the last release
 2. Determines the next version number based on [Conventional Commits](https://www.conventionalcommits.org/)
-3. Generates a changelog
-4. Creates a git tag
-5. Publishes a GitHub release
+3. Creates a git tag
+4. Publishes a GitHub release with generated release notes
 
 ## Commit Message Format
 
@@ -86,10 +85,6 @@ git commit -m "ci: update GitHub Actions workflow"
 ## Initial Release
 
 If there are no previous tags, semantic-release will create version `1.0.0` on the first run.
-
-## Skipping CI
-
-The release commit itself includes `[skip ci]` to prevent triggering another workflow run.
 
 ## Configuration
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -132,5 +132,5 @@ Docs-related pull requests and pushes to `main` also run a dedicated GitHub Acti
 
 - CI workflows run on GitHub-hosted runners (`ubuntu-latest`) and must not depend on local or self-hosted infrastructure.
 - `.github/workflows/build-and-push.yml` runs separate `Lint` and `Test` jobs and builds container images for eligible refs only after both pass
-- `.github/workflows/release.yml` uses `semantic-release` on `main`
+- `.github/workflows/release.yml` runs `semantic-release` only after a successful `CI` workflow run on `main`
 - Follow Conventional Commits. See `SEMANTIC_VERSIONING.md` for the expected format and versioning rules


### PR DESCRIPTION
## Summary
- make release workflow run after a successful CI workflow run on main (`workflow_run`) and checkout the exact tested SHA
- remove `@semantic-release/git` and `@semantic-release/changelog` so release automation no longer attempts direct protected-branch pushes
- add repository-level Copilot commit guidance from `copilot-optimizations`
- update release docs to match the new flow

## Why
The previous release run failed on main due to branch rules (PR-only updates, required checks, verified signatures) when `@semantic-release/git` tried to push a generated commit.

## Verification
- release workflow YAML parses
- `.releaserc.json` is valid JSON
- release logic still computes versions from Conventional Commits
