### PR TITLE
test(controller): expand GAIE watch/ref coverage for issue #26

### DIFF
--- a/internal/controller/inferenceidentitybinding_resolver_test.go
+++ b/internal/controller/inferenceidentitybinding_resolver_test.go
@@ -1,0 +1,84 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kleymv1alpha1 "github.com/sonda-red/kleym/api/v1alpha1"
+)
+
+func TestReconcileSetsInvalidRefWhenPoolCannotBeResolved(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newCollisionTestScheme(t)
+
+	binding := newPerObjectiveBinding("binding-missing-pool", "objective-missing-pool")
+	reconciler := &InferenceIdentityBindingReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+			WithObjects(
+				newTestObjective("objective-missing-pool"),
+				binding,
+			).
+			Build(),
+		Scheme: scheme,
+	}
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: binding.Name},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	assertConditionStatus(t, ctx, reconciler.Client, binding.Name, conditionTypeInvalidRef, metav1.ConditionTrue, "TargetPoolNotFound")
+	assertConditionStatus(t, ctx, reconciler.Client, binding.Name, conditionTypeReady, metav1.ConditionFalse, "TargetPoolNotFound")
+}
+
+func TestReconcileSetsInvalidRefWhenObjectivePoolRefIsInvalid(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newCollisionTestScheme(t)
+
+	objective := &unstructured.Unstructured{
+		Object: map[string]any{
+			"spec": map[string]any{
+				"poolRef": map[string]any{
+					"group": "inference.networking.k8s.io",
+				},
+			},
+		},
+	}
+	objective.SetGroupVersionKind(inferenceObjectiveGVKs[0])
+	objective.SetNamespace(testNamespace)
+	objective.SetName("objective-invalid-pool-ref")
+
+	binding := newPerObjectiveBinding("binding-invalid-pool-ref", objective.GetName())
+	reconciler := &InferenceIdentityBindingReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+			WithObjects(objective, binding).
+			Build(),
+		Scheme: scheme,
+	}
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: binding.Name},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	assertConditionStatus(t, ctx, reconciler.Client, binding.Name, conditionTypeInvalidRef, metav1.ConditionTrue, "InvalidPoolRef")
+	assertConditionStatus(t, ctx, reconciler.Client, binding.Name, conditionTypeReady, metav1.ConditionFalse, "InvalidPoolRef")
+}

--- a/internal/controller/inferenceidentitybinding_watch_test.go
+++ b/internal/controller/inferenceidentitybinding_watch_test.go
@@ -70,6 +70,52 @@ func TestMapPoolToBindingsTargetsOnlyBindingsForReferencingObjectives(t *testing
 	}
 }
 
+func TestMapPoolToBindingsRespectsPoolRefGroup(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newCollisionTestScheme(t)
+	reconciler := &InferenceIdentityBindingReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithIndex(&kleymv1alpha1.InferenceIdentityBinding{}, fieldIndexTargetRefName, bindingTargetRefNameIndexValue).
+			WithObjects(
+				newObjectiveWithPool("objective-default", "pool-shared", ""),
+				newObjectiveWithPool("objective-k8s", "pool-shared", "inference.networking.k8s.io"),
+				newObjectiveWithPool("objective-x", "pool-shared", "inference.networking.x-k8s.io"),
+				newPerObjectiveBinding("binding-default", "objective-default"),
+				newPerObjectiveBinding("binding-k8s", "objective-k8s"),
+				newPerObjectiveBinding("binding-x", "objective-x"),
+			).
+			Build(),
+		Scheme: scheme,
+	}
+
+	k8sPool := newTestPool()
+	k8sPool.SetName("pool-shared")
+	k8sPool.SetGroupVersionKind(inferencePoolGVKs[0])
+	k8sRequests := reconciler.mapPoolToBindings(ctx, k8sPool)
+	k8sExpected := []string{
+		types.NamespacedName{Namespace: testNamespace, Name: "binding-default"}.String(),
+		types.NamespacedName{Namespace: testNamespace, Name: "binding-k8s"}.String(),
+	}
+	if got := requestNames(k8sRequests); !equalStringSlices(got, k8sExpected) {
+		t.Fatalf("mapPoolToBindings (k8s group) returned %v, want %v", got, k8sExpected)
+	}
+
+	xPool := newTestPool()
+	xPool.SetName("pool-shared")
+	xPool.SetGroupVersionKind(inferencePoolGVKs[1])
+	xRequests := reconciler.mapPoolToBindings(ctx, xPool)
+	xExpected := []string{
+		types.NamespacedName{Namespace: testNamespace, Name: "binding-default"}.String(),
+		types.NamespacedName{Namespace: testNamespace, Name: "binding-x"}.String(),
+	}
+	if got := requestNames(xRequests); !equalStringSlices(got, xExpected) {
+		t.Fatalf("mapPoolToBindings (x-k8s group) returned %v, want %v", got, xExpected)
+	}
+}
+
 func TestReconcileWatchPredicateSkipsStatusOnlyUpdates(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add focused unit coverage for pool watch fanout by API group in `mapPoolToBindings`.
- Add focused unit coverage for `InvalidRef` outcomes when `poolRef` resolution fails.
- Keep behavior unchanged; this PR strengthens acceptance-level verification for GAIE watch/ref behavior.

## Changes
- Added `TestMapPoolToBindingsRespectsPoolRefGroup` to verify enqueue behavior when objectives reference the same pool name across different GAIE API groups.
- Added `internal/controller/inferenceidentitybinding_resolver_test.go` with:
  - `TestReconcileSetsInvalidRefWhenPoolCannotBeResolved` (`TargetPoolNotFound`)
  - `TestReconcileSetsInvalidRefWhenObjectivePoolRefIsInvalid` (`InvalidPoolRef`)

## Findings (History / Why)
The watch implementation landed in phases:
- Initial GAIE watch + targetRef/poolRef reconciliation flow came via PR #61 (`Closes #3`).
- Watch hardening (field indexes, targeted fanout, predicates, transient infra retries) came via PR #74 (`Fixes #64`).
- Later split into concern files in PR #88 (`Fixes #81`) without behavior change.

There is no merged PR explicitly closing #26 yet, although most runtime behavior is already present via #3 + #64. This PR closes the remaining gap by adding direct tests aligned with #26 acceptance checks.

Fixes #26

## Validation
- `go test ./internal/controller/...`
- `make test`
- `make lint`

## Docs
- not needed: behavior/API contract unchanged (test coverage only)
