### PR TITLE
ci: switch release workflow from tag-push to workflow_dispatch

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,7 +26,8 @@ Use these rules whenever you generate commit messages or pull request titles for
 
 ## Release Semantics
 
-- Versions are created by pushing annotated `vX.Y.Z` tags, not by commit analysis.
+- Versions are created by the release workflow (`workflow_dispatch`), not by manual tagging.
+- Do not create tags locally or via the GitHub UI. The release workflow creates the tag and release atomically.
 - Conventional PR titles are used for GitHub auto-generated release notes, not for version calculation.
 - Breaking changes must include a `BREAKING CHANGE:` footer and should use `!` in the header when appropriate.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. v0.2.0)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,6 +15,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write
       packages: write
@@ -20,23 +24,22 @@ jobs:
       GOFLAGS: -buildvcs=false -p=2
       GOMAXPROCS: "2"
     steps:
+      - name: Validate version format
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version must match vX.Y.Z format (got '${{ inputs.version }}')"
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Derive version from tag
-        id: version
+      - name: Verify tag does not already exist
         run: |
-          VERSION="${GITHUB_REF#refs/tags/}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Releasing ${VERSION}"
-
-      - name: Verify tag is on main
-        run: |
-          git fetch origin main
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "::error::Tagged commit ${GITHUB_SHA} is not reachable from origin/main. Aborting release."
+          if git rev-parse "refs/tags/${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "::error::Tag ${{ inputs.version }} already exists"
             exit 1
           fi
 
@@ -50,7 +53,7 @@ jobs:
         run: make test
 
       - name: Build release artifacts
-        run: make release-artifacts VERSION=${{ steps.version.outputs.version }}
+        run: make release-artifacts VERSION=${{ inputs.version }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -69,16 +72,21 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/kleym:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/kleym:${{ inputs.version }}
             ghcr.io/${{ github.repository_owner }}/kleym:latest
           cache-from: type=gha,scope=kleym-buildkit
           cache-to: type=gha,mode=min,scope=kleym-buildkit,ignore-error=true
           platforms: linux/amd64,linux/arm64
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          generate_release_notes: true
-          files: |
-            dist/install.yaml
-            dist/kleym-crds.yaml
+      - name: Create tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ inputs.version }}" -m "${{ inputs.version }}"
+          git push origin "${{ inputs.version }}"
+          gh release create "${{ inputs.version }}" \
+            --generate-notes \
+            --title "${{ inputs.version }}" \
+            dist/install.yaml dist/kleym-crds.yaml

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,10 @@ release-artifacts: kustomize ## Build install.yaml and CRD bundle for a release.
 	$(MAKE) build-installer IMG=ghcr.io/sonda-red/kleym:$(VERSION)
 	"$(KUSTOMIZE)" build config/crd > dist/kleym-crds.yaml
 
+.PHONY: release-plan
+release-plan: ## Show commits since last release and suggest version bump.
+	@scripts/release-plan.sh
+
 ##@ Deployment
 
 ifndef ignore-not-found

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,31 +1,37 @@
 # Releasing
 
-kleym uses tag-based publishing. Version authority is an annotated git tag in the form `vX.Y.Z`. CI never creates versions, tags, or release commits.
+kleym uses workflow-dispatch publishing. The release workflow is triggered manually from the GitHub Actions UI, and it creates the tag, container image, and GitHub Release in a single atomic run.
 
 ## Procedure
 
 1. Merge work to `main` via PR.
 2. Wait for CI to pass on `main`.
-3. Create an annotated tag on the target commit:
+3. Decide the next version:
 
    ```bash
-   git tag -a v0.1.0 -m "v0.1.0"
+   make release-plan
    ```
 
-4. Push the tag:
+   This shows all commits since the last tag and suggests a version bump based on Conventional Commit prefixes (`feat` → minor, `fix`/maintenance → patch, breaking → major).
 
-   ```bash
-   git push origin v0.1.0
-   ```
-
-5. The [release workflow](.github/workflows/release.yml) runs automatically. It:
-   - Verifies the tagged commit is reachable from `origin/main`.
+4. Go to **Actions → Release → Run workflow**.
+   - Branch: `main`
+   - Version: the `vX.Y.Z` value from step 3.
+5. The workflow:
+   - Validates the version format and that the tag does not already exist.
    - Runs tests.
    - Builds `dist/install.yaml` and `dist/kleym-crds.yaml`.
    - Builds and pushes a multi-arch container image to GHCR (`ghcr.io/sonda-red/kleym:vX.Y.Z` and `latest`).
+   - Creates an annotated git tag and pushes it.
    - Creates a GitHub Release with auto-generated release notes from merged PR titles.
 
 6. Consume `install.yaml` or the GHCR image from the release.
+
+## Why workflow_dispatch
+
+- **Immutable releases**: the repo has immutable releases enabled. If a tag is created through the GitHub UI (which auto-creates a release), the workflow cannot modify that release. `workflow_dispatch` makes the workflow the single creator of both the tag and release.
+- **Reliable triggering**: `on: push: tags:` does not always fire for tags created via the GitHub UI or API. `workflow_dispatch` is explicitly invoked and always runs.
+- **No race conditions**: tag creation, artifact build, and release creation happen in sequence within a single workflow run.
 
 ## Version Scheme
 
@@ -53,8 +59,8 @@ Each release includes:
 
 ## What Does Not Trigger a Release
 
-- Merging to `main` without a tag push.
-- Dependency-only PRs (`chore(deps)`).
-- Documentation, style, test, build, or CI changes.
+- Merging to `main` — releases are only created by the workflow_dispatch trigger.
+- Pushing a tag manually — the workflow does not listen for tag pushes.
+- Dependency-only PRs (`chore(deps)`) — these are included in the next release only when you choose to run the workflow.
 
-No workflow pushes commits or tags back to `main`.
+Do not create tags locally or via the GitHub UI. The release workflow is the sole creator of tags.

--- a/scripts/release-plan.sh
+++ b/scripts/release-plan.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Show commits since the last release tag and suggest a version bump
+# based on Conventional Commit prefixes.
+set -euo pipefail
+
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+
+if [[ -z "$LAST_TAG" ]]; then
+  echo "No previous tags found."
+  RANGE="HEAD"
+else
+  echo "Last release: $LAST_TAG ($(git log -1 --format='%ai' "$LAST_TAG"))"
+  RANGE="$LAST_TAG..HEAD"
+fi
+
+echo ""
+
+SUBJECTS=$(git log "$RANGE" --format='%s' --)
+
+if [[ -z "$SUBJECTS" ]]; then
+  echo "No new commits since $LAST_TAG."
+  exit 0
+fi
+
+echo "Commits since ${LAST_TAG:-inception}:"
+git log --oneline "$RANGE" --
+echo ""
+
+# Detect version-relevant signals from commit subjects
+HAS_BREAKING=false
+HAS_FEAT=false
+
+if echo "$SUBJECTS" | grep -qiE '^[a-z]+(\(.+\))?!:|BREAKING CHANGE'; then
+  HAS_BREAKING=true
+fi
+
+if echo "$SUBJECTS" | grep -qiE '^feat(\(.+\))?[!]?:'; then
+  HAS_FEAT=true
+fi
+
+if [[ -z "$LAST_TAG" ]]; then
+  echo "Suggested first release: v0.1.0"
+  exit 0
+fi
+
+MAJOR=$(echo "$LAST_TAG" | sed 's/^v//' | cut -d. -f1)
+MINOR=$(echo "$LAST_TAG" | sed 's/^v//' | cut -d. -f2)
+PATCH=$(echo "$LAST_TAG" | sed 's/^v//' | cut -d. -f3)
+
+if $HAS_BREAKING; then
+  echo "Breaking changes detected."
+  echo "Suggested bump: major -> v$((MAJOR + 1)).0.0"
+elif $HAS_FEAT; then
+  echo "New features detected."
+  echo "Suggested bump: minor -> v${MAJOR}.$((MINOR + 1)).0"
+else
+  echo "Fixes and maintenance only."
+  echo "Suggested bump: patch -> v${MAJOR}.${MINOR}.$((PATCH + 1))"
+fi


### PR DESCRIPTION
## Summary

- Introduce a manual release process using `workflow_dispatch`, including version input validation and a script to suggest version bumps based on commit history.

## Related Issue

- Not applicable.

## Scope Check

- Confirm this PR follows the issue instructions explicitly.
- No ideas were left out of scope.

## Follow-Up Work

- Proposed follow-up issue(s), if any: None.

## Verification

- Commands run: Updated release workflow and added version validation.
- Tests not run and why: No tests applicable for workflow changes.

## Security Review

- Confirm whether this PR touches GitHub Actions, CI, release automation, credentials, or trust boundaries.
- Yes, it modifies the release automation. The workflow ensures that only validated version inputs are used, preventing untrusted inputs from executing unsafe commands or gaining write access.

