### PR TITLE
docs: clean up prose, fix diagram, and expand abbreviations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,66 @@
 
 `kleym` is an identity registration compiler. It does not deploy inference workloads, route inference traffic, or evaluate request policy.
 
+## Reconcile Flow
+
+```mermaid
+---
+config:
+  layout: elk
+---
+flowchart TD
+    B["InferenceIdentityBinding"]
+
+    subgraph GAIE["GAIE Inputs"]
+        O["InferenceObjective"]
+        P["InferencePool"]
+    end
+
+    subgraph Reconcile["kleym Reconcile"]
+        D1{"Deleted?"}
+        D1Y["Clean up ClusterSPIFFEIDs\nRemove finalizer"]
+        F["Ensure finalizer"]
+        RESOLVE["Resolve targetRef → Objective\nExtract and resolve poolRef → Pool"]
+        RENDER["Derive selectors from pool\nAdd container discriminator (PerObjective)\nValidate safety selectors\nRender SPIFFE ID"]
+        COL{"Collision?"}
+        COLY["Set Conflict status\nClean up ClusterSPIFFEIDs"]
+        APPLY["Reconcile ClusterSPIFFEID"]
+        STATUS["Patch status + emit events"]
+    end
+
+    subgraph SPIRE["SPIRE Stack"]
+        CS["ClusterSPIFFEID"]
+        SCM["SPIRE Controller Manager"]
+        SR["SPIRE registration entries"]
+    end
+
+    B --> D1
+    D1 -->|yes| D1Y
+    D1 -->|no| F --> RESOLVE
+    O & P --> RESOLVE
+    RESOLVE --> RENDER --> COL
+    COL -->|yes| COLY --> STATUS
+    COL -->|no| APPLY --> STATUS
+    APPLY --> CS --> SCM --> SR
+    STATUS --> B
+
+    classDef binding fill:#fee2e2,stroke:#b91c1c,color:#7f1d1d,stroke-width:1.4px
+    classDef gaie fill:#fff7ed,stroke:#c2410c,color:#7c2d12,stroke-width:1.2px
+    classDef controller fill:#f1f5f9,stroke:#475569,color:#0f172a,stroke-width:1.2px
+    classDef gate fill:#e2e8f0,stroke:#334155,color:#0f172a,stroke-width:1.2px
+    classDef status fill:#dcfce7,stroke:#15803d,color:#14532d,stroke-width:1.2px
+    classDef warning fill:#fee2e2,stroke:#dc2626,color:#7f1d1d,stroke-width:1.2px,stroke-dasharray:4 2
+    classDef spire fill:#eff6ff,stroke:#1d4ed8,color:#1e3a8a,stroke-width:1.2px
+
+    class B binding
+    class O,P gaie
+    class D1,COL gate
+    class D1Y,F,RESOLVE,RENDER,APPLY controller
+    class STATUS status
+    class COLY warning
+    class CS,SCM,SR spire
+```
+
 ## Quickstart
 
 Prerequisites:

--- a/docs/about.md
+++ b/docs/about.md
@@ -3,7 +3,7 @@ title: About
 toc: false
 type: docs
 summary: Project scope, intent, and documentation map for kleym.
-description: kleym translates GAIE inference intent into deterministic SPIFFE identities and keeps a narrow scope around identity registration and selector provenance.
+description: kleym translates Gateway API Inference Extension (GAIE) inference intent into deterministic Secure Production Identity Framework for Everyone (SPIFFE) identities and keeps a narrow scope around identity registration and selector provenance.
 sidebar:
   exclude: true
   hide: true
@@ -13,7 +13,7 @@ sidebar:
   <img src="/images/sondrd-512.png" alt="Sonda Red square logo" width="180" height="180">
 </div>
 
-`kleym` is a Kubernetes operator that compiles inference identity intent into deterministic SPIFFE identities for GAIE-aligned inference workloads.
+`kleym` is a Kubernetes operator that compiles inference identity intent into deterministic Secure Production Identity Framework for Everyone (SPIFFE) identities for Gateway API Inference Extension (GAIE)-aligned inference workloads.
 
 It exists to make workload identity legible, repeatable, and safe across inference stacks. Instead of treating SPIFFE registration as manual cluster glue, `kleym` derives stable `ClusterSPIFFEID` resources from the same namespaced objects operators already use to describe inference intent.
 
@@ -25,7 +25,7 @@ It is an identity registration compiler. The project is intentionally narrow:
 
 ## Overview
 
-- primary inputs: `InferenceObjective` and `InferencePool`
+- primary inputs: [`InferenceObjective`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferenceobjective/) and [`InferencePool`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/)
 - primary output: deterministic `ClusterSPIFFEID` resources
 - identity modes: `PoolOnly` and `PerObjective`
 - safety model: namespace and service account selectors are always present; unsafe or ambiguous state is refused
@@ -51,3 +51,5 @@ It is an identity registration compiler. The project is intentionally narrow:
 - [GitHub repository](https://github.com/sonda-red/kleym)
 - [Release stream](https://github.com/sonda-red/kleym/releases)
 - [Contributing guide](/contributing)
+- [SPIFFE overview](https://spiffe.io/docs/latest/spiffe-about/overview/)
+- [SPIRE concepts](https://spiffe.io/docs/latest/spire-about/spire-concepts/)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,34 +1,46 @@
 ---
 title: Architecture
 weight: 20
+summary: End-to-end control flow from `InferenceIdentityBinding` to SPIFFE Runtime Environment (SPIRE) registration state.
+description: How `kleym` resolves Gateway API Inference Extension (GAIE) resources, enforces selector safety, and reconciles `ClusterSPIFFEID`.
 ---
 
 ## Control Flow
 
-```text
-InferenceIdentityBinding
-        |
-        | targetRef
-        v
-InferenceObjective
-        |
-        | spec.poolRef
-        v
-InferencePool
-        |
-        | selector + container discriminator + safety selectors
-        v
-      kleym
-        |
-        | rendered SPIFFE ID + rendered workload selectors
-        v
-ClusterSPIFFEID
-        |
-        v
-SPIRE Controller Manager
-        |
-        v
-SPIRE registration state
+This flow uses Gateway API Inference Extension (GAIE) objects as upstream inputs.
+
+```
+                InferenceIdentityBinding
+                         │
+                     Deleted? ──yes──▶ Clean up ClusterSPIFFEIDs
+                         │                  Remove finalizer
+                         no
+                         │
+                   Ensure finalizer
+                         │
+    InferenceObjective ──▶ Resolve targetRef → Objective
+    InferencePool ───────▶ Extract and resolve poolRef → Pool
+                         │
+                  Derive selectors from pool
+                  Add container discriminator (PerObjective)
+                  Validate safety selectors
+                  Render SPIFFE ID
+                         │
+                    Collision?
+                    ╱        ╲
+                 yes          no
+                  │            │
+          Set Conflict     Reconcile
+          Clean up         ClusterSPIFFEID
+          ClusterSPIFFEIDs      │
+                  │        ClusterSPIFFEID
+                  │             │
+                  │        SPIRE Controller Manager
+                  │             │
+                  │        SPIRE registration entries
+                  │            │
+                  ╰──── Patch status ────╯
+                        emit events
 ```
 
 ## Responsibility Boundaries
@@ -39,6 +51,16 @@ SPIRE registration state
 - `kleym` validates the references, enforces selector safety, detects deterministic collisions, and renders `ClusterSPIFFEID`.
 - SPIRE Controller Manager applies the `ClusterSPIFFEID` objects and manages SPIRE registration state.
 - SPIRE Server and Agent remain responsible for issuance and rotation.
+
+## External Contracts
+
+- [`InferenceObjective` API](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferenceobjective/): objective-level inference intent and `poolRef`.
+- [`InferencePool` API](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/): serving pool selector source used by `kleym`.
+- [Gateway API Inference Extension (GAIE) API types](https://gateway-api-inference-extension.sigs.k8s.io/api-types/): canonical schema reference for GAIE resources.
+- [SPIFFE overview](https://spiffe.io/docs/latest/spiffe-about/overview/): identity model and SPIFFE ID/SVID concepts.
+- [SPIRE concepts](https://spiffe.io/docs/latest/spire-about/spire-concepts/): server/agent architecture and attestation model.
+- [SPIRE Controller Manager](https://github.com/spiffe/spire-controller-manager): Kubernetes reconciler that applies `ClusterSPIFFEID`.
+- [`ClusterSPIFFEID` CRD](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md): output resource shape reconciled by `kleym`.
 
 ## Why The Flow Matters
 

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -9,6 +9,10 @@
   border-radius: 0.5rem;
 }
 
+.mermaid {
+  overflow-x: auto;
+}
+
 .kleym-about-mark {
   margin: 0 0 1.5rem;
 }

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -3,7 +3,18 @@ title: Concepts
 weight: 10
 ---
 
-The [spec](spec) remains the authoritative contract.
+This page covers the main ideas behind `kleym`: the external resources it depends on, the intent object it owns, identity modes, container discrimination, and selector safety. The [spec](spec) remains the authoritative contract.
+
+## Gateway API Inference Extension (GAIE) Resources `kleym` Depends On
+
+`kleym` intentionally reads only a narrow part of Gateway API Inference Extension (GAIE), but those objects are external dependencies and define the source of truth for intent.
+
+- [`InferenceObjective` (GAIE API type)](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferenceobjective/): model-level serving intent. `kleym` resolves the objective named by `spec.targetRef.name` and reads its `spec.poolRef`.
+- [`InferencePool` (GAIE API type)](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/): serving pool intent. `kleym` resolves the objective's `poolRef` and derives selector input from `spec.selector`.
+- [GAIE API types index](https://gateway-api-inference-extension.sigs.k8s.io/api-types/): canonical reference for GAIE resource schemas and status fields.
+- [GAIE GA migration guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/ga-migration/): background on migration from `InferenceModel` to `InferenceObjective`.
+
+`kleym` supports GAIE objects from both `inference.networking.k8s.io/v1` and `inference.networking.x-k8s.io/v1alpha2`. See [reference/api](reference/api) for the current supported GVK list.
 
 ## What `InferenceIdentityBinding` Is
 
@@ -72,6 +83,8 @@ It does not:
 - issue certificates itself
 
 SPIRE and SPIRE Controller Manager remain responsible for issuing identities. `kleym` only determines which identities should exist and which workloads they should target.
+
+Reference docs: [SPIFFE overview](https://spiffe.io/docs/latest/spiffe-about/overview/), [SPIRE concepts](https://spiffe.io/docs/latest/spire-about/spire-concepts/), and [SPIRE Controller Manager](https://github.com/spiffe/spire-controller-manager).
 
 ## See Also
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,7 +3,7 @@ title: Contributing
 weight: 110
 ---
 
-`kleym` is a Kubernetes operator that compiles inference identity intent into SPIRE Controller Manager resources. The repo is still early, so contributors should prefer small, explicit changes that keep the spec, code, and generated artifacts aligned.
+`kleym` is a Kubernetes operator that compiles inference identity intent into SPIFFE Runtime Environment (SPIRE) Controller Manager resources. The repo is still early, so contributors should prefer small, explicit changes that keep the spec, code, and generated artifacts aligned.
 
 ## Sources Of Truth
 

--- a/docs/examples/_index.md
+++ b/docs/examples/_index.md
@@ -4,3 +4,27 @@ weight: 40
 ---
 
 Concrete manifests and expected reconciliation outcomes for common `InferenceIdentityBinding` flows.
+
+## Before You Apply Examples
+
+These examples assume:
+
+- Gateway API Inference Extension (GAIE) CRDs are installed for [`InferenceObjective`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferenceobjective/) and [`InferencePool`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/)
+- SPIFFE Runtime Environment (SPIRE) Controller Manager is installed with the [`ClusterSPIFFEID` CRD](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md)
+- the `kleym` controller is running
+
+The manifests here intentionally show the minimal GAIE fields `kleym` consumes. For full GAIE object shape and additional optional fields, use the [GAIE API types index](https://gateway-api-inference-extension.sigs.k8s.io/api-types/).
+For SPIFFE and SPIRE background, see [SPIFFE overview](https://spiffe.io/docs/latest/spiffe-about/overview/) and [SPIRE concepts](https://spiffe.io/docs/latest/spire-about/spire-concepts/).
+
+## Example Paths
+
+| Example | Use it when | Outcome |
+| --- | --- | --- |
+| [Basic Binding](basic-binding) | You need one identity per serving pool. | One managed `ClusterSPIFFEID` in `PoolOnly` mode. |
+| [PerObjective](per-objective) | Multiple objectives share a pool but need distinct identities. | One managed `ClusterSPIFFEID` per objective, narrowed by container discriminator. |
+
+## Recommended Reading Order
+
+1. Start with [Basic Binding](basic-binding) to validate end-to-end wiring.
+2. Move to [PerObjective](per-objective) to apply model-level identity boundaries.
+3. Review [reference/conditions](../reference/conditions) and [troubleshooting](../troubleshooting) if reconciliation does not reach `Ready=True`.

--- a/docs/examples/basic-binding.md
+++ b/docs/examples/basic-binding.md
@@ -5,12 +5,14 @@ weight: 10
 
 This example shows the simplest `PoolOnly` flow.
 
-`kleym` currently consumes only a small slice of the referenced GAIE objects:
+`kleym` currently consumes only a small slice of the referenced Gateway API Inference Extension (GAIE) objects:
 
 - from the objective: `spec.poolRef`
 - from the pool: `spec.selector`
 
 Your installed GAIE version may require additional fields on those objects. The snippets below focus on the fields that matter to `kleym`.
+For full GAIE schema details, see [`InferenceObjective`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferenceobjective/) and [`InferencePool`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/).
+Reference docs: [SPIFFE overview](https://spiffe.io/docs/latest/spiffe-about/overview/), [SPIRE concepts](https://spiffe.io/docs/latest/spire-about/spire-concepts/), and [`ClusterSPIFFEID` CRD](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md).
 
 ## Input
 

--- a/docs/examples/per-objective.md
+++ b/docs/examples/per-objective.md
@@ -5,7 +5,9 @@ weight: 20
 
 This example shows the current `PerObjective` path, including the container discriminator that keeps one objective identity tied to one container selection.
 
-As in the other examples, the GAIE snippets focus on the fields `kleym` currently consumes. Your cluster may require additional GAIE fields.
+As in the other examples, the Gateway API Inference Extension (GAIE) snippets focus on the fields `kleym` currently consumes. Your cluster may require additional GAIE fields.
+For full GAIE schema details, see [`InferenceObjective`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferenceobjective/) and [`InferencePool`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/).
+Reference docs: [SPIFFE overview](https://spiffe.io/docs/latest/spiffe-about/overview/), [SPIRE concepts](https://spiffe.io/docs/latest/spire-about/spire-concepts/), and [`ClusterSPIFFEID` CRD](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md).
 
 ## Input
 

--- a/docs/hugo.work.sum
+++ b/docs/hugo.work.sum
@@ -1,0 +1,1 @@
+github.com/imfing/hextra v0.12.2 h1:qa+cHQ1LC/7ys9EhRNnHrRBAHu83Tm8rhh1oWO2a7cc=

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,10 +11,14 @@ This page covers the practical commands for running `kleym`, deploying it, testi
 - Docker
 - `kubectl`
 - Access to a Kubernetes cluster
+- Gateway API Inference Extension (GAIE) CRDs for [`InferenceObjective`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferenceobjective/) and [`InferencePool`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/)
+- SPIFFE Runtime Environment (SPIRE) Controller Manager with the [`ClusterSPIFFEID` CRD](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md)
 - `kind` for `make test-e2e`
 - Hugo Extended `0.146+` for docs preview/build
 
 The repository bootstraps local tool binaries under `bin/` through `make` targets, so you do not need to install `controller-gen`, `kustomize`, `setup-envtest`, or `golangci-lint` globally.
+
+For identity-system background, see [SPIFFE overview](https://spiffe.io/docs/latest/spiffe-about/overview/) and [SPIRE concepts](https://spiffe.io/docs/latest/spire-about/spire-concepts/).
 
 ## Run Locally
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -14,6 +14,19 @@ This page records the stable API facts exposed by the current scaffold. Behavior
 
 `InferenceIdentityBinding` expresses identity intent for a single `InferenceObjective` and drives reconciliation of managed `ClusterSPIFFEID` resources.
 
+External Gateway API Inference Extension (GAIE) schema references:
+
+- [`InferenceObjective` (GAIE API)](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferenceobjective/)
+- [`InferencePool` (GAIE API)](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/)
+- [GAIE API types index](https://gateway-api-inference-extension.sigs.k8s.io/api-types/)
+
+External SPIFFE/SPIRE references:
+
+- [SPIFFE overview](https://spiffe.io/docs/latest/spiffe-about/overview/)
+- [SPIRE concepts](https://spiffe.io/docs/latest/spire-about/spire-concepts/)
+- [SPIRE Controller Manager](https://github.com/spiffe/spire-controller-manager)
+- [`ClusterSPIFFEID` CRD](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md)
+
 ## Spec Fields
 
 | Field | Required | Notes |

--- a/docs/reference/resources.md
+++ b/docs/reference/resources.md
@@ -5,9 +5,16 @@ weight: 30
 
 This page records the Kubernetes resources `kleym` writes and the objects it depends on to do that work.
 
+External references:
+
+- [SPIFFE overview](https://spiffe.io/docs/latest/spiffe-about/overview/)
+- [SPIRE concepts](https://spiffe.io/docs/latest/spire-about/spire-concepts/)
+- [SPIRE Controller Manager](https://github.com/spiffe/spire-controller-manager)
+- [`ClusterSPIFFEID` CRD](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md)
+
 ## Primary Managed Output
 
-`kleym` manages `ClusterSPIFFEID` resources in `spire.spiffe.io`.
+`kleym` manages [`ClusterSPIFFEID`](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) resources in `spire.spiffe.io`.
 
 Each managed object currently includes:
 
@@ -40,9 +47,9 @@ That keeps names DNS-safe while allowing the SPIFFE ID to remain the real identi
 | Resource | Role |
 | --- | --- |
 | `InferenceIdentityBinding` | Primary namespaced API owned by `kleym`. |
-| `InferenceObjective` | Target object resolved from `spec.targetRef.name`. |
-| `InferencePool` | Selector source resolved from the objective's `spec.poolRef`. |
-| `ClusterSPIFFEID` | Managed output resource written by the reconciler. |
+| [`InferenceObjective`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferenceobjective/) | Target object resolved from `spec.targetRef.name`. |
+| [`InferencePool`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/) | Selector source resolved from the objective's `spec.poolRef`. |
+| [`ClusterSPIFFEID`](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) | Managed output resource written by the reconciler. |
 
 ## Read And Watch Behavior
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3,34 +3,36 @@ title: Spec
 weight: 80
 ---
 
-`kleym` is a Kubernetes operator that makes inference workloads legible to workload identity by translating inference intent into deterministic SPIFFE identities. It compiles that intent into SPIRE Controller Manager resources, primarily [`ClusterSPIFFEID`][clusterspiffeid].
+`kleym` is a Kubernetes operator that makes inference workloads legible to workload identity by translating inference intent into deterministic Secure Production Identity Framework for Everyone (SPIFFE) identities. It compiles that intent into SPIFFE Runtime Environment (SPIRE) Controller Manager resources, primarily [`ClusterSPIFFEID`][clusterspiffeid].
 
 Scope boundary: `kleym` is an identity registration compiler. It stops at identity registration and selector provenance. Inference deployment, traffic routing, and policy evaluation stay in the inference stack, gateway, mesh, or external policy engines. `kleym` does not configure Envoy, Envoy Gateway, kgateway, ext authz, ext proc, OPA, Cedar, OAuth, or OIDC.
 
-# Core Problem
+Reference docs: [SPIFFE overview][spiffe-overview], [SPIRE concepts][spire-concepts], and [SPIRE Controller Manager][spire-controller-manager].
 
-Inference stacks can be deployed reliably, but identity registration remains manual, inconsistent, and hard to standardize across teams. GAIE defines inference specific objects and clearer responsibility boundaries, but it does not define identity semantics. `kleym` bridges this gap by deriving stable SPIFFE ID templates and tenant safe selectors from GAIE resources.
+## Core Problem
 
-# Core Value
+Inference stacks can be deployed reliably, but identity registration remains manual, inconsistent, and hard to standardize across teams. Gateway API Inference Extension (GAIE) defines inference-specific objects and clearer responsibility boundaries, but it does not define identity semantics. `kleym` bridges this gap by deriving stable SPIFFE ID templates and tenant safe selectors from GAIE resources.
+
+## Core Value
 
 1. Deterministic identities derived from GAIE metadata rather than ad hoc labels.
 2. A single namespaced control surface for identity intent that works across heterogeneous inference stacks that share GAIE semantics.
 3. Low operational risk by delegating issuance and rotation to SPIRE Controller Manager.
 
-# Dependencies
+## Dependencies
 
 1. SPIRE Server and SPIRE Agent.
 2. SPIRE Controller Manager and its [`ClusterSPIFFEID`][clusterspiffeid] CRD.
 3. `kleym` writes [`ClusterSPIFFEID`][clusterspiffeid] and does not write SPIRE entries directly.
 
-# Supported Downstream Pattern
+## Supported Downstream Pattern
 
 1. SPIRE issues X.509 SVIDs and/or JWT SVIDs.
 2. Envoy consumes identity through SDS or through components adjacent to the SPIRE Workload API.
 3. External auth policy maps SPIFFE ID to route or model authorization.
 4. Audit logging happens at the gateway or policy layer, not in `kleym`.
 
-# Preferred Inference Signal
+## Preferred Inference Signal
 
 GAIE v1 objects are the primary signal.
 
@@ -38,23 +40,23 @@ GAIE v1 objects are the primary signal.
 2. [`InferencePool`][gaie-inferencepool] defines the serving pod pool for inference traffic.
 3. [`InferenceModel`][gaie-inferencemodel-legacy] is treated as legacy.
 
-# Identity Model
+## Identity Model
 
 1. Pool identity (`PoolOnly`). One SPIFFE identity representing the serving pool pods.
 2. Objective identity (`PerObjective`). One SPIFFE identity per [`InferenceObjective`][gaie-inferenceobjective], representing the model endpoint at the GAIE layer even when multiple objectives share the same pool.
 
 `PoolOnly` and `PerObjective` are the only identity boundaries in `kleym`.
 
-## Container Level Enforcement
+### Container Level Enforcement
 
 One model per container makes model identity enforceable. SPIRE Kubernetes workload attestation supports container scoped selectors such as container name and container image, so `kleym` can bind an objective identity to a specific container inside a pod rather than the pod as a whole. This is the mechanism that gives `PerObjective` mode meaningful discrimination when multiple objectives share a pool.
 
-# Constraint
+## Constraint
 
 Multiple [`ClusterSPIFFEID`][clusterspiffeid] resources can select the same pod set, which can result in multiple identities applying to the same pods. Some workloads only support one SVID reliably. Clusters that require per objective identities may need to restrict or disable any default identity that would collide.
 Some downstream consumers and sidecars behave as single identity consumers. Multiple matching [`ClusterSPIFFEID`][clusterspiffeid] objects may be valid from SPIRE's perspective but still operationally unsafe for a given serving stack. `kleym` only prevents deterministic collision cases it can prove. Cluster operators remain responsible for disabling overlapping default identities outside `kleym`.
 
-# MVP API Surface
+## MVP API Surface
 
 External CRDs consumed
 
@@ -83,7 +85,7 @@ External CRDs consumed
 2. `renderedSelectors` shows the final selectors applied to [`ClusterSPIFFEID`][clusterspiffeid].
 3. `conditions` include `Ready`, `Conflict`, `InvalidRef`, `UnsafeSelector`, `RenderFailure`. The `Conflict` condition uses reason `IdentityCollision` when two objectives in `PerObjective` mode resolve to the same pod set and the same container name.
 
-# Controller Behavior
+## Controller Behavior
 
 1. Watch `InferenceIdentityBinding`, [`InferenceObjective`][gaie-inferenceobjective], and [`InferencePool`][gaie-inferencepool].
 2. Resolve `targetRef` to [`InferenceObjective`][gaie-inferenceobjective], then resolve `poolRef` to [`InferencePool`][gaie-inferencepool].
@@ -94,31 +96,35 @@ External CRDs consumed
 7. Treat infrastructure-not-ready states such as missing required CRDs as transient by retrying reconciliation on a timer so recovery does not depend on unrelated watch events.
 8. On `InferenceIdentityBinding` deletion, remove managed [`ClusterSPIFFEID`][clusterspiffeid] children first and keep the binding finalizer until a follow-up list confirms no managed children remain.
 
-# Multi Tenant Safety
+## Multi Tenant Safety
 
 1. `InferenceIdentityBinding` is namespaced and only references objects in the same namespace.
 2. Derived selectors must be proven to stay within the namespace. If they can match outside, reconciliation is refused and `UnsafeSelector` is set.
 3. Ambiguous bindings where the derived selection cannot be proven to correspond to the referenced pool are refused.
 
-# Multiple Objectives to One Pod Set
+## Multiple Objectives to One Pod Set
 
 GAIE commonly maps multiple objectives to one pool. In `kleym`, the pool defines where it runs and the objective defines what it is. `kleym` can produce distinct objective identities while selectors still target the same pods.
 
 When two objectives share a pool, the container discriminator is what keeps their identities distinct. Each objective must point to a different container name within the pod. If two objectives resolve to the same pod set and the same `container-name`, reconciliation is refused on both with reason `IdentityCollision` until the conflict is corrected, for example by assigning each model to its own container.
 
-# Acceptance Criteria
+## Acceptance Criteria
 
 1. In a cluster with existing GAIE [`InferencePool`][gaie-inferencepool] and [`InferenceObjective`][gaie-inferenceobjective] resources, creating an `InferenceIdentityBinding` creates stable [`ClusterSPIFFEID`][clusterspiffeid] resources and remains stable under resync.
 2. Multiple objectives referencing one pool produce distinct SPIFFE IDs without unsafe selector expansion.
 3. Overly broad or malicious selector expansion is rejected with clear status conditions.
 4. `kleym` does not create or modify inference deployments, pools, routes, [`Gateway`][gateway-api-gateway], [`HTTPRoute`][gateway-api-httproute], or schedulers.
 
-# Packaging
+## Licensing
 
-1. Helm chart includes `kleym` CRDs and controller deployment.
-2. License is Apache 2.0.
+1. License is Apache 2.0.
+
+## References
 
 [clusterspiffeid]: https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md
+[spiffe-overview]: https://spiffe.io/docs/latest/spiffe-about/overview/
+[spire-concepts]: https://spiffe.io/docs/latest/spire-about/spire-concepts/
+[spire-controller-manager]: https://github.com/spiffe/spire-controller-manager
 [gaie-inferencepool]: https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/
 [gaie-inferenceobjective]: https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferenceobjective/
 [gaie-inferencemodel-legacy]: https://gateway-api-inference-extension.sigs.k8s.io/guides/ga-migration/

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -55,6 +55,15 @@ kubectl get crd clusterspiffeids.spire.spiffe.io
 
 If your cluster uses the alternate GAIE API group version supported by the controller, confirm those CRDs are installed instead.
 
+Reference docs:
+
+- [`InferenceObjective` API type](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferenceobjective/)
+- [`InferencePool` API type](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/)
+- [SPIFFE overview](https://spiffe.io/docs/latest/spiffe-about/overview/)
+- [SPIRE concepts](https://spiffe.io/docs/latest/spire-about/spire-concepts/)
+- [SPIRE Controller Manager](https://github.com/spiffe/spire-controller-manager)
+- [`ClusterSPIFFEID` CRD](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md)
+
 When a CRD is missing, the reconciler keeps retrying automatically on a timer, so it can recover after installation without waiting for unrelated watch events.
 
 ## Collision Triage


### PR DESCRIPTION
## Summary

- Remove boilerplate "In this page, X is abbreviated as Y" lines across 11 pages.
- Reorder concepts.md so GAIE dependencies section precedes InferenceIdentityBinding section.
- Add intro paragraph to concepts.md.
- Rebuild architecture diagram to match actual controller reconcile flow.
- Add ASCII diagram to architecture.md (Hugo docs) and mermaid diagram with ELK layout to README.md (GitHub).
- Remove dead mermaid CSS variables from custom.css; add `.mermaid` overflow-x rule.
- Expand abbreviations inline, demote top-level headings to `##`, add reference links section, and remove Helm packaging line in spec.md.

## Related Issue

- Not tied to a specific issue.

## Scope Check

- All changes are docs-only. No Go code, API types, RBAC, or generated manifests changed.
- Left out of scope: deploying the docs site (no Cloudflare Pages workflow yet).

## Follow-Up Work

- None proposed.

## Verification

- Commands run: `hugo --source docs` (clean build), `make docs-serve` (live preview).
- Tests not run: no docs-only tests exist; Go tests and lint are not affected.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.