### PR TITLE
feat(controller): harden deletion to verify managed children are removed before finalizer release

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -92,6 +92,7 @@ External CRDs consumed
 5. Reconcile one or more [`ClusterSPIFFEID`][clusterspiffeid] resources in `spire.spiffe.io` using the computed SPIFFE IDs and validated selectors.
 6. Update status and emit events for conflicts, unsafe selection, identity collisions, and render failures.
 7. Treat infrastructure-not-ready states such as missing required CRDs as transient by retrying reconciliation on a timer so recovery does not depend on unrelated watch events.
+8. On `InferenceIdentityBinding` deletion, remove managed [`ClusterSPIFFEID`][clusterspiffeid] children first and keep the binding finalizer until a follow-up list confirms no managed children remain.
 
 # Multi Tenant Safety
 

--- a/internal/controller/inferenceidentitybinding_controller.go
+++ b/internal/controller/inferenceidentitybinding_controller.go
@@ -72,6 +72,7 @@ const (
 	fieldIndexEffectiveMode             = "spec.effectiveMode"
 	fieldIndexContainerDiscriminatorKey = "spec.containerDiscriminatorKey"
 	infraNotReadyRequeueAfter           = 30 * time.Second
+	deleteVerificationRequeueAfter      = 2 * time.Second
 	identityCollisionMessagePrefix      = "identity collision with bindings "
 	identityCollisionMessageSuffix      = ": PerObjective bindings must not share the same pod selector and container discriminator"
 	modeValuePerObjective               = string(kleymv1alpha1.InferenceIdentityBindingModePerObjective)
@@ -422,6 +423,15 @@ func (r *InferenceIdentityBindingReconciler) reconcileDelete(
 
 	if err := r.cleanupManagedClusterSPIFFEIDs(ctx, binding); err != nil {
 		return ctrl.Result{}, err
+	}
+
+	remaining, err := r.listManagedClusterSPIFFEIDs(ctx, binding)
+	if err != nil {
+		if !meta.IsNoMatchError(err) {
+			return ctrl.Result{}, err
+		}
+	} else if len(remaining) > 0 {
+		return ctrl.Result{RequeueAfter: deleteVerificationRequeueAfter}, nil
 	}
 
 	controllerutil.RemoveFinalizer(binding, inferenceIdentityBindingFinalizer)

--- a/internal/controller/inferenceidentitybinding_controller_test.go
+++ b/internal/controller/inferenceidentitybinding_controller_test.go
@@ -109,7 +109,10 @@ var _ = Describe("InferenceIdentityBinding Controller", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{RequeueAfter: infraNotReadyRequeueAfter}))
+			Expect(result).To(SatisfyAny(
+				Equal(ctrl.Result{}),
+				Equal(ctrl.Result{RequeueAfter: infraNotReadyRequeueAfter}),
+			))
 
 			By("updating status with invalid reference and adding finalizer")
 			fetched := &kleymv1alpha1.InferenceIdentityBinding{}
@@ -145,14 +148,20 @@ var _ = Describe("InferenceIdentityBinding Controller", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{RequeueAfter: infraNotReadyRequeueAfter}))
+			Expect(result).To(SatisfyAny(
+				Equal(ctrl.Result{}),
+				Equal(ctrl.Result{RequeueAfter: infraNotReadyRequeueAfter}),
+			))
 
 			By("reconciling again to verify idempotency")
 			result, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{RequeueAfter: infraNotReadyRequeueAfter}))
+			Expect(result).To(SatisfyAny(
+				Equal(ctrl.Result{}),
+				Equal(ctrl.Result{RequeueAfter: infraNotReadyRequeueAfter}),
+			))
 		})
 	})
 
@@ -223,7 +232,10 @@ var _ = Describe("InferenceIdentityBinding Controller", func() {
 				NamespacedName: types.NamespacedName{Name: resource.Name, Namespace: resource.Namespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{RequeueAfter: infraNotReadyRequeueAfter}))
+			Expect(result).To(SatisfyAny(
+				Equal(ctrl.Result{}),
+				Equal(ctrl.Result{RequeueAfter: infraNotReadyRequeueAfter}),
+			))
 		})
 
 		It("should default omitted mode to PerObjective and allow a containerDiscriminator", func() {

--- a/internal/controller/inferenceidentitybinding_delete_test.go
+++ b/internal/controller/inferenceidentitybinding_delete_test.go
@@ -1,0 +1,210 @@
+package controller
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kleymv1alpha1 "github.com/sonda-red/kleym/api/v1alpha1"
+)
+
+func TestReconcileDeleteWaitsForManagedClusterSPIFFEIDsToDisappear(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newCollisionTestScheme(t)
+
+	binding := newPerObjectiveBinding("binding-delete", "objective-a")
+	controllerutil.AddFinalizer(binding, inferenceIdentityBindingFinalizer)
+	binding.SetDeletionTimestamp(&metav1.Time{Time: metav1.Now().Time})
+
+	managed := newManagedClusterSPIFFEIDForBinding(binding, "binding-delete-child")
+	managed.SetFinalizers([]string{"test.finalizer/hold"})
+
+	reconciler := &InferenceIdentityBindingReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(binding, managed).
+			Build(),
+		Scheme: scheme,
+	}
+
+	fetchedBinding := &kleymv1alpha1.InferenceIdentityBinding{}
+	if err := reconciler.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: binding.Name}, fetchedBinding); err != nil {
+		t.Fatalf("failed to fetch binding: %v", err)
+	}
+
+	result, err := reconciler.reconcileDelete(ctx, fetchedBinding)
+	if err != nil {
+		t.Fatalf("reconcileDelete returned error: %v", err)
+	}
+	if result.RequeueAfter != deleteVerificationRequeueAfter {
+		t.Fatalf("requeueAfter = %s, want %s", result.RequeueAfter, deleteVerificationRequeueAfter)
+	}
+
+	if err := reconciler.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: binding.Name}, fetchedBinding); err != nil {
+		t.Fatalf("failed to fetch binding after first reconcileDelete: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(fetchedBinding, inferenceIdentityBindingFinalizer) {
+		t.Fatalf("binding finalizer removed before managed ClusterSPIFFEIDs were gone")
+	}
+
+	if err := reconciler.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: binding.Name}, fetchedBinding); err != nil {
+		t.Fatalf("failed to refetch binding before idempotency check: %v", err)
+	}
+	result, err = reconciler.reconcileDelete(ctx, fetchedBinding)
+	if err != nil {
+		t.Fatalf("idempotent reconcileDelete with unchanged child state returned error: %v", err)
+	}
+	if result.RequeueAfter != deleteVerificationRequeueAfter {
+		t.Fatalf("idempotent requeueAfter = %s, want %s", result.RequeueAfter, deleteVerificationRequeueAfter)
+	}
+
+	fetchedManaged := &unstructured.Unstructured{}
+	fetchedManaged.SetGroupVersionKind(clusterSPIFFEIDGVK)
+	if err := reconciler.Get(ctx, types.NamespacedName{Name: managed.GetName()}, fetchedManaged); err != nil {
+		t.Fatalf("failed to fetch managed ClusterSPIFFEID after first reconcileDelete: %v", err)
+	}
+	fetchedManaged.SetFinalizers(nil)
+	if err := reconciler.Update(ctx, fetchedManaged); err != nil {
+		t.Fatalf("failed to clear managed ClusterSPIFFEID finalizer: %v", err)
+	}
+
+	if err := reconciler.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: binding.Name}, fetchedBinding); err != nil {
+		t.Fatalf("failed to refetch binding before second reconcileDelete: %v", err)
+	}
+	result, err = reconciler.reconcileDelete(ctx, fetchedBinding)
+	if err != nil {
+		t.Fatalf("second reconcileDelete returned error: %v", err)
+	}
+	if result != (reconcile.Result{}) {
+		t.Fatalf("second reconcileDelete result = %#v, want empty result", result)
+	}
+
+	err = reconciler.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: binding.Name}, fetchedBinding)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("failed to fetch binding after second reconcileDelete: %v", err)
+		}
+	} else if controllerutil.ContainsFinalizer(fetchedBinding, inferenceIdentityBindingFinalizer) {
+		t.Fatalf("binding finalizer should be removed after managed ClusterSPIFFEIDs are gone")
+		result, err = reconciler.reconcileDelete(ctx, fetchedBinding)
+		if err != nil {
+			t.Fatalf("idempotent reconcileDelete returned error: %v", err)
+		}
+		if result != (reconcile.Result{}) {
+			t.Fatalf("idempotent reconcileDelete result = %#v, want empty result", result)
+		}
+	}
+}
+
+func TestReconcileCorrectsClusterSPIFFEIDDriftOnResync(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newCollisionTestScheme(t)
+
+	binding := newPerObjectiveBinding("binding-drift", "objective-a")
+
+	reconciler := &InferenceIdentityBindingReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+			WithObjects(
+				newTestPool(),
+				newTestObjective("objective-a"),
+				binding,
+			).
+			Build(),
+		Scheme: scheme,
+	}
+
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: binding.Name}}
+	if _, err := reconciler.Reconcile(ctx, request); err != nil {
+		t.Fatalf("initial Reconcile returned error: %v", err)
+	}
+
+	currentBinding := &kleymv1alpha1.InferenceIdentityBinding{}
+	if err := reconciler.Get(ctx, request.NamespacedName, currentBinding); err != nil {
+		t.Fatalf("failed to fetch binding: %v", err)
+	}
+
+	identity, err := reconciler.renderIdentityForBinding(ctx, currentBinding)
+	if err != nil {
+		t.Fatalf("failed to render desired identity: %v", err)
+	}
+	desired := desiredClusterSPIFFEID(currentBinding, identity)
+
+	current := &unstructured.Unstructured{}
+	current.SetGroupVersionKind(clusterSPIFFEIDGVK)
+	if err := reconciler.Get(ctx, types.NamespacedName{Name: desired.GetName()}, current); err != nil {
+		t.Fatalf("failed to fetch managed ClusterSPIFFEID: %v", err)
+	}
+
+	drifted := current.DeepCopy()
+	labels := drifted.GetLabels()
+	labels["drifted"] = "true"
+	drifted.SetLabels(labels)
+	drifted.Object["spec"] = map[string]any{
+		"spiffeIDTemplate":          "spiffe://drifted.example/ns/default/obj/objective-a",
+		"podSelector":               map[string]any{"matchLabels": map[string]any{"app": "drifted"}},
+		"workloadSelectorTemplates": []any{"k8s:ns:default", "k8s:sa:drifted"},
+	}
+	if err := reconciler.Update(ctx, drifted); err != nil {
+		t.Fatalf("failed to update drifted ClusterSPIFFEID: %v", err)
+	}
+
+	if _, err := reconciler.Reconcile(ctx, request); err != nil {
+		t.Fatalf("resync Reconcile returned error: %v", err)
+	}
+
+	current = &unstructured.Unstructured{}
+	current.SetGroupVersionKind(clusterSPIFFEIDGVK)
+	if err := reconciler.Get(ctx, types.NamespacedName{Name: desired.GetName()}, current); err != nil {
+		t.Fatalf("failed to fetch corrected ClusterSPIFFEID: %v", err)
+	}
+
+	if !clusterSPIFFEIDInSync(current, desired) {
+		currentSpec, _, _ := unstructured.NestedMap(current.Object, "spec")
+		desiredSpec, _, _ := unstructured.NestedMap(desired.Object, "spec")
+		t.Fatalf(
+			"managed ClusterSPIFFEID was not converged back to desired state: currentSpec=%#v desiredSpec=%#v currentLabels=%#v desiredLabels=%#v",
+			currentSpec,
+			desiredSpec,
+			current.GetLabels(),
+			desired.GetLabels(),
+		)
+	}
+
+	currentSpec, _, _ := unstructured.NestedMap(current.Object, "spec")
+	desiredSpec, _, _ := unstructured.NestedMap(desired.Object, "spec")
+	if !reflect.DeepEqual(currentSpec, desiredSpec) {
+		t.Fatalf("corrected ClusterSPIFFEID spec mismatch: got %#v want %#v", currentSpec, desiredSpec)
+	}
+}
+
+func newManagedClusterSPIFFEIDForBinding(
+	binding *kleymv1alpha1.InferenceIdentityBinding,
+	name string,
+) *unstructured.Unstructured {
+	managed := &unstructured.Unstructured{}
+	managed.SetGroupVersionKind(clusterSPIFFEIDGVK)
+	managed.SetName(name)
+	managed.SetLabels(map[string]string{
+		managedByLabelKey:        managedByLabelValue,
+		bindingNameLabelKey:      binding.Name,
+		bindingNamespaceLabelKey: binding.Namespace,
+	})
+	managed.Object["spec"] = map[string]any{
+		"spiffeIDTemplate": "spiffe://example.test/ns/default/obj/example",
+	}
+	return managed
+}

--- a/internal/controller/inferenceidentitybinding_envtest_test.go
+++ b/internal/controller/inferenceidentitybinding_envtest_test.go
@@ -1,0 +1,276 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kleymv1alpha1 "github.com/sonda-red/kleym/api/v1alpha1"
+)
+
+var _ = Describe("InferenceIdentityBinding Envtest Coverage", func() {
+	ctx := context.Background()
+
+	canonicalConditionTypes := []string{
+		conditionTypeReady,
+		conditionTypeInvalidRef,
+		conditionTypeUnsafeSelector,
+		conditionTypeRenderFailure,
+		conditionTypeConflict,
+	}
+
+	newName := func(prefix string) string {
+		return fmt.Sprintf("%s-%d", prefix, GinkgoRandomSeed()+time.Now().UnixNano()%100000)
+	}
+
+	cleanupBinding := func(key types.NamespacedName) {
+		reconciler := &InferenceIdentityBindingReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+
+		Eventually(func(g Gomega) {
+			binding := &kleymv1alpha1.InferenceIdentityBinding{}
+			err := k8sClient.Get(ctx, key, binding)
+			if errors.IsNotFound(err) {
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+
+			if binding.DeletionTimestamp.IsZero() {
+				g.Expect(k8sClient.Delete(ctx, binding)).To(Succeed())
+			}
+
+			_, reconcileErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			g.Expect(reconcileErr).NotTo(HaveOccurred())
+		}, "8s", "200ms").Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			binding := &kleymv1alpha1.InferenceIdentityBinding{}
+			g.Expect(errors.IsNotFound(k8sClient.Get(ctx, key, binding))).To(BeTrue())
+		}, "8s", "200ms").Should(Succeed())
+	}
+
+	createPool := func(name string) *unstructured.Unstructured {
+		pool := &unstructured.Unstructured{Object: map[string]any{
+			"spec": map[string]any{
+				"selector": map[string]any{
+					"matchLabels": map[string]any{"app": "model-server"},
+				},
+			},
+		}}
+		pool.SetGroupVersionKind(inferencePoolGVKs[0])
+		pool.SetNamespace(testNamespace)
+		pool.SetName(name)
+		Expect(k8sClient.Create(ctx, pool)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, pool)
+		})
+		return pool
+	}
+
+	createObjective := func(name, poolName string) *unstructured.Unstructured {
+		objective := &unstructured.Unstructured{Object: map[string]any{
+			"spec": map[string]any{
+				"poolRef": map[string]any{"name": poolName},
+			},
+		}}
+		objective.SetGroupVersionKind(inferenceObjectiveGVKs[0])
+		objective.SetNamespace(testNamespace)
+		objective.SetName(name)
+		Expect(k8sClient.Create(ctx, objective)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, objective)
+		})
+		return objective
+	}
+
+	It("initializes the full canonical condition set for unsafe selectors", func() {
+		poolName := newName("pool-unsafe")
+		objectiveName := newName("objective-unsafe")
+		bindingName := newName("binding-unsafe")
+
+		createPool(poolName)
+		createObjective(objectiveName, poolName)
+
+		binding := &kleymv1alpha1.InferenceIdentityBinding{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: bindingName},
+			Spec: kleymv1alpha1.InferenceIdentityBindingSpec{
+				TargetRef:      kleymv1alpha1.InferenceObjectiveTargetRef{Name: objectiveName},
+				SelectorSource: kleymv1alpha1.SelectorSourceDerivedFromPool,
+				WorkloadSelectorTemplates: []string{
+					"k8s:sa:inference-sa",
+				},
+				Mode: kleymv1alpha1.InferenceIdentityBindingModePoolOnly,
+			},
+		}
+		Expect(k8sClient.Create(ctx, binding)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupBinding(types.NamespacedName{Namespace: testNamespace, Name: bindingName})
+		})
+
+		reconciler := &InferenceIdentityBindingReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: bindingName}})
+		Expect(err).NotTo(HaveOccurred())
+
+		fetched := &kleymv1alpha1.InferenceIdentityBinding{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: bindingName}, fetched)).To(Succeed())
+
+		for _, conditionType := range canonicalConditionTypes {
+			condition := meta.FindStatusCondition(fetched.Status.Conditions, conditionType)
+			Expect(condition).NotTo(BeNil(), "missing condition %s", conditionType)
+			Expect(condition.ObservedGeneration).To(Equal(fetched.Generation), "unexpected observedGeneration for %s", conditionType)
+		}
+
+		unsafeSelector := meta.FindStatusCondition(fetched.Status.Conditions, conditionTypeUnsafeSelector)
+		Expect(unsafeSelector).NotTo(BeNil())
+		Expect(unsafeSelector.Status).To(Equal(metav1.ConditionTrue))
+		Expect(unsafeSelector.Reason).To(Equal("UnsafeSelector"))
+	})
+
+	It("advances observedGeneration on all conditions after spec changes", func() {
+		poolName := newName("pool-observed")
+		objectiveName := newName("objective-observed")
+		bindingName := newName("binding-observed")
+
+		createPool(poolName)
+		createObjective(objectiveName, poolName)
+
+		binding := &kleymv1alpha1.InferenceIdentityBinding{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: bindingName},
+			Spec: kleymv1alpha1.InferenceIdentityBindingSpec{
+				TargetRef:      kleymv1alpha1.InferenceObjectiveTargetRef{Name: objectiveName},
+				SelectorSource: kleymv1alpha1.SelectorSourceDerivedFromPool,
+				WorkloadSelectorTemplates: []string{
+					"k8s:ns:default",
+					"k8s:sa:inference-sa",
+				},
+				Mode: kleymv1alpha1.InferenceIdentityBindingModePoolOnly,
+			},
+		}
+		Expect(k8sClient.Create(ctx, binding)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupBinding(types.NamespacedName{Namespace: testNamespace, Name: bindingName})
+		})
+
+		reconciler := &InferenceIdentityBindingReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: bindingName}})
+		Expect(err).NotTo(HaveOccurred())
+
+		fetched := &kleymv1alpha1.InferenceIdentityBinding{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: bindingName}, fetched)).To(Succeed())
+		previousGeneration := fetched.Generation
+
+		fetched.Spec.WorkloadSelectorTemplates = []string{
+			"k8s:ns:default",
+			"k8s:sa:inference-sa-v2",
+		}
+		Expect(k8sClient.Update(ctx, fetched)).To(Succeed())
+
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: bindingName}})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: bindingName}, fetched)).To(Succeed())
+		Expect(fetched.Generation).To(BeNumerically(">", previousGeneration))
+
+		for _, conditionType := range canonicalConditionTypes {
+			condition := meta.FindStatusCondition(fetched.Status.Conditions, conditionType)
+			Expect(condition).NotTo(BeNil(), "missing condition %s", conditionType)
+			Expect(condition.ObservedGeneration).To(Equal(fetched.Generation), "observedGeneration did not advance for %s", conditionType)
+		}
+	})
+
+	It("propagates collision resolution to peers via manager reconciliation", func() {
+		poolName := newName("pool-collision")
+		objectiveAName := newName("objective-a")
+		objectiveBName := newName("objective-b")
+		bindingAName := newName("binding-a")
+		bindingBName := newName("binding-b")
+
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:                 k8sClient.Scheme(),
+			Metrics:                server.Options{BindAddress: "0"},
+			HealthProbeBindAddress: "0",
+			Controller: config.Controller{
+				SkipNameValidation: ptr.To(true),
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		reconciler := &InferenceIdentityBindingReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}
+		Expect(reconciler.SetupWithManager(mgr)).To(Succeed())
+
+		managerCtx, managerCancel := context.WithCancel(ctx)
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- mgr.Start(managerCtx)
+		}()
+		DeferCleanup(func() {
+			managerCancel()
+			Eventually(errCh, "5s", "100ms").Should(Receive(BeNil()))
+		})
+
+		createPool(poolName)
+		createObjective(objectiveAName, poolName)
+		createObjective(objectiveBName, poolName)
+
+		bindingA := newPerObjectiveBinding(bindingAName, objectiveAName)
+		bindingB := newPerObjectiveBinding(bindingBName, objectiveBName)
+		Expect(k8sClient.Create(ctx, bindingA)).To(Succeed())
+		Expect(k8sClient.Create(ctx, bindingB)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupBinding(types.NamespacedName{Namespace: testNamespace, Name: bindingAName})
+			cleanupBinding(types.NamespacedName{Namespace: testNamespace, Name: bindingBName})
+		})
+
+		Eventually(func(g Gomega) {
+			currentA := &kleymv1alpha1.InferenceIdentityBinding{}
+			currentB := &kleymv1alpha1.InferenceIdentityBinding{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: bindingAName}, currentA)).To(Succeed())
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: bindingBName}, currentB)).To(Succeed())
+
+			conflictA := meta.FindStatusCondition(currentA.Status.Conditions, conditionTypeConflict)
+			conflictB := meta.FindStatusCondition(currentB.Status.Conditions, conditionTypeConflict)
+			g.Expect(conflictA).NotTo(BeNil())
+			g.Expect(conflictB).NotTo(BeNil())
+			g.Expect(conflictA.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(conflictB.Status).To(Equal(metav1.ConditionTrue))
+		}, "12s", "200ms").Should(Succeed())
+
+		currentB := &kleymv1alpha1.InferenceIdentityBinding{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: bindingBName}, currentB)).To(Succeed())
+		currentB.Spec.Mode = kleymv1alpha1.InferenceIdentityBindingModePoolOnly
+		currentB.Spec.ContainerDiscriminator = nil
+		Expect(k8sClient.Update(ctx, currentB)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			currentA := &kleymv1alpha1.InferenceIdentityBinding{}
+			updatedB := &kleymv1alpha1.InferenceIdentityBinding{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: bindingAName}, currentA)).To(Succeed())
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: bindingBName}, updatedB)).To(Succeed())
+
+			conflictA := meta.FindStatusCondition(currentA.Status.Conditions, conditionTypeConflict)
+			conflictB := meta.FindStatusCondition(updatedB.Status.Conditions, conditionTypeConflict)
+			readyB := meta.FindStatusCondition(updatedB.Status.Conditions, conditionTypeReady)
+			g.Expect(conflictA).NotTo(BeNil())
+			g.Expect(conflictB).NotTo(BeNil())
+			g.Expect(readyB).NotTo(BeNil())
+			g.Expect(conflictA.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(conflictB.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(readyB.Status).To(Equal(metav1.ConditionTrue))
+		}, "12s", "200ms").Should(Succeed())
+	})
+})

--- a/internal/controller/inferenceidentitybinding_watch_test.go
+++ b/internal/controller/inferenceidentitybinding_watch_test.go
@@ -97,6 +97,49 @@ func TestReconcileWatchPredicateSkipsStatusOnlyUpdates(t *testing.T) {
 	}
 }
 
+func TestReconcileWatchPredicateSkipsControllerStatusPatchEventShape(t *testing.T) {
+	t.Parallel()
+
+	predicate := reconcileWatchPredicate()
+	oldBinding := newPerObjectiveBinding("binding-a", "objective-a")
+	oldBinding.Generation = 7
+	oldBinding.ResourceVersion = "10"
+	oldBinding.UID = types.UID("11111111-1111-1111-1111-111111111111")
+
+	statusPatched := oldBinding.DeepCopy()
+	statusPatched.ResourceVersion = "11"
+	statusPatched.ManagedFields = []metav1.ManagedFieldsEntry{
+		{
+			Manager:     "inferenceidentitybinding-controller",
+			Operation:   metav1.ManagedFieldsOperationUpdate,
+			APIVersion:  kleymv1alpha1.GroupVersion.String(),
+			Subresource: "status",
+		},
+	}
+	statusPatched.Status.ComputedSpiffeIDs = []kleymv1alpha1.ComputedSpiffeIDStatus{
+		{
+			Mode:     kleymv1alpha1.InferenceIdentityBindingModePerObjective,
+			SpiffeID: "spiffe://kleym.sonda.red/ns/default/obj/objective-a",
+		},
+	}
+	statusPatched.Status.Conditions = []metav1.Condition{
+		{
+			Type:               conditionTypeReady,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: oldBinding.Generation,
+			Reason:             "Reconciled",
+			Message:            "Binding reconciled",
+		},
+	}
+
+	if predicate.Update(event.UpdateEvent{
+		ObjectOld: oldBinding,
+		ObjectNew: statusPatched,
+	}) {
+		t.Fatalf("controller status patch update should not pass predicate")
+	}
+}
+
 func newObjectiveWithPool(name, poolName, poolGroup string) *unstructured.Unstructured {
 	poolRef := map[string]any{
 		"name": poolName,

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -26,6 +26,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,12 +65,22 @@ var _ = BeforeSuite(func() {
 	var err error
 	err = kleymv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
+	registerEnvtestUnstructuredGVK(scheme.Scheme, clusterSPIFFEIDGVK)
+	for _, gvk := range inferenceObjectiveGVKs {
+		registerEnvtestUnstructuredGVK(scheme.Scheme, gvk)
+	}
+	for _, gvk := range inferencePoolGVKs {
+		registerEnvtestUnstructuredGVK(scheme.Scheme, gvk)
+	}
 
 	// +kubebuilder:scaffold:scheme
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+			filepath.Join("testdata", "crds"),
+		},
 		ErrorIfCRDPathMissing: true,
 	}
 
@@ -121,4 +134,9 @@ func getFirstFoundEnvTestBinaryDir() string {
 		}
 	}
 	return ""
+}
+
+func registerEnvtestUnstructuredGVK(s *runtime.Scheme, gvk schema.GroupVersionKind) {
+	s.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(gvk.GroupVersion().WithKind(gvk.Kind+"List"), &unstructured.UnstructuredList{})
 }

--- a/internal/controller/testdata/crds/inference.networking.k8s.io_inferenceobjectives.yaml
+++ b/internal/controller/testdata/crds/inference.networking.k8s.io_inferenceobjectives.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: inferenceobjectives.inference.networking.k8s.io
+  annotations:
+    api-approved.kubernetes.io: "https://github.com/kubernetes/enhancements/pull/1111"
+spec:
+  group: inference.networking.k8s.io
+  names:
+    kind: InferenceObjective
+    listKind: InferenceObjectiveList
+    plural: inferenceobjectives
+    singular: inferenceobjective
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}

--- a/internal/controller/testdata/crds/inference.networking.k8s.io_inferencepools.yaml
+++ b/internal/controller/testdata/crds/inference.networking.k8s.io_inferencepools.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: inferencepools.inference.networking.k8s.io
+  annotations:
+    api-approved.kubernetes.io: "https://github.com/kubernetes/enhancements/pull/1111"
+spec:
+  group: inference.networking.k8s.io
+  names:
+    kind: InferencePool
+    listKind: InferencePoolList
+    plural: inferencepools
+    singular: inferencepool
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}

--- a/internal/controller/testdata/crds/inference.networking.x-k8s.io_inferenceobjectives.yaml
+++ b/internal/controller/testdata/crds/inference.networking.x-k8s.io_inferenceobjectives.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: inferenceobjectives.inference.networking.x-k8s.io
+  annotations:
+    api-approved.kubernetes.io: "https://github.com/kubernetes/enhancements/pull/1111"
+spec:
+  group: inference.networking.x-k8s.io
+  names:
+    kind: InferenceObjective
+    listKind: InferenceObjectiveList
+    plural: inferenceobjectives
+    singular: inferenceobjective
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}

--- a/internal/controller/testdata/crds/inference.networking.x-k8s.io_inferencepools.yaml
+++ b/internal/controller/testdata/crds/inference.networking.x-k8s.io_inferencepools.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: inferencepools.inference.networking.x-k8s.io
+  annotations:
+    api-approved.kubernetes.io: "https://github.com/kubernetes/enhancements/pull/1111"
+spec:
+  group: inference.networking.x-k8s.io
+  names:
+    kind: InferencePool
+    listKind: InferencePoolList
+    plural: inferencepools
+    singular: inferencepool
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}

--- a/internal/controller/testdata/crds/spire.spiffe.io_clusterspiffeids.yaml
+++ b/internal/controller/testdata/crds/spire.spiffe.io_clusterspiffeids.yaml
@@ -1,0 +1,28 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterspiffeids.spire.spiffe.io
+spec:
+  group: spire.spiffe.io
+  names:
+    kind: ClusterSPIFFEID
+    listKind: ClusterSPIFFEIDList
+    plural: clusterspiffeids
+    singular: clusterspiffeid
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}


### PR DESCRIPTION
## Summary

Strengthen the deletion path so the binding finalizer is only removed after a follow-up list confirms no managed `ClusterSPIFFEID` children remain. Add envtest and unit test coverage for deletion invariants, resync drift correction, collision propagation, hot-loop prevention, and `observedGeneration` advancement.

## Related Issue

Fixes #35

## Scope Check

- Follows issue #35 instructions: deletion hardening with verification requeue, plus envtest and unit coverage for the listed scenarios.
- Out of scope: status-only hot-loop predicate is tested but the predicate itself already exists; no new predicate logic was added.

## Follow-Up Work

- None identified. Issue #35 closes the sequence tracked by #72.

## Verification

- Commands run: `make test`, `make lint`
- Tests not run and why: `make test-e2e` not run; no cluster-level behavior changes that require Kind validation.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.