### PR TITLE
docs: add reference inference environment manifests

### DIFF
--- a/docs/examples/_index.md
+++ b/docs/examples/_index.md
@@ -5,6 +5,11 @@ weight: 40
 
 Concrete manifests and expected reconciliation outcomes for common `InferenceIdentityBinding` flows.
 
+Reusable reference inputs for e2e tests and demo docs live under
+`test/reference/inference-environment/`. Those manifests represent externally
+managed workload and GAIE resources that exist before `kleym` reconciles a
+binding.
+
 ## Before You Apply Examples
 
 These examples assume:

--- a/test/reference/inference-environment/README.md
+++ b/test/reference/inference-environment/README.md
@@ -1,0 +1,65 @@
+# Reference Inference Environment
+
+This directory contains a small reference inference environment that users,
+tests, and demo docs can reuse before applying an `InferenceIdentityBinding`.
+It gives `kleym` something realistic and deterministic to bind to: a namespace,
+service account, serving workload, `InferencePool`, and `InferenceObjective`
+with stable names and selectors.
+
+These manifests are helpful when you want to verify the base `kleym` flow
+without bringing a full inference stack, gateway, route, or policy layer:
+
+1. Apply this reference environment.
+2. Apply an `InferenceIdentityBinding` that targets `reference-objective`.
+3. Check that `kleym` renders the expected managed `ClusterSPIFFEID`.
+
+The resources in this directory model inputs that already exist in the cluster.
+They are externally owned, not part of the default `kleym` install path, not
+Helm-style product templates, and not resources that `kleym` creates, modifies,
+or reconciles.
+
+## Included Resources
+
+| Resource | Name | Purpose |
+| --- | --- | --- |
+| `Namespace` | `kleym-reference-inference` | Stable namespace for `k8s:ns` selector tests. |
+| `ServiceAccount` | `reference-inference` | Stable service account for `k8s:sa` selector tests. |
+| `Deployment` | `reference-model-server` | Minimal externally managed workload input. |
+| `InferencePool` | `reference-pool` | GAIE pool that selects the workload pods. |
+| `InferenceObjective` | `reference-objective` | GAIE objective that references the pool. |
+
+## Stable Selector Values
+
+Tests and demos can rely on these values:
+
+| Field | Value |
+| --- | --- |
+| Namespace | `kleym-reference-inference` |
+| Service account | `reference-inference` |
+| Pod label | `app.kubernetes.io/name=reference-model-server` |
+| Pod label | `app.kubernetes.io/part-of=kleym-reference-inference` |
+| Container name | `model-server` |
+| Container port | `8000` |
+
+An `InferenceIdentityBinding` that targets this reference environment should be
+applied by the test or demo layer, not by this directory. For `PerObjective`
+mode, use `containerDiscriminator.type: ContainerName` and
+`containerDiscriminator.value: model-server`.
+
+## Not Included
+
+This reference environment intentionally does not include:
+
+- `InferenceIdentityBinding` resources
+- managed `ClusterSPIFFEID` resources
+- Envoy, OPA, Gateway API, Envoy Gateway, route, policy, SDS, or downstream
+  enforcement resources
+
+Those layers are separate from the reference inference environment and should be
+added only by tests or demos that explicitly need them.
+
+Apply the reference manifests with:
+
+```sh
+kubectl apply -k test/reference/inference-environment
+```

--- a/test/reference/inference-environment/gaie.yaml
+++ b/test/reference/inference-environment/gaie.yaml
@@ -1,0 +1,33 @@
+# Externally owned GAIE reference inputs. kleym resolves these objects when an
+# InferenceIdentityBinding targets reference-objective, but it does not create,
+# modify, or manage either resource.
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: reference-pool
+  namespace: kleym-reference-inference
+  labels:
+    app.kubernetes.io/name: reference-pool
+    app.kubernetes.io/part-of: kleym-reference-inference
+    kleym.sonda.red/reference: inference-environment
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: reference-model-server
+      app.kubernetes.io/part-of: kleym-reference-inference
+  targetPorts:
+    - number: 8000
+---
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferenceObjective
+metadata:
+  name: reference-objective
+  namespace: kleym-reference-inference
+  labels:
+    app.kubernetes.io/name: reference-objective
+    app.kubernetes.io/part-of: kleym-reference-inference
+    kleym.sonda.red/reference: inference-environment
+spec:
+  poolRef:
+    name: reference-pool
+  priority: 0

--- a/test/reference/inference-environment/kustomization.yaml
+++ b/test/reference/inference-environment/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - workload.yaml
+  - gaie.yaml

--- a/test/reference/inference-environment/namespace.yaml
+++ b/test/reference/inference-environment/namespace.yaml
@@ -1,0 +1,10 @@
+# Externally owned reference namespace for tests and demos. kleym does not
+# create, modify, or manage this resource.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kleym-reference-inference
+  labels:
+    app.kubernetes.io/name: kleym-reference-inference
+    app.kubernetes.io/part-of: kleym
+    kleym.sonda.red/reference: inference-environment

--- a/test/reference/inference-environment/serviceaccount.yaml
+++ b/test/reference/inference-environment/serviceaccount.yaml
@@ -1,0 +1,11 @@
+# Externally owned reference service account. kleym only consumes the rendered
+# k8s:sa selector supplied by an InferenceIdentityBinding.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: reference-inference
+  namespace: kleym-reference-inference
+  labels:
+    app.kubernetes.io/name: reference-inference
+    app.kubernetes.io/part-of: kleym-reference-inference
+    kleym.sonda.red/reference: inference-environment

--- a/test/reference/inference-environment/workload.yaml
+++ b/test/reference/inference-environment/workload.yaml
@@ -1,0 +1,53 @@
+# Externally owned reference workload. It is deliberately implementation-neutral:
+# the stable namespace, service account, pod labels, and container name are the
+# parts consumed by kleym selector tests and demos.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reference-model-server
+  namespace: kleym-reference-inference
+  labels:
+    app.kubernetes.io/name: reference-model-server
+    app.kubernetes.io/part-of: kleym-reference-inference
+    kleym.sonda.red/reference: inference-environment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: reference-model-server
+      app.kubernetes.io/part-of: kleym-reference-inference
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: reference-model-server
+        app.kubernetes.io/part-of: kleym-reference-inference
+        kleym.sonda.red/reference: inference-environment
+    spec:
+      serviceAccountName: reference-inference
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: model-server
+          image: registry.k8s.io/e2e-test-images/agnhost:2.53
+          args:
+            - netexec
+            - --http-port=8000
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL


### PR DESCRIPTION
## What I changed and why

Adds a small reference inference environment under `test/reference/inference-environment/` for e2e tests and future demo docs.

The manifests provide externally owned inputs that exist before `kleym` reconciles an `InferenceIdentityBinding`:

- stable namespace: `kleym-reference-inference`
- stable service account: `reference-inference`
- minimal serving workload: `reference-model-server`
- GAIE `InferencePool`: `reference-pool`
- GAIE `InferenceObjective`: `reference-objective`
- stable pod labels and container name for predictable selector behavior

This gives tests and demos a deterministic environment to bind to without requiring Envoy, OPA, Gateway API routes, Envoy Gateway, policies, or downstream enforcement resources.

Also links the reference environment from the examples index so users can find it.

Fixes #6

## Validation

- `kustomize build test/reference/inference-environment`
- `make docs-build`

## Docs

updated: `test/reference/inference-environment/README.md`, `docs/examples/_index.md`

## GitHub context checked

Checked issue #6, its comment, dependency #4, related demo issue #8 and comment, and downstream handoff issue #108.
