### PR TITLE
docs: add compatibility policy for external APIs and SCM render contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://github.com/sonda-red/kleym/actions/workflows/docs.yml">
     <img src="https://github.com/sonda-red/kleym/actions/workflows/docs.yml/badge.svg" alt="Docs">
   </a>
-  <img src="https://img.shields.io/badge/go-1.25%2B-00ADD8?logo=go&logoColor=white" alt="Go 1.25+">
+  <img src="https://img.shields.io/badge/go-1.26%2B-00ADD8?logo=go&logoColor=white" alt="Go 1.26+">
   <a href="LICENSE">
     <img src="https://img.shields.io/badge/license-Apache%202.0-black" alt="License: Apache-2.0">
   </a>
@@ -55,7 +55,7 @@
 
 Prerequisites:
 
-- Go `1.25+`
+- Go `1.26+`
 - Docker
 - `kubectl`
 - Access to a Kubernetes cluster with the Gateway API Inference Extension [`InferenceObjective`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferenceobjective/) and [`InferencePool`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/) CRDs

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,7 +34,7 @@ Keep that review narrow. Read the issue or PR that motivated the change and any 
 
 ## Development Prerequisites
 
-- Go `1.25+`
+- Go `1.26+`
 - Docker
 - `kubectl`
 - Access to a Kubernetes cluster for deployment testing

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@ This page covers the practical commands for running `kleym`, deploying it, testi
 
 ## Prerequisites
 
-- Go `1.25+`
+- Go `1.26+`
 - Docker
 - `kubectl`
 - Access to a Kubernetes cluster

--- a/docs/reference/_index.md
+++ b/docs/reference/_index.md
@@ -3,4 +3,9 @@ title: Reference
 weight: 50
 ---
 
-Stable API facts for fields, conditions, and managed resources.
+Stable API facts for fields, conditions, compatibility, and managed resources.
+
+- [API](api): `InferenceIdentityBinding` fields, defaults, status fields, and external objects resolved by the controller.
+- [Conditions](conditions): current condition types, reasons, and status behavior.
+- [Managed Resources](resources): resources written by `kleym`, managed labels, naming, and watch behavior.
+- [Compatibility](compatibility): version support, API-change response, and `ClusterSPIFFEID` render-contract guidance.

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -1,0 +1,118 @@
+---
+title: Compatibility
+weight: 55
+---
+
+This page records version support, external API assumptions, and upgrade checks.
+The [spec](../spec) remains the behavior contract.
+
+For Gateway API Inference Extension (GAIE), `kleym` compatibility is guaranteed
+only for the objective and pool shapes listed below.
+
+## Terms
+
+| Term | Meaning |
+| --- | --- |
+| Supported | Intended to work for the documented input or output surface. |
+| Tested | Exercised by project tests or an explicit upgrade check. |
+| Pinned | Resolved to a release, module version, CRD schema, or install bundle before promotion. |
+| External | Required by the deployment, but not implemented or guaranteed by `kleym`. |
+
+## Release Matrix
+
+The `main` row records the development baseline until the first versioned
+release.
+
+| `kleym` version | Status | Go | Kubernetes libraries | GAIE inputs | SPIRE Controller Manager output | Validation |
+| --- | --- | --- | --- | --- | --- | --- |
+| `main` | Development | `1.26+` | `k8s.io/api`, `apimachinery`, and `client-go` `v0.36.0`; `controller-runtime v0.24.0` | See [GAIE Inputs](#gaie-inputs). | See [ClusterSPIFFEID Output](#clusterspiffeid-output). | `make test`, `make lint`, `make docs-build` |
+
+## Compatibility Surfaces
+
+| Surface | `kleym` position | Source of truth |
+| --- | --- | --- |
+| Go | Root module defines the public toolchain floor. | `go.mod`, README, install docs |
+| Kubernetes API clients | Follows `client-go`, `apimachinery`, and controller-runtime module versions. | `go.mod` |
+| Gateway API | External; no route object is a direct `kleym` input. | Selected gateway/inference stack docs |
+| GAIE | Supported only for documented objective and pool GVKs and fields. | [API](api), [spec](../spec) |
+| Inference stack | External; workloads, schedulers, routes, and gateways stay outside `kleym`. | Selected stack release docs |
+| SPIRE | External unless a rendered SPIRE Controller Manager field changes SPIRE registration behavior. | SPIRE release docs |
+| SPIRE Controller Manager | Supported for the documented `ClusterSPIFFEID` output fields. | [Managed Resources](resources), `ClusterSPIFFEID` CRD schema |
+
+## GAIE Inputs
+
+| Object | Supported GVKs | Consumed fields |
+| --- | --- | --- |
+| `InferenceObjective` | `inference.networking.x-k8s.io/v1alpha2`; `inference.networking.k8s.io/v1` when served | `spec.poolRef` |
+| `InferencePool` | `inference.networking.k8s.io/v1`; `inference.networking.x-k8s.io/v1alpha2` | `spec.selector.matchLabels`; flat string label maps are normalized for compatibility |
+
+`InferencePool` selectors must render deterministically. Non-empty
+`spec.selector.matchExpressions` are not supported.
+
+When `spec.poolRef.group` is set, the controller constrains pool resolution to
+that group using `v1` and `v1alpha2` `InferencePool` candidates. Groups outside
+the documented GVKs are best-effort lookup only, not a compatibility guarantee.
+
+| Startup case | Behavior |
+| --- | --- |
+| Some supported GAIE GVKs are unavailable | Log and skip unavailable GVKs. |
+| No supported objective or pool GVK is served | Startup fails. |
+| A supported GVK is installed after startup | Restart the controller to register new watches. |
+| Binding references a missing objective or pool | Reconcile fails with `InvalidRef`. |
+
+## ClusterSPIFFEID Output
+
+`kleym` currently renders only these `ClusterSPIFFEID` spec fields:
+
+| Field | Status |
+| --- | --- |
+| `spec.spiffeIDTemplate` | Rendered. |
+| `spec.podSelector` | Rendered from the referenced pool. |
+| `spec.workloadSelectorTemplates` | Rendered safety selectors, pool-derived selectors, and optional container discriminator. |
+| `spec.fallback` | Not rendered. Requires design decision. |
+| `spec.hint` | Not rendered. Requires design decision. |
+| JWT-SVID-related fields | Not rendered. Requires user story and SPIRE Controller Manager/SPIRE version gate. |
+
+Managed `ClusterSPIFFEID` objects are labeled with:
+
+| Label | Purpose |
+| --- | --- |
+| `kleym.sonda.red/managed-by=kleym` | Marks controller ownership. |
+| `kleym.sonda.red/binding-name=<binding-name>` | Finds children for a binding. |
+| `kleym.sonda.red/binding-namespace=<binding-namespace>` | Disambiguates namespaced bindings for a cluster-scoped output resource. |
+
+Related design issue: [#109](https://github.com/sonda-red/kleym/issues/109).
+
+## Change Checklist
+
+| Change | Required updates | Required validation |
+| --- | --- | --- |
+| Go, Kubernetes, controller-runtime, build, or CI-sensitive dependency | README or install docs if the public floor changes | `make test`, `make lint` |
+| GAIE GVK or consumed field | [API](api), [spec](../spec), `docs/troubleshooting.md` | Resolver and partial-CRD tests |
+| Rendered `ClusterSPIFFEID` field | [Managed Resources](resources), this page, design issue when behavior changes | Create, update, delete, and resync tests |
+| Reconciliation or status behavior | [spec](../spec), [Conditions](conditions), troubleshooting docs | `make test`; `make test-e2e` when cluster behavior changes |
+| Docs-only compatibility policy | This page | `make docs-build` |
+
+## Upgrade Checks
+
+Before promoting a dependency or external API upgrade:
+
+| Check | Expected result |
+| --- | --- |
+| Pin component versions. | Kubernetes libraries, GAIE bundle, inference stack, SPIRE, and SPIRE Controller Manager versions are known. |
+| Verify served APIs. | Required GAIE resources and `clusterspiffeids.spire.spiffe.io` exist. |
+| Apply a representative binding. | Status reaches `Ready=True`. |
+| Inspect managed output. | SPIFFE IDs, selectors, labels, and `ClusterSPIFFEID` fields match this page. |
+| Reconcile unchanged inputs again. | No managed-object drift. |
+| Validate downstream consumers. | Gateway, mesh, and policy behavior is checked outside `kleym`. |
+
+## References
+
+- Gateway API versioning: <https://gateway-api.sigs.k8s.io/concepts/versioning/>
+- Gateway API implementer guidance: <https://gateway-api.sigs.k8s.io/guides/implementers/>
+- GAIE conformance: <https://gateway-api-inference-extension.sigs.k8s.io/concepts/conformance/>
+- GAIE migration guide: <https://gateway-api-inference-extension.sigs.k8s.io/guides/ga-migration/>
+- llm-d infrastructure docs: <https://llm-d.ai/docs/architecture/Components/infra>
+- SPIRE concepts: <https://spiffe.io/docs/latest/spire-about/spire-concepts/>
+- SPIRE configuration: <https://spiffe.io/docs/latest/deploying/configuring/>
+- SPIRE Controller Manager `ClusterSPIFFEID` docs: <https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md>


### PR DESCRIPTION
### Motivation

- Close the compatibility-policy gap tracked in #94.
- Make the supported dependency and external API surfaces explicit for the current development line.
- Keep the `ClusterSPIFFEID` output contract narrow and reviewable before adopting additional SPIRE Controller Manager fields such as `hint`, `fallback`, or JWT-SVID-related options.
- Align the public Go prerequisite with the root module toolchain requirement.

### What I changed and why

- Added `docs/reference/compatibility.md` as the compatibility reference for the `main` development baseline.
- Documented the current Go, Kubernetes client, and controller-runtime baseline from `go.mod`.
- Documented GAIE compatibility for the supported `InferenceObjective` and `InferencePool` GVKs, including the consumed fields and the deterministic pool selector shape `kleym` accepts.
- Documented startup and reconciliation behavior for partial GAIE availability, missing references, and newly installed supported GVKs.
- Documented the current managed `ClusterSPIFFEID` output contract: `spec.spiffeIDTemplate`, `spec.podSelector`, `spec.workloadSelectorTemplates`, and the controller ownership labels.
- Marked `fallback`, `hint`, and JWT-SVID-related fields as intentionally not rendered until a design decision and version gate exist.
- Added a compatibility change checklist and operator upgrade checks for future dependency, GAIE, reconciliation, and rendered-output changes.
- Updated the reference index so the compatibility page is visible from the published docs navigation.
- Updated README, install, and contributing docs from Go `1.25+` to `1.26+` to match the root module.

Closes #94.
Related: #108, #109.

### Testing

- `make docs-build`
- `git diff --check origin/main...HEAD`

No controller tests were run because this is documentation-only and does not change API types, generated manifests, RBAC, reconciliation behavior, or controller code.

### Security / Scope Review

- Documentation-only.
- Does not change controller behavior, CRDs, RBAC, CI, release automation, credentials, or trust boundaries.
- Keeps downstream gateway, mesh, policy, OAuth/OIDC, Envoy, and inference-stack behavior external to `kleym`.
- Does not render new SPIRE Controller Manager fields; `hint`, `fallback`, and JWT-SVID-related behavior remain deferred to explicit design/version-gate work.