### PR TITLE
feat: add structured reconcile logging

### DIFF
--- a/internal/controller/inferenceidentitybinding_collision_test.go
+++ b/internal/controller/inferenceidentitybinding_collision_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -12,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -35,7 +35,7 @@ func TestReconcilePerObjectiveCollisionMarksAllAndBlocksClusterSPIFFEID(t *testi
 		newPerObjectiveBinding("binding-b", "objective-b"),
 	}
 
-	fakeRecorder := record.NewFakeRecorder(32)
+	fakeRecorder := newFakeEventRecorder(32)
 	reconciler := &InferenceIdentityBindingReconciler{
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -74,7 +74,7 @@ func TestReconcilePerObjectiveCollisionResolutionClearsConflictAndResumes(t *tes
 		newPerObjectiveBinding("binding-b", "objective-b"),
 	}
 
-	fakeRecorder := record.NewFakeRecorder(64)
+	fakeRecorder := newFakeEventRecorder(64)
 	reconciler := &InferenceIdentityBindingReconciler{
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -457,4 +457,24 @@ func assertEventContains(t *testing.T, events <-chan string, expectedSubstring s
 			t.Fatalf("timed out waiting for event containing %q", expectedSubstring)
 		}
 	}
+}
+
+type fakeEventRecorder struct {
+	Events chan string
+}
+
+func newFakeEventRecorder(buffer int) *fakeEventRecorder {
+	return &fakeEventRecorder{Events: make(chan string, buffer)}
+}
+
+func (r *fakeEventRecorder) Eventf(
+	_ runtime.Object,
+	_ runtime.Object,
+	eventType string,
+	reason string,
+	action string,
+	note string,
+	args ...any,
+) {
+	r.Events <- fmt.Sprintf("%s %s %s %s", eventType, reason, action, fmt.Sprintf(note, args...))
 }

--- a/internal/controller/inferenceidentitybinding_controller.go
+++ b/internal/controller/inferenceidentitybinding_controller.go
@@ -62,6 +62,27 @@ const (
 	identityCollisionMessagePrefix      = "identity collision with bindings "
 	identityCollisionMessageSuffix      = ": PerObjective bindings must not share the same pod selector and container discriminator"
 	modeValuePerObjective               = string(kleymv1alpha1.InferenceIdentityBindingModePerObjective)
+
+	logKeyBinding          = "binding"
+	logKeyNamespace        = "namespace"
+	logKeyName             = "name"
+	logKeyTargetRef        = "targetRef"
+	logKeyObjective        = "objective"
+	logKeyObjectiveGVK     = "objectiveGVK"
+	logKeyPool             = "pool"
+	logKeyPoolGVK          = "poolGVK"
+	logKeyPoolGroup        = "poolGroup"
+	logKeyMode             = "mode"
+	logKeySpiffeID         = "spiffeID"
+	logKeyClusterSPIFFEID  = "clusterspiffeid"
+	logKeySelectors        = "selectors"
+	logKeyPodSelector      = "podSelector"
+	logKeyCondition        = "condition"
+	logKeyReason           = "reason"
+	logKeyRequeueAfter     = "requeueAfter"
+	logKeyCollision        = "collision"
+	logKeyCollisionMessage = "collisionMessage"
+	logKeyPeerBinding      = "peerBinding"
 )
 
 var (
@@ -114,22 +135,52 @@ type InferenceIdentityBindingReconciler struct {
 // through to the next. Status is patched exactly once near the end of each path.
 //
 // See docs/design/reconciliation.md for the full flow diagram.
-func (r *InferenceIdentityBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := logf.FromContext(ctx).WithValues("inferenceIdentityBinding", req.NamespacedName)
+func (r *InferenceIdentityBindingReconciler) Reconcile(
+	ctx context.Context,
+	req ctrl.Request,
+) (result ctrl.Result, reconcileErr error) {
+	logger := logf.FromContext(ctx).WithValues(
+		logKeyBinding, req.String(),
+		logKeyNamespace, req.Namespace,
+		logKeyName, req.Name,
+	)
+	ctx = logf.IntoContext(ctx, logger)
+
+	logger.Info("starting InferenceIdentityBinding reconcile")
+	defer func() {
+		if reconcileErr != nil {
+			logger.Error(reconcileErr, "finished InferenceIdentityBinding reconcile")
+			return
+		}
+		logger.Info(
+			"finished InferenceIdentityBinding reconcile",
+			logKeyRequeueAfter, result.RequeueAfter,
+		)
+	}()
 
 	// Phase 1: Fetch the binding.
 	binding := &kleymv1alpha1.InferenceIdentityBinding{}
 	if err := r.Get(ctx, req.NamespacedName, binding); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			logger.V(1).Info("InferenceIdentityBinding not found")
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	logger = logger.WithValues(
+		logKeyTargetRef, binding.Spec.TargetRef.Name,
+		logKeyMode, effectiveMode(binding.Spec.Mode),
+	)
+	ctx = logf.IntoContext(ctx, logger)
 
 	// Phase 2: Handle deletion — clean up children, then remove finalizer.
 	if !binding.DeletionTimestamp.IsZero() {
+		logger.Info("handling deleted InferenceIdentityBinding")
 		return r.reconcileDelete(ctx, binding)
 	}
 
 	// Phase 3: Ensure finalizer is present (requeues implicitly via Update).
 	if !controllerutil.ContainsFinalizer(binding, inferenceIdentityBindingFinalizer) {
+		logger.Info("adding InferenceIdentityBinding finalizer")
 		controllerutil.AddFinalizer(binding, inferenceIdentityBindingFinalizer)
 		if err := r.Update(ctx, binding); err != nil {
 			return ctrl.Result{}, err
@@ -157,11 +208,21 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(ctx context.Context, req 
 		if err := r.patchStatusFromBase(ctx, statusBase, binding); err != nil {
 			return ctrl.Result{}, err
 		}
+		logger.Info(
+			"applied failure status",
+			logKeyCondition, stateErr.conditionType,
+			logKeyReason, stateErr.reason,
+		)
 		r.recordEventf(binding, corev1.EventTypeWarning, stateErr.reason, "%s", stateErr.message)
 		// Infrastructure-not-ready (e.g. CRD missing) is transient: requeue on
 		// a timer so recovery does not depend on an unrelated watch event.
 		// Permanent errors (invalid ref, unsafe selector) stop here.
 		if isInfrastructureNotReadyReason(stateErr.reason) {
+			logger.Info(
+				"requeueing after transient infrastructure readiness failure",
+				logKeyReason, stateErr.reason,
+				logKeyRequeueAfter, infraNotReadyRequeueAfter,
+			)
 			return ctrl.Result{RequeueAfter: infraNotReadyRequeueAfter}, nil
 		}
 		return ctrl.Result{}, nil
@@ -183,7 +244,12 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(ctx context.Context, req 
 		if collisionResult.currentResolved {
 			r.recordEventf(binding, corev1.EventTypeNormal, "IdentityCollisionResolved", "identity collision resolved")
 		}
-		logger.V(1).Info("skipping ClusterSPIFFEID reconciliation due to per-objective identity collision")
+		logger.Info(
+			"skipping ClusterSPIFFEID reconciliation due to per-objective identity collision",
+			logKeyCondition, conditionTypeConflict,
+			logKeyReason, "IdentityCollision",
+			logKeyCollisionMessage, collisionResult.currentMessage,
+		)
 		return ctrl.Result{}, nil
 	}
 
@@ -197,7 +263,17 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(ctx context.Context, req 
 			if err := r.patchStatusFromBase(ctx, statusBase, binding); err != nil {
 				return ctrl.Result{}, err
 			}
+			logger.Info(
+				"applied failure status",
+				logKeyCondition, stateErr.conditionType,
+				logKeyReason, stateErr.reason,
+			)
 			r.recordEventf(binding, corev1.EventTypeWarning, stateErr.reason, "%s", stateErr.message)
+			logger.Info(
+				"requeueing after transient infrastructure readiness failure",
+				logKeyReason, stateErr.reason,
+				logKeyRequeueAfter, infraNotReadyRequeueAfter,
+			)
 			return ctrl.Result{RequeueAfter: infraNotReadyRequeueAfter}, nil
 		}
 		return ctrl.Result{}, err
@@ -207,6 +283,11 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(ctx context.Context, req 
 	if err := r.patchStatusFromBase(ctx, statusBase, binding); err != nil {
 		return ctrl.Result{}, err
 	}
+	logger.Info(
+		"applied success status",
+		logKeyCondition, conditionTypeReady,
+		logKeyReason, "Reconciled",
+	)
 
 	if collisionResult.currentResolved {
 		r.recordEventf(binding, corev1.EventTypeNormal, "IdentityCollisionResolved", "identity collision resolved")
@@ -214,7 +295,11 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(ctx context.Context, req 
 
 	primaryIdentity := desiredState.identities[0]
 	r.recordEventf(binding, corev1.EventTypeNormal, "Reconciled", "reconciled ClusterSPIFFEID %q", primaryIdentity.Name)
-	logger.V(1).Info("reconciled successfully", "clusterspiffeid", primaryIdentity.Name)
+	logger.Info(
+		"reconciled successfully",
+		logKeyClusterSPIFFEID, primaryIdentity.Name,
+		logKeySpiffeID, primaryIdentity.SpiffeID,
+	)
 
 	return ctrl.Result{}, nil
 }
@@ -223,7 +308,6 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(ctx context.Context, req 
 func (r *InferenceIdentityBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	setupLogger := logf.Log.WithName("setup").WithName("inferenceidentitybinding")
 
-	//nolint:staticcheck // We intentionally use the legacy recorder interface required by this reconciler.
 	r.Recorder = mgr.GetEventRecorderFor("inferenceidentitybinding-controller")
 
 	if err := r.setupFieldIndexes(mgr); err != nil {
@@ -315,7 +399,9 @@ func (r *InferenceIdentityBindingReconciler) reconcileDelete(
 	ctx context.Context,
 	binding *kleymv1alpha1.InferenceIdentityBinding,
 ) (ctrl.Result, error) {
+	logger := logf.FromContext(ctx)
 	if !controllerutil.ContainsFinalizer(binding, inferenceIdentityBindingFinalizer) {
+		logger.V(1).Info("deleted InferenceIdentityBinding has no finalizer")
 		return ctrl.Result{}, nil
 	}
 
@@ -329,9 +415,15 @@ func (r *InferenceIdentityBindingReconciler) reconcileDelete(
 			return ctrl.Result{}, err
 		}
 	} else if len(remaining) > 0 {
+		logger.Info(
+			"waiting for managed ClusterSPIFFEIDs to disappear before removing finalizer",
+			"remaining", len(remaining),
+			logKeyRequeueAfter, deleteVerificationRequeueAfter,
+		)
 		return ctrl.Result{RequeueAfter: deleteVerificationRequeueAfter}, nil
 	}
 
+	logger.Info("removing InferenceIdentityBinding finalizer")
 	controllerutil.RemoveFinalizer(binding, inferenceIdentityBindingFinalizer)
 	if err := r.Update(ctx, binding); err != nil {
 		return ctrl.Result{}, err
@@ -345,29 +437,64 @@ func (r *InferenceIdentityBindingReconciler) computeDesiredState(
 	binding *kleymv1alpha1.InferenceIdentityBinding,
 	wasCurrentColliding bool,
 ) (desiredBindingState, error) {
+	logger := logf.FromContext(ctx)
 	objective, err := r.resolveInferenceObjective(ctx, binding.Namespace, binding.Spec.TargetRef.Name)
 	if err != nil {
 		return desiredBindingState{}, err
 	}
+	logger.Info(
+		"resolved target InferenceObjective",
+		logKeyObjective, namespacedBindingKey(objective.GetNamespace(), objective.GetName()),
+		logKeyObjectiveGVK, objective.GroupVersionKind().String(),
+	)
 
 	poolRef, err := extractPoolRef(objective, binding.Namespace)
 	if err != nil {
 		return desiredBindingState{}, newStateError(conditionTypeInvalidRef, "InvalidPoolRef", err.Error())
 	}
+	logger.Info(
+		"resolved objective poolRef",
+		logKeyPool, namespacedBindingKey(poolRef.Namespace, poolRef.Name),
+		logKeyPoolGroup, poolRef.Group,
+	)
 
 	pool, err := r.resolveInferencePool(ctx, poolRef)
 	if err != nil {
 		return desiredBindingState{}, err
 	}
+	logger.Info(
+		"resolved target InferencePool",
+		logKeyPool, namespacedBindingKey(pool.GetNamespace(), pool.GetName()),
+		logKeyPoolGVK, pool.GroupVersionKind().String(),
+	)
 
 	identity, err := r.renderIdentity(binding, objective, pool)
 	if err != nil {
 		return desiredBindingState{}, err
 	}
+	logger.Info(
+		"rendered identity from inference intent",
+		logKeyMode, identity.Mode,
+		logKeySpiffeID, identity.SpiffeID,
+		logKeyClusterSPIFFEID, identity.Name,
+		logKeySelectors, identity.Selectors,
+		logKeyPodSelector, identity.PodSelector,
+		logKeyObjective, identity.ObjectiveRef,
+		logKeyPool, identity.PoolRef,
+	)
 
 	collisionSet, err := r.computePerObjectiveCollisionSet(ctx, binding, identity, wasCurrentColliding)
 	if err != nil {
 		return desiredBindingState{}, err
+	}
+	if collisionSet.currentHasCollision {
+		logger.Info(
+			"computed per-objective identity collision",
+			logKeyCollision, true,
+			logKeyCollisionMessage, collisionSet.currentMessage,
+		)
+	} else {
+		logger.V(1).Info("computed per-objective identity collision state", logKeyCollision, false)
 	}
 
 	return desiredBindingState{
@@ -381,7 +508,13 @@ func (r *InferenceIdentityBindingReconciler) applyStateError(
 	binding *kleymv1alpha1.InferenceIdentityBinding,
 	stateErr *reconcileStateError,
 ) error {
+	logger := logf.FromContext(ctx)
 	if shouldCleanupManagedClusterSPIFFEIDs(stateErr.conditionType) {
+		logger.Info(
+			"cleaning up managed ClusterSPIFFEIDs after reconcile failure",
+			logKeyCondition, stateErr.conditionType,
+			logKeyReason, stateErr.reason,
+		)
 		if err := r.cleanupManagedClusterSPIFFEIDs(ctx, binding); err != nil {
 			return err
 		}
@@ -397,6 +530,7 @@ func (r *InferenceIdentityBindingReconciler) applyCollisionState(
 	collisionSet perObjectiveCollisionSet,
 	wasCurrentColliding bool,
 ) (collisionApplyResult, error) {
+	logger := logf.FromContext(ctx)
 	currentBindingKey := namespacedBindingKey(binding.Namespace, binding.Name)
 	result := collisionApplyResult{
 		currentHasCollision: collisionSet.currentHasCollision,
@@ -426,6 +560,12 @@ func (r *InferenceIdentityBindingReconciler) applyCollisionState(
 		}); err != nil {
 			return collisionApplyResult{}, err
 		}
+		logger.Info(
+			"applied peer collision status",
+			logKeyPeerBinding, bindingKey,
+			logKeyCollision, state.hasCollision,
+			logKeyCollisionMessage, state.message,
+		)
 
 		if !wasColliding && state.hasCollision {
 			r.recordEventf(state.binding, corev1.EventTypeWarning, "IdentityCollision", "%s", state.message)
@@ -436,6 +576,11 @@ func (r *InferenceIdentityBindingReconciler) applyCollisionState(
 	}
 
 	if result.currentHasCollision {
+		logger.Info(
+			"cleaning up managed ClusterSPIFFEIDs for colliding binding",
+			logKeyCondition, conditionTypeConflict,
+			logKeyReason, "IdentityCollision",
+		)
 		if err := r.cleanupManagedClusterSPIFFEIDs(ctx, binding); err != nil {
 			return collisionApplyResult{}, err
 		}

--- a/internal/controller/inferenceidentitybinding_controller.go
+++ b/internal/controller/inferenceidentitybinding_controller.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -105,7 +105,7 @@ var (
 type InferenceIdentityBindingReconciler struct {
 	client.Client
 	Scheme                 *runtime.Scheme
-	Recorder               record.EventRecorder
+	Recorder               events.EventRecorder
 	availableObjectiveGVKs []schema.GroupVersionKind
 	availablePoolGVKs      []schema.GroupVersionKind
 }
@@ -308,7 +308,7 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(
 func (r *InferenceIdentityBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	setupLogger := logf.Log.WithName("setup").WithName("inferenceidentitybinding")
 
-	r.Recorder = mgr.GetEventRecorderFor("inferenceidentitybinding-controller")
+	r.Recorder = mgr.GetEventRecorder("inferenceidentitybinding-controller")
 
 	if err := r.setupFieldIndexes(mgr); err != nil {
 		return err
@@ -599,5 +599,5 @@ func (r *InferenceIdentityBindingReconciler) recordEventf(
 	if r.Recorder == nil {
 		return
 	}
-	r.Recorder.Eventf(object, eventType, reason, messageFormat, args...)
+	r.Recorder.Eventf(object, nil, eventType, reason, reason, messageFormat, args...)
 }

--- a/internal/controller/inferenceidentitybinding_logging_test.go
+++ b/internal/controller/inferenceidentitybinding_logging_test.go
@@ -1,0 +1,279 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kleymv1alpha1 "github.com/sonda-red/kleym/api/v1alpha1"
+)
+
+func TestReconcileLogsStructuredSuccessPath(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger, logs := newRecordingLogger()
+	ctx = logf.IntoContext(ctx, logger)
+
+	scheme := newCollisionTestScheme(t)
+	binding := newPoolOnlyBinding("binding-log-success", "objective-a")
+	reconciler := &InferenceIdentityBindingReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+			WithObjects(newTestPool(), newTestObjective("objective-a"), binding).
+			Build(),
+		Scheme: scheme,
+	}
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(binding),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	logs.requireEntry(t, "starting InferenceIdentityBinding reconcile", map[string]string{
+		logKeyBinding:   "default/binding-log-success",
+		logKeyNamespace: testNamespace,
+		logKeyName:      "binding-log-success",
+	})
+	logs.requireEntry(t, "resolved target InferenceObjective", map[string]string{
+		logKeyTargetRef: "objective-a",
+		logKeyObjective: "default/objective-a",
+	})
+	logs.requireEntry(t, "resolved target InferencePool", map[string]string{
+		logKeyPool: "default/pool-a",
+	})
+	logs.requireEntry(t, "rendered identity from inference intent", map[string]string{
+		logKeyMode:      string(kleymv1alpha1.InferenceIdentityBindingModePoolOnly),
+		logKeyObjective: "objective-a",
+		logKeyPool:      "pool-a",
+		logKeySpiffeID:  "spiffe://kleym.sonda.red/ns/default/pool/pool-a",
+	})
+	logs.requireEntry(t, "creating managed ClusterSPIFFEID", map[string]string{
+		logKeyMode:     string(kleymv1alpha1.InferenceIdentityBindingModePoolOnly),
+		logKeySpiffeID: "spiffe://kleym.sonda.red/ns/default/pool/pool-a",
+	})
+	logs.requireEntry(t, "applied success status", map[string]string{
+		logKeyCondition: conditionTypeReady,
+		logKeyReason:    "Reconciled",
+	})
+	logs.requireEntry(t, "finished InferenceIdentityBinding reconcile", map[string]string{
+		logKeyRequeueAfter: "0s",
+	})
+}
+
+func TestReconcileLogsFailureStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger, logs := newRecordingLogger()
+	ctx = logf.IntoContext(ctx, logger)
+
+	scheme := newCollisionTestScheme(t)
+	binding := newPerObjectiveBinding("binding-log-failure", "missing-objective")
+	reconciler := &InferenceIdentityBindingReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+			WithObjects(binding).
+			Build(),
+		Scheme: scheme,
+	}
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(binding),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	logs.requireEntry(t, "cleaning up managed ClusterSPIFFEIDs after reconcile failure", map[string]string{
+		logKeyCondition: conditionTypeInvalidRef,
+		logKeyReason:    "TargetObjectiveNotFound",
+	})
+	logs.requireEntry(t, "applied failure status", map[string]string{
+		logKeyCondition: conditionTypeInvalidRef,
+		logKeyReason:    "TargetObjectiveNotFound",
+	})
+	logs.requireEntry(t, "finished InferenceIdentityBinding reconcile", map[string]string{
+		logKeyBinding: "default/binding-log-failure",
+	})
+}
+
+func TestReconcileClusterSPIFFEIDsLogsApplyDecisions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger, logs := newRecordingLogger()
+	ctx = logf.IntoContext(ctx, logger)
+
+	scheme := newCollisionTestScheme(t)
+	binding := newPoolOnlyBinding("binding-log-apply", "objective-a")
+	identity := renderedIdentity{
+		Name:     "desired-clusterspiffeid",
+		Mode:     kleymv1alpha1.InferenceIdentityBindingModePoolOnly,
+		SpiffeID: "spiffe://kleym.sonda.red/ns/default/pool/pool-a",
+		Selectors: []string{
+			"k8s:ns:default",
+			"k8s:pod-label:app:model-server",
+			"k8s:sa:inference-sa",
+		},
+		PodSelector: map[string]any{
+			"matchLabels": map[string]any{"app": "model-server"},
+		},
+		ObjectiveRef: "objective-a",
+		PoolRef:      "pool-a",
+	}
+
+	drifted := desiredClusterSPIFFEID(binding, identity)
+	drifted.Object["spec"] = map[string]any{"spiffeIDTemplate": "spiffe://wrong"}
+
+	staleIdentity := identity
+	staleIdentity.Name = "stale-clusterspiffeid"
+	stale := desiredClusterSPIFFEID(binding, staleIdentity)
+
+	reconciler := &InferenceIdentityBindingReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(binding, drifted, stale).
+			Build(),
+		Scheme: scheme,
+	}
+
+	if err := reconciler.reconcileClusterSPIFFEIDs(ctx, binding, []renderedIdentity{identity}); err != nil {
+		t.Fatalf("reconcileClusterSPIFFEIDs returned error: %v", err)
+	}
+
+	logs.requireEntry(t, "updating drifted managed ClusterSPIFFEID", map[string]string{
+		logKeyClusterSPIFFEID: "desired-clusterspiffeid",
+		logKeySpiffeID:        identity.SpiffeID,
+	})
+	logs.requireEntry(t, "deleting stale managed ClusterSPIFFEID", map[string]string{
+		logKeyClusterSPIFFEID: "stale-clusterspiffeid",
+	})
+}
+
+type recordedLogEntry struct {
+	message string
+	values  map[string]string
+}
+
+type recordedLogs struct {
+	mu      sync.Mutex
+	entries []recordedLogEntry
+}
+
+func newRecordingLogger() (logr.Logger, *recordedLogs) {
+	logs := &recordedLogs{}
+	return logr.New(&recordingLogSink{logs: logs}), logs
+}
+
+func (l *recordedLogs) add(message string, keyValues []any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.entries = append(l.entries, recordedLogEntry{
+		message: message,
+		values:  keyValueStrings(keyValues),
+	})
+}
+
+func (l *recordedLogs) requireEntry(t *testing.T, message string, expected map[string]string) {
+	t.Helper()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for _, entry := range l.entries {
+		if entry.message != message {
+			continue
+		}
+		matches := true
+		for key, value := range expected {
+			if entry.values[key] != value {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return
+		}
+	}
+
+	t.Fatalf("missing log entry %q with values %v\nlogs:\n%s", message, expected, l.dumpLocked())
+}
+
+func (l *recordedLogs) dumpLocked() string {
+	var builder strings.Builder
+	for _, entry := range l.entries {
+		builder.WriteString(entry.message)
+		builder.WriteString(" ")
+		fmt.Fprint(&builder, entry.values)
+		builder.WriteString("\n")
+	}
+	return builder.String()
+}
+
+type recordingLogSink struct {
+	logs   *recordedLogs
+	values []any
+}
+
+func (s *recordingLogSink) Init(logr.RuntimeInfo) {}
+
+func (s *recordingLogSink) Enabled(int) bool {
+	return true
+}
+
+func (s *recordingLogSink) Info(_ int, message string, keyValues ...any) {
+	s.logs.add(message, appendKeyValues(s.values, keyValues))
+}
+
+func (s *recordingLogSink) Error(err error, message string, keyValues ...any) {
+	allValues := appendKeyValues(s.values, keyValues)
+	allValues = append(allValues, "error", err)
+	s.logs.add(message, allValues)
+}
+
+func (s *recordingLogSink) WithValues(keyValues ...any) logr.LogSink {
+	return &recordingLogSink{
+		logs:   s.logs,
+		values: appendKeyValues(s.values, keyValues),
+	}
+}
+
+func (s *recordingLogSink) WithName(string) logr.LogSink {
+	return &recordingLogSink{
+		logs:   s.logs,
+		values: appendKeyValues(s.values, nil),
+	}
+}
+
+func appendKeyValues(base []any, extra []any) []any {
+	combined := make([]any, 0, len(base)+len(extra))
+	combined = append(combined, base...)
+	combined = append(combined, extra...)
+	return combined
+}
+
+func keyValueStrings(keyValues []any) map[string]string {
+	values := make(map[string]string, len(keyValues)/2)
+	for i := 0; i+1 < len(keyValues); i += 2 {
+		key, ok := keyValues[i].(string)
+		if !ok {
+			continue
+		}
+		values[key] = fmt.Sprint(keyValues[i+1])
+	}
+	return values
+}

--- a/internal/controller/inferenceidentitybinding_spiffe.go
+++ b/internal/controller/inferenceidentitybinding_spiffe.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	kleymv1alpha1 "github.com/sonda-red/kleym/api/v1alpha1"
 )
@@ -32,10 +33,12 @@ func (r *InferenceIdentityBindingReconciler) reconcileClusterSPIFFEIDs(
 	binding *kleymv1alpha1.InferenceIdentityBinding,
 	identities []renderedIdentity,
 ) error {
+	logger := logf.FromContext(ctx)
 	existing, err := r.listManagedClusterSPIFFEIDs(ctx, binding)
 	if err != nil {
 		return err
 	}
+	logger.V(1).Info("listed managed ClusterSPIFFEIDs", "count", len(existing))
 
 	existingByName := make(map[string]*unstructured.Unstructured, len(existing))
 	for _, item := range existing {
@@ -49,6 +52,12 @@ func (r *InferenceIdentityBindingReconciler) reconcileClusterSPIFFEIDs(
 
 		current, exists := existingByName[identity.Name]
 		if !exists {
+			logger.Info(
+				"creating managed ClusterSPIFFEID",
+				logKeyClusterSPIFFEID, identity.Name,
+				logKeyMode, identity.Mode,
+				logKeySpiffeID, identity.SpiffeID,
+			)
 			if err := r.Create(ctx, desired); err != nil && !apierrors.IsAlreadyExists(err) {
 				return err
 			}
@@ -56,17 +65,31 @@ func (r *InferenceIdentityBindingReconciler) reconcileClusterSPIFFEIDs(
 		}
 
 		if !clusterSPIFFEIDInSync(current, desired) {
+			logger.Info(
+				"updating drifted managed ClusterSPIFFEID",
+				logKeyClusterSPIFFEID, identity.Name,
+				logKeyMode, identity.Mode,
+				logKeySpiffeID, identity.SpiffeID,
+			)
 			mergeDesiredClusterSPIFFEID(current, desired)
 			if err := r.Update(ctx, current); err != nil {
 				return err
 			}
+			continue
 		}
+		logger.V(1).Info(
+			"managed ClusterSPIFFEID already in sync",
+			logKeyClusterSPIFFEID, identity.Name,
+			logKeyMode, identity.Mode,
+			logKeySpiffeID, identity.SpiffeID,
+		)
 	}
 
 	for name, object := range existingByName {
 		if _, keep := desiredNames[name]; keep {
 			continue
 		}
+		logger.Info("deleting stale managed ClusterSPIFFEID", logKeyClusterSPIFFEID, name)
 		if err := r.Delete(ctx, object); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
@@ -171,14 +194,20 @@ func (r *InferenceIdentityBindingReconciler) cleanupManagedClusterSPIFFEIDs(
 	ctx context.Context,
 	binding *kleymv1alpha1.InferenceIdentityBinding,
 ) error {
+	logger := logf.FromContext(ctx)
 	objects, err := r.listManagedClusterSPIFFEIDs(ctx, binding)
 	if err != nil {
 		if meta.IsNoMatchError(err) {
+			logger.Info("skipping managed ClusterSPIFFEID cleanup because CRD is unavailable")
 			return nil
 		}
 		return err
 	}
+	if len(objects) == 0 {
+		logger.V(1).Info("no managed ClusterSPIFFEIDs to clean up")
+	}
 	for _, object := range objects {
+		logger.Info("deleting managed ClusterSPIFFEID during cleanup", logKeyClusterSPIFFEID, object.GetName())
 		if err := r.Delete(ctx, object); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}


### PR DESCRIPTION
## Summary

- Add structured reconcile logs for InferenceIdentityBinding resolution, rendering, collision handling, status outcomes, and managed ClusterSPIFFEID apply decisions.
- Add focused logging tests for success, failure, and ClusterSPIFFEID update/delete decision paths.
- Keep render helpers pure and keep no-op ClusterSPIFFEID sync logs at V(1) to avoid noisy resync logs.

## Related Issue

- Fixes #29

## Scope Check

- Follows #29 by adding controller reconcile logging only.
- Does not change API types, CRDs, RBAC, rendered ClusterSPIFFEID spec shape, reconciliation semantics, or request-level inference attribution.
- Left broader observability work, metrics, and docs/tutorial updates out of scope.

## Follow-Up Work

- None required for this issue.

## Verification

- Commands run:
  - `go test ./internal/controller`
  - `make test`
  - `make lint LOCALBIN=/tmp/kgw`
- Tests not run and why:
  - `make test-e2e` was not run because this change is controller logging only and does not change cluster behavior.

## Security Review

- Does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.
- Logs controller reconciliation metadata only; it does not expose secrets or execute user-controlled commands.
