### PR TITLE
feat: fix controller startup on GAIE partial-CRD clusters via dynamic GVK discovery

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -34,11 +34,15 @@ Inference stacks can be deployed reliably, but identity registration remains man
 
 ## Preferred Inference Signal
 
-GAIE v1 objects are the primary signal.
+GAIE objects are the primary signal.
 
 1. [`InferenceObjective`][gaie-inferenceobjective] is the primary model level object and references an [`InferencePool`][gaie-inferencepool] via `poolRef`.
 2. [`InferencePool`][gaie-inferencepool] defines the serving pod pool for inference traffic.
 3. [`InferenceModel`][gaie-inferencemodel-legacy] is treated as legacy.
+4. At startup, `kleym` discovers which supported GAIE GVKs are served by the cluster and watches only that subset.
+   - `GVK` means `GroupVersionKind` (`<api-group>/<version>, Kind=<kind>`), for example:
+     - `inference.networking.x-k8s.io/v1alpha2, Kind=InferenceObjective`
+     - `inference.networking.k8s.io/v1, Kind=InferencePool`
 
 ## Identity Model
 
@@ -60,8 +64,12 @@ Some downstream consumers and sidecars behave as single identity consumers. Mult
 
 External CRDs consumed
 
-1. GAIE [`InferencePool`][gaie-inferencepool]
-2. GAIE v1 [`InferenceObjective`][gaie-inferenceobjective]
+Compatibility matrix for GAIE inputs (by GVK):
+
+1. `inference.networking.k8s.io/v1, Kind=InferencePool` (preferred).
+2. `inference.networking.x-k8s.io/v1alpha2, Kind=InferencePool` (compatible).
+3. `inference.networking.x-k8s.io/v1alpha2, Kind=InferenceObjective` (currently required in most released GAIE versions).
+4. `inference.networking.k8s.io/v1, Kind=InferenceObjective` (compatible when present).
 
 `kleym` CRD
 
@@ -87,14 +95,17 @@ External CRDs consumed
 
 ## Controller Behavior
 
-1. Watch `InferenceIdentityBinding`, [`InferenceObjective`][gaie-inferenceobjective], and [`InferencePool`][gaie-inferencepool].
-2. Resolve `targetRef` to [`InferenceObjective`][gaie-inferenceobjective], then resolve `poolRef` to [`InferencePool`][gaie-inferencepool].
-3. Derive pod selection from [`InferencePool`][gaie-inferencepool], then intersect with the mandatory safety selectors (namespace and service account) and, in `PerObjective` mode, the container discriminator.
-4. Detect identity collisions: if two `InferenceIdentityBinding` resources in `PerObjective` mode would match the same pod set and the same `container-name` value, set the `Conflict` condition with reason `IdentityCollision` on both resources and refuse to reconcile either until the collision is resolved.
-5. Reconcile one or more [`ClusterSPIFFEID`][clusterspiffeid] resources in `spire.spiffe.io` using the computed SPIFFE IDs and validated selectors.
-6. Update status and emit events for conflicts, unsafe selection, identity collisions, and render failures.
-7. Treat infrastructure-not-ready states such as missing required CRDs as transient by retrying reconciliation on a timer so recovery does not depend on unrelated watch events.
-8. On `InferenceIdentityBinding` deletion, remove managed [`ClusterSPIFFEID`][clusterspiffeid] children first and keep the binding finalizer until a follow-up list confirms no managed children remain.
+1. Discover supported GAIE objective and pool GVKs served by the cluster (`GVK = GroupVersionKind`); watch only discovered GVKs.
+   - Startup fails only when none of the supported GAIE objective/pool GVKs are available.
+2. Watch `InferenceIdentityBinding`, plus discovered [`InferenceObjective`][gaie-inferenceobjective] and discovered [`InferencePool`][gaie-inferencepool] GVKs.
+   - Example: if the cluster serves only `InferenceObjective` in `inference.networking.x-k8s.io/v1alpha2`, `kleym` watches that GVK and skips `inference.networking.k8s.io/v1` objective.
+3. Resolve `targetRef` to [`InferenceObjective`][gaie-inferenceobjective], then resolve `poolRef` to [`InferencePool`][gaie-inferencepool].
+4. Derive pod selection from [`InferencePool`][gaie-inferencepool], then intersect with the mandatory safety selectors (namespace and service account) and, in `PerObjective` mode, the container discriminator.
+5. Detect identity collisions: if two `InferenceIdentityBinding` resources in `PerObjective` mode would match the same pod set and the same `container-name` value, set the `Conflict` condition with reason `IdentityCollision` on both resources and refuse to reconcile either until the collision is resolved.
+6. Reconcile one or more [`ClusterSPIFFEID`][clusterspiffeid] resources in `spire.spiffe.io` using the computed SPIFFE IDs and validated selectors.
+7. Update status and emit events for conflicts, unsafe selection, identity collisions, and render failures.
+8. Treat infrastructure-not-ready states such as missing required CRDs as transient by retrying reconciliation on a timer so recovery does not depend on unrelated watch events.
+9. On `InferenceIdentityBinding` deletion, remove managed [`ClusterSPIFFEID`][clusterspiffeid] children first and keep the binding finalizer until a follow-up list confirms no managed children remain.
 
 ## Multi Tenant Safety
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -45,15 +45,40 @@ If reconciliation fails, `Ready=False` and the triggering condition becomes `Tru
 
 `kleym` depends on external CRDs as inputs and outputs.
 
+`GVK` means `GroupVersionKind` (`<api-group>/<version>, Kind=<kind>`). In this context:
+
+- `inference.networking.x-k8s.io/v1alpha2, Kind=InferenceObjective`
+- `inference.networking.k8s.io/v1, Kind=InferenceObjective`
+- `inference.networking.k8s.io/v1, Kind=InferencePool`
+- `inference.networking.x-k8s.io/v1alpha2, Kind=InferencePool`
+
 Check for:
 
 ```sh
 kubectl get crd inferenceobjectives.inference.networking.k8s.io
+kubectl get crd inferenceobjectives.inference.networking.x-k8s.io
 kubectl get crd inferencepools.inference.networking.k8s.io
+kubectl get crd inferencepools.inference.networking.x-k8s.io
 kubectl get crd clusterspiffeids.spire.spiffe.io
 ```
 
 If your cluster uses the alternate GAIE API group version supported by the controller, confirm those CRDs are installed instead.
+
+During startup, `kleym` discovers supported GAIE GVKs and logs a warning for each unavailable one:
+
+```text
+... skipping unavailable GVK ...
+```
+
+These warnings are expected when your cluster intentionally serves only part of the compatibility matrix.
+Example: cluster has `InferenceObjective` only in `inference.networking.x-k8s.io/v1alpha2`, so startup logs a skip warning for `inference.networking.k8s.io/v1, Kind=InferenceObjective`.
+
+You can confirm what is actually served via:
+
+```sh
+kubectl api-resources --api-group=inference.networking.x-k8s.io
+kubectl api-resources --api-group=inference.networking.k8s.io
+```
 
 Reference docs:
 
@@ -65,6 +90,7 @@ Reference docs:
 - [`ClusterSPIFFEID` CRD](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md)
 
 When a CRD is missing, the reconciler keeps retrying automatically on a timer, so it can recover after installation without waiting for unrelated watch events.
+If you install a newly supported GAIE CRD after `kleym` has already started, restart the controller so startup-time GVK discovery can register the new watches.
 
 ## Collision Triage
 

--- a/internal/controller/inferenceidentitybinding_controller.go
+++ b/internal/controller/inferenceidentitybinding_controller.go
@@ -17,8 +17,10 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -81,8 +83,10 @@ var (
 // InferenceIdentityBindingReconciler reconciles a InferenceIdentityBinding object
 type InferenceIdentityBindingReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	Scheme                 *runtime.Scheme
+	Recorder               record.EventRecorder
+	availableObjectiveGVKs []schema.GroupVersionKind
+	availablePoolGVKs      []schema.GroupVersionKind
 }
 
 // +kubebuilder:rbac:groups=kleym.sonda.red,resources=inferenceidentitybindings,verbs=get;list;watch;create;update;patch;delete
@@ -188,6 +192,8 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(ctx context.Context, req 
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *InferenceIdentityBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	setupLogger := logf.Log.WithName("setup").WithName("inferenceidentitybinding")
+
 	//nolint:staticcheck // We intentionally use the legacy recorder interface required by this reconciler.
 	r.Recorder = mgr.GetEventRecorderFor("inferenceidentitybinding-controller")
 
@@ -195,12 +201,47 @@ func (r *InferenceIdentityBindingReconciler) SetupWithManager(mgr ctrl.Manager) 
 		return err
 	}
 
+	availableObjectiveGVKs, err := filterAvailableGVKs(
+		mgr.GetRESTMapper(),
+		inferenceObjectiveGVKs,
+		setupLogger.WithValues("resourceKind", "InferenceObjective"),
+	)
+	if err != nil {
+		return err
+	}
+
+	availablePoolGVKs, err := filterAvailableGVKs(
+		mgr.GetRESTMapper(),
+		inferencePoolGVKs,
+		setupLogger.WithValues("resourceKind", "InferencePool"),
+	)
+	if err != nil {
+		return err
+	}
+
+	if len(availableObjectiveGVKs) == 0 && len(availablePoolGVKs) == 0 {
+		return fmt.Errorf(
+			"no supported GAIE GVKs are available: objective candidates=%v, pool candidates=%v",
+			inferenceObjectiveGVKs,
+			inferencePoolGVKs,
+		)
+	}
+
+	r.availableObjectiveGVKs = append(
+		make([]schema.GroupVersionKind, 0, len(availableObjectiveGVKs)),
+		availableObjectiveGVKs...,
+	)
+	r.availablePoolGVKs = append(
+		make([]schema.GroupVersionKind, 0, len(availablePoolGVKs)),
+		availablePoolGVKs...,
+	)
+
 	watchPredicate := reconcileWatchPredicate()
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(&kleymv1alpha1.InferenceIdentityBinding{}, builder.WithPredicates(watchPredicate)).
 		Named("inferenceidentitybinding")
 
-	for _, gvk := range inferenceObjectiveGVKs {
+	for _, gvk := range availableObjectiveGVKs {
 		objective := &unstructured.Unstructured{}
 		objective.SetGroupVersionKind(gvk)
 		controllerBuilder = controllerBuilder.Watches(
@@ -210,7 +251,7 @@ func (r *InferenceIdentityBindingReconciler) SetupWithManager(mgr ctrl.Manager) 
 		)
 	}
 
-	for _, gvk := range inferencePoolGVKs {
+	for _, gvk := range availablePoolGVKs {
 		pool := &unstructured.Unstructured{}
 		pool.SetGroupVersionKind(gvk)
 		controllerBuilder = controllerBuilder.Watches(
@@ -221,6 +262,25 @@ func (r *InferenceIdentityBindingReconciler) SetupWithManager(mgr ctrl.Manager) 
 	}
 
 	return controllerBuilder.Complete(r)
+}
+
+func filterAvailableGVKs(
+	mapper meta.RESTMapper,
+	candidates []schema.GroupVersionKind,
+	logger logr.Logger,
+) ([]schema.GroupVersionKind, error) {
+	available := make([]schema.GroupVersionKind, 0, len(candidates))
+	for _, gvk := range candidates {
+		if _, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
+			if meta.IsNoMatchError(err) {
+				logger.Info("skipping unavailable GVK", "gvk", gvk.String())
+				continue
+			}
+			return nil, fmt.Errorf("resolve REST mapping for %s: %w", gvk.String(), err)
+		}
+		available = append(available, gvk)
+	}
+	return available, nil
 }
 func (r *InferenceIdentityBindingReconciler) reconcileDelete(
 	ctx context.Context,

--- a/internal/controller/inferenceidentitybinding_gvk.go
+++ b/internal/controller/inferenceidentitybinding_gvk.go
@@ -1,0 +1,24 @@
+package controller
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+func (r *InferenceIdentityBindingReconciler) watchObjectiveGVKs() []schema.GroupVersionKind {
+	if r.availableObjectiveGVKs != nil {
+		return r.availableObjectiveGVKs
+	}
+	return inferenceObjectiveGVKs
+}
+
+func (r *InferenceIdentityBindingReconciler) resolveObjectiveGVKs() []schema.GroupVersionKind {
+	if len(r.availableObjectiveGVKs) > 0 {
+		return r.availableObjectiveGVKs
+	}
+	return inferenceObjectiveGVKs
+}
+
+func (r *InferenceIdentityBindingReconciler) resolvePoolGVKs() []schema.GroupVersionKind {
+	if len(r.availablePoolGVKs) > 0 {
+		return r.availablePoolGVKs
+	}
+	return inferencePoolGVKs
+}

--- a/internal/controller/inferenceidentitybinding_gvk_discovery_test.go
+++ b/internal/controller/inferenceidentitybinding_gvk_discovery_test.go
@@ -1,0 +1,141 @@
+package controller
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestFilterAvailableGVKs_AllAvailable(t *testing.T) {
+	t.Parallel()
+
+	mapper := newTestRESTMapper(inferenceObjectiveGVKs, inferenceObjectiveGVKs)
+	available, err := filterAvailableGVKs(mapper, inferenceObjectiveGVKs, logr.Discard())
+	if err != nil {
+		t.Fatalf("filterAvailableGVKs returned error: %v", err)
+	}
+
+	if !equalGVKSets(available, inferenceObjectiveGVKs) {
+		t.Fatalf("available GVKs = %v, want %v", available, inferenceObjectiveGVKs)
+	}
+}
+
+func TestFilterAvailableGVKs_XOnlyAvailable(t *testing.T) {
+	t.Parallel()
+
+	mapper := newTestRESTMapper(inferenceObjectiveGVKs, []schema.GroupVersionKind{inferenceObjectiveGVKs[0]})
+	available, err := filterAvailableGVKs(mapper, inferenceObjectiveGVKs, logr.Discard())
+	if err != nil {
+		t.Fatalf("filterAvailableGVKs returned error: %v", err)
+	}
+
+	want := []schema.GroupVersionKind{inferenceObjectiveGVKs[0]}
+	if !equalGVKSets(available, want) {
+		t.Fatalf("available GVKs = %v, want %v", available, want)
+	}
+}
+
+func TestFilterAvailableGVKs_K8sOnlyAvailable(t *testing.T) {
+	t.Parallel()
+
+	mapper := newTestRESTMapper(inferenceObjectiveGVKs, []schema.GroupVersionKind{inferenceObjectiveGVKs[1]})
+	available, err := filterAvailableGVKs(mapper, inferenceObjectiveGVKs, logr.Discard())
+	if err != nil {
+		t.Fatalf("filterAvailableGVKs returned error: %v", err)
+	}
+
+	want := []schema.GroupVersionKind{inferenceObjectiveGVKs[1]}
+	if !equalGVKSets(available, want) {
+		t.Fatalf("available GVKs = %v, want %v", available, want)
+	}
+}
+
+func TestFilterAvailableGVKs_NoneAvailable(t *testing.T) {
+	t.Parallel()
+
+	mapper := newTestRESTMapper(inferenceObjectiveGVKs, nil)
+	available, err := filterAvailableGVKs(mapper, inferenceObjectiveGVKs, logr.Discard())
+	if err != nil {
+		t.Fatalf("filterAvailableGVKs returned error: %v", err)
+	}
+	if len(available) != 0 {
+		t.Fatalf("available GVKs = %v, want empty", available)
+	}
+}
+
+func TestFilterAvailableGVKs_PropagatesUnexpectedRESTMapperError(t *testing.T) {
+	t.Parallel()
+
+	base := newTestRESTMapper(inferenceObjectiveGVKs, []schema.GroupVersionKind{inferenceObjectiveGVKs[0]})
+	mapper := restMapperWithInjectedError{
+		RESTMapper: base,
+		groupKind:  inferenceObjectiveGVKs[0].GroupKind(),
+		err:        errors.New("boom"),
+	}
+
+	_, err := filterAvailableGVKs(mapper, inferenceObjectiveGVKs, logr.Discard())
+	if err == nil {
+		t.Fatalf("filterAvailableGVKs returned nil error")
+	}
+	if !strings.Contains(err.Error(), "resolve REST mapping for") {
+		t.Fatalf("error = %q, want context about REST mapping", err)
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("error = %q, want wrapped mapper error", err)
+	}
+}
+
+type restMapperWithInjectedError struct {
+	meta.RESTMapper
+	groupKind schema.GroupKind
+	err       error
+}
+
+func (m restMapperWithInjectedError) RESTMapping(
+	groupKind schema.GroupKind,
+	versions ...string,
+) (*meta.RESTMapping, error) {
+	if groupKind == m.groupKind {
+		return nil, m.err
+	}
+	return m.RESTMapper.RESTMapping(groupKind, versions...)
+}
+
+func newTestRESTMapper(candidates []schema.GroupVersionKind, available []schema.GroupVersionKind) meta.RESTMapper {
+	versions := uniqueGroupVersions(candidates)
+	mapper := meta.NewDefaultRESTMapper(versions)
+	for _, gvk := range available {
+		mapper.Add(gvk, meta.RESTScopeNamespace)
+	}
+	return mapper
+}
+
+func uniqueGroupVersions(gvks []schema.GroupVersionKind) []schema.GroupVersion {
+	seen := map[schema.GroupVersion]struct{}{}
+	versions := make([]schema.GroupVersion, 0, len(gvks))
+	for _, gvk := range gvks {
+		gv := gvk.GroupVersion()
+		if _, exists := seen[gv]; exists {
+			continue
+		}
+		seen[gv] = struct{}{}
+		versions = append(versions, gv)
+	}
+	return versions
+}
+
+func equalGVKSets(left []schema.GroupVersionKind, right []schema.GroupVersionKind) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/controller/inferenceidentitybinding_resolver.go
+++ b/internal/controller/inferenceidentitybinding_resolver.go
@@ -35,7 +35,7 @@ func (r *InferenceIdentityBindingReconciler) resolveInferenceObjective(
 	objective, crdMissing, err := r.resolveByCandidates(
 		ctx,
 		types.NamespacedName{Namespace: namespace, Name: name},
-		inferenceObjectiveGVKs,
+		r.resolveObjectiveGVKs(),
 	)
 	if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (r *InferenceIdentityBindingReconciler) resolveInferencePool(
 	ctx context.Context,
 	poolRef inferencePoolRef,
 ) (*unstructured.Unstructured, error) {
-	poolCandidates := candidatePoolGVKs(poolRef.Group)
+	poolCandidates := candidatePoolGVKs(r.resolvePoolGVKs(), poolRef.Group)
 	pool, crdMissing, err := r.resolveByCandidates(
 		ctx,
 		types.NamespacedName{Namespace: poolRef.Namespace, Name: poolRef.Name},
@@ -168,13 +168,13 @@ func extractPoolRef(objective *unstructured.Unstructured, defaultNamespace strin
 	}, nil
 }
 
-func candidatePoolGVKs(group string) []schema.GroupVersionKind {
+func candidatePoolGVKs(candidates []schema.GroupVersionKind, group string) []schema.GroupVersionKind {
 	if group == "" {
-		return inferencePoolGVKs
+		return candidates
 	}
 
-	filtered := make([]schema.GroupVersionKind, 0, len(inferencePoolGVKs))
-	for _, gvk := range inferencePoolGVKs {
+	filtered := make([]schema.GroupVersionKind, 0, len(candidates))
+	for _, gvk := range candidates {
 		if gvk.Group == group {
 			filtered = append(filtered, gvk)
 		}

--- a/internal/controller/inferenceidentitybinding_resolver_test.go
+++ b/internal/controller/inferenceidentitybinding_resolver_test.go
@@ -6,6 +6,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -81,4 +82,59 @@ func TestReconcileSetsInvalidRefWhenObjectivePoolRefIsInvalid(t *testing.T) {
 
 	assertConditionStatus(t, ctx, reconciler.Client, binding.Name, conditionTypeInvalidRef, metav1.ConditionTrue, "InvalidPoolRef")
 	assertConditionStatus(t, ctx, reconciler.Client, binding.Name, conditionTypeReady, metav1.ConditionFalse, "InvalidPoolRef")
+}
+
+func TestReconcileUsesDiscoveredObjectiveGVKsForResolution(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newCollisionTestScheme(t)
+
+	xPool := newTestPool()
+	xPool.SetGroupVersionKind(inferencePoolGVKs[1])
+	xPool.SetName("pool-x")
+
+	xObjective := newTestObjective("objective-shared")
+	xObjective.Object["spec"] = map[string]any{
+		"poolRef": map[string]any{
+			"name":  "pool-x",
+			"group": "inference.networking.x-k8s.io",
+		},
+	}
+
+	k8sObjective := newTestObjective("objective-shared")
+	k8sObjective.SetGroupVersionKind(inferenceObjectiveGVKs[1])
+	k8sObjective.Object["spec"] = map[string]any{
+		"poolRef": map[string]any{
+			"name":  "pool-k8s-missing",
+			"group": "inference.networking.k8s.io",
+		},
+	}
+
+	binding := newPerObjectiveBinding("binding-filtered-objective", "objective-shared")
+
+	reconciler := &InferenceIdentityBindingReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+			WithObjects(
+				xPool,
+				xObjective,
+				k8sObjective,
+				binding,
+			).
+			Build(),
+		Scheme:                 scheme,
+		availableObjectiveGVKs: []schema.GroupVersionKind{inferenceObjectiveGVKs[1]},
+	}
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: binding.Name},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	assertConditionStatus(t, ctx, reconciler.Client, binding.Name, conditionTypeInvalidRef, metav1.ConditionTrue, "TargetPoolNotFound")
+	assertConditionStatus(t, ctx, reconciler.Client, binding.Name, conditionTypeReady, metav1.ConditionFalse, "TargetPoolNotFound")
 }

--- a/internal/controller/inferenceidentitybinding_setup_partial_crd_test.go
+++ b/internal/controller/inferenceidentitybinding_setup_partial_crd_test.go
@@ -1,0 +1,287 @@
+package controller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	kleymv1alpha1 "github.com/sonda-red/kleym/api/v1alpha1"
+)
+
+func TestSetupWithManagerStartsAndReconcilesWithXObjectiveOnlyCRD(t *testing.T) {
+	t.Helper()
+
+	testScheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(testScheme); err != nil {
+		t.Fatalf("add client-go scheme: %v", err)
+	}
+	if err := kleymv1alpha1.AddToScheme(testScheme); err != nil {
+		t.Fatalf("add kleym scheme: %v", err)
+	}
+	registerEnvtestUnstructuredGVK(testScheme, clusterSPIFFEIDGVK)
+	for _, gvk := range inferenceObjectiveGVKs {
+		registerEnvtestUnstructuredGVK(testScheme, gvk)
+	}
+	for _, gvk := range inferencePoolGVKs {
+		registerEnvtestUnstructuredGVK(testScheme, gvk)
+	}
+
+	crdDir := t.TempDir()
+	copyCRDFile(t, filepath.Join("testdata", "crds", "inference.networking.x-k8s.io_inferenceobjectives.yaml"), crdDir)
+	copyCRDFile(t, filepath.Join("testdata", "crds", "inference.networking.x-k8s.io_inferencepools.yaml"), crdDir)
+	copyCRDFile(t, filepath.Join("testdata", "crds", "inference.networking.k8s.io_inferencepools.yaml"), crdDir)
+	copyCRDFile(t, filepath.Join("testdata", "crds", "spire.spiffe.io_clusterspiffeids.yaml"), crdDir)
+
+	testEnvironment := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+			crdDir,
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+	if binDir := getFirstFoundEnvTestBinaryDir(); binDir != "" {
+		testEnvironment.BinaryAssetsDirectory = binDir
+	}
+
+	cfg, err := testEnvironment.Start()
+	if err != nil {
+		t.Fatalf("start envtest: %v", err)
+	}
+	t.Cleanup(func() {
+		if stopErr := testEnvironment.Stop(); stopErr != nil {
+			t.Fatalf("stop envtest: %v", stopErr)
+		}
+	})
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                 testScheme,
+		Metrics:                server.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+		Controller: config.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create manager: %v", err)
+	}
+
+	reconciler := &InferenceIdentityBindingReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}
+	if err := reconciler.SetupWithManager(mgr); err != nil {
+		t.Fatalf("setup controller with partial CRDs: %v", err)
+	}
+
+	if len(reconciler.availableObjectiveGVKs) != 1 || reconciler.availableObjectiveGVKs[0] != inferenceObjectiveGVKs[0] {
+		t.Fatalf("availableObjectiveGVKs = %v, want [%v]", reconciler.availableObjectiveGVKs, inferenceObjectiveGVKs[0])
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- mgr.Start(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case runErr := <-errCh:
+			if runErr != nil {
+				t.Fatalf("manager returned error: %v", runErr)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for manager shutdown")
+		}
+	})
+
+	poolName := "pool-x"
+	objectiveName := "objective-x"
+	bindingName := "binding-x"
+
+	pool := &unstructured.Unstructured{
+		Object: map[string]any{
+			"spec": map[string]any{
+				"selector": map[string]any{
+					"matchLabels": map[string]any{"app": "model-server"},
+				},
+			},
+		},
+	}
+	pool.SetGroupVersionKind(inferencePoolGVKs[1])
+	pool.SetNamespace(testNamespace)
+	pool.SetName(poolName)
+	if err := mgr.GetClient().Create(ctx, pool); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+
+	objective := &unstructured.Unstructured{
+		Object: map[string]any{
+			"spec": map[string]any{
+				"poolRef": map[string]any{
+					"name":  poolName,
+					"group": "inference.networking.x-k8s.io",
+				},
+			},
+		},
+	}
+	objective.SetGroupVersionKind(inferenceObjectiveGVKs[0])
+	objective.SetNamespace(testNamespace)
+	objective.SetName(objectiveName)
+	if err := mgr.GetClient().Create(ctx, objective); err != nil {
+		t.Fatalf("create objective: %v", err)
+	}
+
+	binding := &kleymv1alpha1.InferenceIdentityBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      bindingName,
+		},
+		Spec: kleymv1alpha1.InferenceIdentityBindingSpec{
+			TargetRef:      kleymv1alpha1.InferenceObjectiveTargetRef{Name: objectiveName},
+			SelectorSource: kleymv1alpha1.SelectorSourceDerivedFromPool,
+			WorkloadSelectorTemplates: []string{
+				"k8s:ns:default",
+				"k8s:sa:inference-sa",
+			},
+			Mode: kleymv1alpha1.InferenceIdentityBindingModePoolOnly,
+		},
+	}
+	if err := mgr.GetClient().Create(ctx, binding); err != nil {
+		t.Fatalf("create binding: %v", err)
+	}
+
+	waitForBindingReady(t, ctx, mgr.GetClient(), types.NamespacedName{Namespace: testNamespace, Name: bindingName})
+}
+
+func TestSetupWithManagerFailsWithoutAnySupportedGAIEGVKs(t *testing.T) {
+	t.Helper()
+
+	testScheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(testScheme); err != nil {
+		t.Fatalf("add client-go scheme: %v", err)
+	}
+	if err := kleymv1alpha1.AddToScheme(testScheme); err != nil {
+		t.Fatalf("add kleym scheme: %v", err)
+	}
+	registerEnvtestUnstructuredGVK(testScheme, clusterSPIFFEIDGVK)
+	for _, gvk := range inferenceObjectiveGVKs {
+		registerEnvtestUnstructuredGVK(testScheme, gvk)
+	}
+	for _, gvk := range inferencePoolGVKs {
+		registerEnvtestUnstructuredGVK(testScheme, gvk)
+	}
+
+	testEnvironment := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+	if binDir := getFirstFoundEnvTestBinaryDir(); binDir != "" {
+		testEnvironment.BinaryAssetsDirectory = binDir
+	}
+
+	cfg, err := testEnvironment.Start()
+	if err != nil {
+		t.Fatalf("start envtest: %v", err)
+	}
+	t.Cleanup(func() {
+		if stopErr := testEnvironment.Stop(); stopErr != nil {
+			t.Fatalf("stop envtest: %v", stopErr)
+		}
+	})
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                 testScheme,
+		Metrics:                server.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+		Controller: config.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create manager: %v", err)
+	}
+
+	reconciler := &InferenceIdentityBindingReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}
+	setupErr := reconciler.SetupWithManager(mgr)
+	if setupErr == nil {
+		t.Fatalf("SetupWithManager returned nil, want startup error without GAIE CRDs")
+	}
+	if !strings.Contains(setupErr.Error(), "no supported GAIE GVKs are available") {
+		t.Fatalf("unexpected setup error: %v", setupErr)
+	}
+}
+
+func copyCRDFile(t *testing.T, sourcePath string, destinationDir string) {
+	t.Helper()
+
+	content, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read CRD %s: %v", sourcePath, err)
+	}
+
+	destinationPath := filepath.Join(destinationDir, filepath.Base(sourcePath))
+	if err := os.WriteFile(destinationPath, content, 0o600); err != nil {
+		t.Fatalf("write CRD %s: %v", destinationPath, err)
+	}
+}
+
+func waitForBindingReady(
+	t *testing.T,
+	ctx context.Context,
+	k8sClient client.Client,
+	key types.NamespacedName,
+) {
+	t.Helper()
+
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		current := &kleymv1alpha1.InferenceIdentityBinding{}
+		if err := k8sClient.Get(ctx, key, current); err == nil {
+			ready := findCondition(current.Status.Conditions, conditionTypeReady)
+			if ready != nil && ready.Status == metav1.ConditionTrue {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("timed out waiting for Ready=True, last conditions=%v", current.Status.Conditions)
+			}
+		} else if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for binding %s: %v", key, err)
+		}
+
+		select {
+		case <-ctx.Done():
+			t.Fatalf("context canceled before binding became ready: %v", ctx.Err())
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+}
+
+func findCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type != conditionType {
+			continue
+		}
+		return &conditions[i]
+	}
+	return nil
+}

--- a/internal/controller/inferenceidentitybinding_watch.go
+++ b/internal/controller/inferenceidentitybinding_watch.go
@@ -252,7 +252,7 @@ func (r *InferenceIdentityBindingReconciler) objectiveNamesReferencingPool(
 ) map[string]struct{} {
 	objectiveNames := map[string]struct{}{}
 
-	for _, gvk := range inferenceObjectiveGVKs {
+	for _, gvk := range r.watchObjectiveGVKs() {
 		list := &unstructured.UnstructuredList{}
 		list.SetGroupVersionKind(gvk.GroupVersion().WithKind(gvk.Kind + "List"))
 		if err := r.List(ctx, list, client.InNamespace(namespace)); err != nil {


### PR DESCRIPTION
## Summary
`kleym` currently attempts to register objective/pool watches for all candidate GAIE GVKs unconditionally. On clusters where only part of the GAIE compatibility matrix is served (for example Objective only in `inference.networking.x-k8s.io/v1alpha2`), manager startup produced repeated kind/source errors and reconciliation did not proceed.

This PR adds startup-time GVK discovery and watch registration only for served GVKs.

## Changes
- add `filterAvailableGVKs` in controller setup to probe REST mappings per candidate GVK
- skip unavailable GVKs with startup warning logs, while surfacing non-NoMatch mapper errors
- fail startup with a clear error when no supported GAIE objective/pool GVK is available
- persist discovered objective/pool GVKs on reconciler and reuse them in resolver/watch helper paths
- update objective and pool resolution paths to consume discovered GVK sets
- update pool->objective watch mapping to iterate discovered objective GVKs

## Tests
- new unit tests for GVK discovery filtering:
  - all available
  - x-only
  - k8s-only
  - none available
  - unexpected mapper error propagation
- new envtest integration coverage:
  - controller starts and reconciles with x-only Objective CRD availability
  - setup fails clearly when no supported GAIE GVK is present
- new resolver behavior test ensuring discovered GVK filtering is respected
- full test suite run: `go test ./... -count=1`

## Docs
- update `docs/spec.md` with startup discovery behavior and GAIE compatibility matrix by GVK
- update `docs/troubleshooting.md` with explicit GVK definition, CRD checks for both API groups, expected skip-warning context, served-resource verification commands, and restart note after adding new CRDs

Fixes #92