### PR TITLE
fix: align identity binding contract with poolRef group support

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -34,7 +34,7 @@ External SPIFFE/SPIRE references:
 | `targetRef.name` | Yes | References an `InferenceObjective` in the same namespace. |
 | `spiffeIDTemplate` | No | Overrides the computed SPIFFE ID when provided. |
 | `selectorSource` | Yes | Current enum: `DerivedFromPool`. |
-| `workloadSelectorTemplates` | Yes | Non-empty set of rendered SPIRE workload selector strings. |
+| `workloadSelectorTemplates` | Yes | Non-empty set of user-supplied SPIRE workload selector templates. |
 | `mode` | No | `PoolOnly` or `PerObjective`. Defaults to `PerObjective`. |
 | `containerDiscriminator.type` | Conditionally | Required in `PerObjective`. Current enum: `ContainerName`, `ContainerImage`. |
 | `containerDiscriminator.value` | Conditionally | Required in `PerObjective`. |
@@ -70,5 +70,8 @@ The current controller resolves `InferenceObjective` and `InferencePool` from th
 - `inference.networking.x-k8s.io/v1alpha2`
 
 For objectives, `kleym` currently reads `spec.poolRef`.
+
+If `spec.poolRef.group` is set, it must match one of the supported GAIE
+InferencePool groups listed above.
 
 For pools, `kleym` currently reads `spec.selector`.

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -50,8 +50,9 @@ release.
 `spec.selector.matchExpressions` are not supported.
 
 When `spec.poolRef.group` is set, the controller constrains pool resolution to
-that group using `v1` and `v1alpha2` `InferencePool` candidates. Groups outside
-the documented GVKs are best-effort lookup only, not a compatibility guarantee.
+that group using supported `InferencePool` candidates. Groups outside the
+documented GVKs are rejected as invalid `poolRef` values instead of being
+looked up best-effort.
 
 | Startup case | Behavior |
 | --- | --- |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -78,9 +78,11 @@ Compatibility matrix for GAIE inputs (by GVK):
 `InferenceIdentityBinding` spec
 
 1. `targetRef` references an [`InferenceObjective`][gaie-inferenceobjective] in the same namespace.
-2. `spiffeIDTemplate` optionally overrides the computed template. Default is deterministic and includes trust domain, namespace, and objective name.
+2. `spiffeIDTemplate` optionally overrides the computed template. Defaults are deterministic and mode-scoped:
+   - `PoolOnly`: `spiffe://kleym.sonda.red/ns/<namespace>/pool/<pool-name>`
+   - `PerObjective`: `spiffe://kleym.sonda.red/ns/<namespace>/objective/<objective-name>`
 3. `selectorSource` is `"DerivedFromPool"`. `kleym` derives pod selection from the objective `poolRef` and validates it.
-4. `workloadSelectorTemplates` are required safety constraints. Every rendered [`ClusterSPIFFEID`][clusterspiffeid] must include at minimum the k8s namespace selector (`k8s:ns:<namespace>`) and k8s service account selector (`k8s:sa:<service-account>`). These safety selectors are always present, then intersected with the derived pool selection and, in `PerObjective` mode, the container discriminator.
+4. `workloadSelectorTemplates` are required user-supplied safety constraints. The controller renders these templates, then requires every rendered [`ClusterSPIFFEID`][clusterspiffeid] selector set to include at minimum the k8s namespace selector (`k8s:ns:<namespace>`) and k8s service account selector (`k8s:sa:<service-account>`). These selectors are validated, then intersected with the derived pool selection and, in `PerObjective` mode, the container discriminator.
 5. `mode` is `"PoolOnly"` or `"PerObjective"`. Default is `"PerObjective"`.
 6. `containerDiscriminator` (required when `mode` is `"PerObjective"`).
    - `type` is `"ContainerName"` (preferred) or `"ContainerImage"` (fallback). `ContainerName` maps to a SPIRE k8s workload selector `k8s:container-name:<value>`. `ContainerImage` maps to `k8s:container-image:<value>` and is weaker because a single image may serve multiple models.
@@ -99,8 +101,8 @@ Compatibility matrix for GAIE inputs (by GVK):
    - Startup fails only when none of the supported GAIE objective/pool GVKs are available.
 2. Watch `InferenceIdentityBinding`, plus discovered [`InferenceObjective`][gaie-inferenceobjective] and discovered [`InferencePool`][gaie-inferencepool] GVKs.
    - Example: if the cluster serves only `InferenceObjective` in `inference.networking.x-k8s.io/v1alpha2`, `kleym` watches that GVK and skips `inference.networking.k8s.io/v1` objective.
-3. Resolve `targetRef` to [`InferenceObjective`][gaie-inferenceobjective], then resolve `poolRef` to [`InferencePool`][gaie-inferencepool].
-4. Derive pod selection from [`InferencePool`][gaie-inferencepool], then intersect with the mandatory safety selectors (namespace and service account) and, in `PerObjective` mode, the container discriminator.
+3. Resolve `targetRef` to [`InferenceObjective`][gaie-inferenceobjective], then resolve `poolRef` to a supported [`InferencePool`][gaie-inferencepool] GVK. If `poolRef.group` is set, it must be one of the documented supported GAIE InferencePool groups.
+4. Derive pod selection from [`InferencePool`][gaie-inferencepool], then intersect it with the validated user-supplied safety selectors (namespace and service account) and, in `PerObjective` mode, the container discriminator.
 5. Detect identity collisions: if two `InferenceIdentityBinding` resources in `PerObjective` mode would match the same pod set and the same `container-name` value, set the `Conflict` condition with reason `IdentityCollision` on both resources and refuse to reconcile either until the collision is resolved.
 6. Reconcile one or more [`ClusterSPIFFEID`][clusterspiffeid] resources in `spire.spiffe.io` using the computed SPIFFE IDs and validated selectors.
 7. Update status and emit events for conflicts, unsafe selection, identity collisions, and render failures.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,7 +26,7 @@ If reconciliation fails, `Ready=False` and the triggering condition becomes `Tru
 | Condition | Reason | Typical cause | What to fix |
 | --- | --- | --- | --- |
 | `InvalidRef` | `TargetObjectiveNotFound` | `spec.targetRef.name` does not resolve to an `InferenceObjective` in the same namespace. | Check the objective name, namespace, and installation of the objective CRD. |
-| `InvalidRef` | `InvalidPoolRef` | The referenced objective has an invalid or cross-namespace `poolRef`. | Fix the objective so `spec.poolRef` points to a valid pool in the same namespace. |
+| `InvalidRef` | `InvalidPoolRef` | The referenced objective has an invalid, cross-namespace, or unsupported-group `poolRef`. | Fix the objective so `spec.poolRef` points to a valid pool in the same namespace and a supported GAIE group. |
 | `InvalidRef` | `TargetPoolNotFound` | The objective points to an `InferencePool` that does not exist. | Create the pool or correct the objective's `poolRef`. |
 | `InvalidRef` | `InferenceObjectiveCRDMissing` | The GAIE `InferenceObjective` CRD is not installed in the cluster. | Install the required GAIE CRDs before reconciling bindings. |
 | `InvalidRef` | `InferencePoolCRDMissing` | The GAIE `InferencePool` CRD is not installed in the cluster. | Install the required GAIE CRDs before reconciling bindings. |

--- a/internal/controller/inferenceidentitybinding_resolver.go
+++ b/internal/controller/inferenceidentitybinding_resolver.go
@@ -135,6 +135,9 @@ func extractPoolRef(objective *unstructured.Unstructured, defaultNamespace strin
 			return inferencePoolRef{}, fmt.Errorf("objective spec.poolRef.group must be a string")
 		}
 		group = strings.TrimSpace(groupValue)
+		if group != "" && !isSupportedInferencePoolGroup(group) {
+			return inferencePoolRef{}, fmt.Errorf("objective spec.poolRef.group %q is not a supported GAIE InferencePool group", group)
+		}
 	}
 
 	namespace := defaultNamespace
@@ -183,10 +186,24 @@ func candidatePoolGVKs(candidates []schema.GroupVersionKind, group string) []sch
 		return filtered
 	}
 
-	return []schema.GroupVersionKind{
-		{Group: group, Version: "v1", Kind: "InferencePool"},
-		{Group: group, Version: "v1alpha2", Kind: "InferencePool"},
+	return supportedPoolGVKsForGroup(group)
+}
+
+func isSupportedInferencePoolGroup(group string) bool {
+	return len(supportedPoolGVKsForGroup(group)) > 0
+}
+
+// supportedPoolGVKsForGroup returns static supported pool GVKs so a supported
+// group with a missing CRD is reported as infrastructure-not-ready instead of
+// being treated as an arbitrary best-effort API lookup.
+func supportedPoolGVKsForGroup(group string) []schema.GroupVersionKind {
+	supported := make([]schema.GroupVersionKind, 0, len(inferencePoolGVKs))
+	for _, gvk := range inferencePoolGVKs {
+		if gvk.Group == group {
+			supported = append(supported, gvk)
+		}
 	}
+	return supported
 }
 
 func shouldCleanupManagedClusterSPIFFEIDs(conditionType string) bool {

--- a/internal/controller/inferenceidentitybinding_resolver_test.go
+++ b/internal/controller/inferenceidentitybinding_resolver_test.go
@@ -84,6 +84,52 @@ func TestReconcileSetsInvalidRefWhenObjectivePoolRefIsInvalid(t *testing.T) {
 	assertConditionStatus(t, ctx, reconciler.Client, binding.Name, conditionTypeReady, metav1.ConditionFalse, "InvalidPoolRef")
 }
 
+func TestReconcileSetsInvalidRefWhenPoolRefGroupIsUnsupported(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newCollisionTestScheme(t)
+	unsupportedPoolGVK := schema.GroupVersionKind{
+		Group:   "inference.example.com",
+		Version: "v1",
+		Kind:    "InferencePool",
+	}
+	registerUnstructuredGVK(scheme, unsupportedPoolGVK)
+
+	pool := newTestPool()
+	pool.SetGroupVersionKind(unsupportedPoolGVK)
+	pool.SetName("pool-unsupported")
+
+	objective := newTestObjective("objective-unsupported-pool-group")
+	objective.Object["spec"] = map[string]any{
+		"poolRef": map[string]any{
+			"name":  pool.GetName(),
+			"group": unsupportedPoolGVK.Group,
+		},
+	}
+
+	binding := newPerObjectiveBinding("binding-unsupported-pool-group", objective.GetName())
+	reconciler := &InferenceIdentityBindingReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+			WithObjects(pool, objective, binding).
+			Build(),
+		Scheme: scheme,
+	}
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: binding.Name},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	assertConditionStatus(t, ctx, reconciler.Client, binding.Name, conditionTypeInvalidRef, metav1.ConditionTrue, "InvalidPoolRef")
+	assertConditionStatus(t, ctx, reconciler.Client, binding.Name, conditionTypeReady, metav1.ConditionFalse, "InvalidPoolRef")
+	assertClusterSPIFFEIDCount(t, ctx, reconciler.Client, 0)
+}
+
 func TestReconcileUsesDiscoveredObjectiveGVKsForResolution(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Align the `InferenceIdentityBinding` contract with the intended #115 decisions.
- Document pool-scoped default SPIFFE IDs for `PoolOnly` and objective-scoped defaults for `PerObjective`.
- Clarify that `workloadSelectorTemplates` are user-supplied safety selectors that the controller validates.
- Reject unsupported `spec.poolRef.group` values as `InvalidRef` / `InvalidPoolRef` instead of probing arbitrary groups best-effort.

## Related Issue

- Fixes #115

## Scope Check

- This PR follows #115 by resolving the contract decisions for SPIFFE ID defaults, selector ownership, and `poolRef.group` compatibility.
- Left out of scope: API field changes, selector injection behavior changes, trust-domain configuration, new identity modes, and downstream integration behavior.

## Follow-Up Work

- #116 can proceed after this lands.
- #117 can proceed after #116.

## Verification

- Commands run:
  - `go test ./internal/controller -run 'TestReconcileSetsInvalidRefWhenPoolRefGroupIsUnsupported|TestReconcileSetsInvalidRefWhenPoolCannotBeResolved|TestReconcileUsesDiscoveredObjectiveGVKsForResolution'`
  - `make test`
  - `make docs-build`
  - `make lint`
- Tests not run and why:
  - `make test-e2e` was not run; this change does not require Kind or cluster behavior validation.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or secret handling.
- It does narrow an external-input trust boundary by rejecting unsupported `spec.poolRef.group` values instead of attempting best-effort lookup against arbitrary groups.
