### PR TITLE
docs: remove stale versioned docs references

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ Docs live under [`docs/`](docs/), with the published site at <https://kleym.sond
 | [`docs/examples/`](docs/examples/) | Concrete manifests and expected outcomes |
 | [`docs/reference/`](docs/reference/) | API surface, conditions, and managed resources |
 | [`docs/troubleshooting.md`](docs/troubleshooting.md) | Condition-driven debugging and dependency checks |
-| [`docs/versioning.md`](docs/versioning.md) | Docs version snapshot workflow |
 | [`docs/spec.md`](docs/spec.md) | Authoritative product and API behavior |
 | [`docs/design/`](docs/design/) | Internal design notes |
 | [`docs/contributing.md`](docs/contributing.md) | Contributor workflow and validation expectations |
@@ -172,12 +171,6 @@ Build the static docs site:
 
 ```sh
 make docs-build
-```
-
-Build root and configured version snapshots:
-
-```sh
-make docs-build-versioned
 ```
 
 ## License

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,7 +60,7 @@ Each release includes:
 ## What Does Not Trigger a Release
 
 - Merging to `main` — releases are only created by the workflow_dispatch trigger.
-- Pushing a tag manually — the workflow does not listen for tag pushes.
+- Pushing a tag manually — the workflow does not run from pushed tags.
 - Dependency-only PRs (`chore(deps)`) — these are included in the next release only when you choose to run the workflow.
 
 Do not create tags locally or via the GitHub UI. The release workflow is the sole creator of tags.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,7 +10,7 @@ weight: 110
 - [`spec.md`](spec) is the authoritative product and API behavior document.
 - `README.md` is the project entry point and quickstart.
 - `AGENTS.md` is the minimal repository contract for coding agents.
-- `RELEASING.md` describes the tag-based release procedure.
+- `RELEASING.md` describes the manual release procedure.
 
 If code and docs disagree, fix the disagreement instead of silently choosing one.
 
@@ -57,7 +57,6 @@ The repository bootstraps local tool binaries under `bin/` through `make` target
 - `make help`: list supported targets
 - `make docs-build`: build the docs site with Hugo + Hextra
 - `make docs-serve`: serve docs locally with Hugo
-- `make docs-build-versioned`: build root docs and configured `/versions/*` snapshots
 - `make run`: run the controller locally against the current kubeconfig
 - `make build`: build the manager binary
 - `make test`: run non-e2e tests with envtest setup
@@ -134,17 +133,11 @@ To build the static site:
 make docs-build
 ```
 
-To build versioned output paths configured in `.docs-versions`:
-
-```sh
-make docs-build-versioned
-```
-
 Docs-related pull requests and pushes to `main` run a dedicated docs workflow that executes `make docs-build`.
 
 ## CI And Releases
 
 - CI workflows run on GitHub-hosted runners (`ubuntu-latest`) and must not depend on local or self-hosted infrastructure.
 - `.github/workflows/ci.yml` runs separate `Lint` and `Test` jobs on pull requests and pushes to `main`
-- `.github/workflows/release.yml` runs on `v*` tag pushes, verifies the tag is on `main`, builds artifacts and images, and creates a GitHub Release
-- Follow Conventional Commits for PR titles. See `RELEASING.md` for the tag-based release procedure
+- `.github/workflows/release.yml` runs by manual `workflow_dispatch` from the GitHub Actions UI, builds artifacts and images, creates the release tag, and creates a GitHub Release
+- Follow Conventional Commits for PR titles. See `RELEASING.md` for the manual release procedure

--- a/docs/install.md
+++ b/docs/install.md
@@ -90,16 +90,8 @@ Build the static site locally:
 make docs-build
 ```
 
-Build the default site plus configured version snapshots:
-
-```sh
-make docs-build-versioned
-```
-
 Override the port if you need something other than `1313`:
 
 ```sh
 make docs-serve DOCS_PORT=8080
 ```
-
-Version snapshots are defined in `.docs-versions`.


### PR DESCRIPTION
## Summary

- Remove stale public references to the missing versioned docs workflow.
- Align contributor and release docs with the current manual `workflow_dispatch` release process.

## Related Issue

- Fixes #116

## Scope Check

- This PR follows #116 as a docs-only cleanup.
- Left out of scope: adding a versioned docs system, adding `docs-build-versioned`, creating `.docs-versions`, or changing the release workflow.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none

## Verification

- Commands run:
  - `rg "docs-build-versioned|\\.docs-versions|docs/versioning|tag pushes|tag-based" README.md docs CONTRIBUTING.md RELEASING.md .github`
  - `git diff --check`
  - `make docs-build`
- Tests not run and why:
  - Go/controller tests were not run because this is a docs-only change.

## Security Review

- This PR updates release documentation only.
- It does not change GitHub Actions, CI/release automation code, credentials, secrets, permissions, or trust boundaries.
