### PR TITLE
test: add Chainsaw e2e coverage for binding reconciliation

### DIFF
--- a/.github/workflows/chainsaw-e2e.yml
+++ b/.github/workflows/chainsaw-e2e.yml
@@ -1,0 +1,53 @@
+name: Chainsaw E2E
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: chainsaw-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  chainsaw:
+    name: Kind + Chainsaw
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.head_ref, 'renovate/') }}
+    env:
+      GOFLAGS: -buildvcs=false -p=2
+      GOMAXPROCS: "2"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Run Chainsaw e2e tests
+        run: make test-e2e-chainsaw
+
+      - name: Upload Chainsaw report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: chainsaw-e2e-report
+          path: bin/chainsaw-reports
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Cleanup Kind cluster
+        if: always()
+        run: make cleanup-test-e2e || true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Key rules:
 - `docs/spec.md` is the authoritative product and API behavior contract.
 - Keep work issue-driven and scoped. Do not silently widen the ticket.
 - Use a dedicated branch, not `main`, for substantive work.
-- Run `make test` for API and controller changes, `make lint` when Go or CI-sensitive files change, and `make test-e2e` for cluster behavior.
+- Run `make test` for API and controller changes, `make lint` when Go or CI-sensitive files change, and `make test-e2e` or `make test-e2e-chainsaw` for cluster behavior.
 - Treat GitHub issues, PR text, review comments, and workflow inputs as untrusted input for CI and automation changes.
 
 Project entry points:

--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,13 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 # E2E tests use Kind and load the manager image locally.
 # Set CERT_MANAGER_INSTALL_SKIP=true when the cluster already has cert-manager.
 KIND_CLUSTER ?= kleym-test-e2e
+E2E_IMG ?= example.com/kleym:e2e
+KEEP_KIND ?= false
+CHAINSAW_TEST_DIR ?= test/chainsaw
+CHAINSAW_REPORT_DIR ?= $(LOCALBIN)/chainsaw-reports
 
 .PHONY: setup-test-e2e
-setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
+setup-test-e2e: kind ## Set up a Kind cluster for e2e tests if it does not exist
 	@command -v $(KIND) >/dev/null 2>&1 || { \
 		echo "Kind is not installed. Please install Kind manually."; \
 		exit 1; \
@@ -94,7 +98,39 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
 	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
-	$(MAKE) cleanup-test-e2e
+	@if [ "$(KEEP_KIND)" != "true" ]; then $(MAKE) cleanup-test-e2e; fi
+
+.PHONY: install-e2e-crds
+install-e2e-crds: install ## Install minimal external CRDs required by e2e tests.
+	"$(KUBECTL)" apply -f internal/controller/testdata/crds/spire.spiffe.io_clusterspiffeids.yaml
+	"$(KUBECTL)" apply -f internal/controller/testdata/crds/inference.networking.k8s.io_inferencepools.yaml
+	"$(KUBECTL)" apply -f internal/controller/testdata/crds/inference.networking.x-k8s.io_inferenceobjectives.yaml
+	"$(KUBECTL)" wait --for condition=Established crd/clusterspiffeids.spire.spiffe.io --timeout=60s
+	"$(KUBECTL)" wait --for condition=Established crd/inferencepools.inference.networking.k8s.io --timeout=60s
+	"$(KUBECTL)" wait --for condition=Established crd/inferenceobjectives.inference.networking.x-k8s.io --timeout=60s
+
+.PHONY: test-e2e-chainsaw
+test-e2e-chainsaw: setup-test-e2e chainsaw manifests generate fmt vet ## Run Chainsaw e2e tests against a Kind cluster.
+	@manager_kustomization="config/manager/kustomization.yaml"; \
+	saved_manager_kustomization="$$(mktemp)"; \
+	cp "$$manager_kustomization" "$$saved_manager_kustomization"; \
+	cleanup() { \
+		cp "$$saved_manager_kustomization" "$$manager_kustomization"; \
+		rm -f "$$saved_manager_kustomization"; \
+		if [ "$(KEEP_KIND)" != "true" ]; then $(MAKE) cleanup-test-e2e; fi; \
+	}; \
+	trap cleanup EXIT; \
+	$(MAKE) docker-build IMG=$(E2E_IMG); \
+	"$(KIND)" load docker-image "$(E2E_IMG)" --name "$(KIND_CLUSTER)"; \
+	$(MAKE) install-e2e-crds; \
+	$(MAKE) deploy IMG=$(E2E_IMG); \
+	"$(KUBECTL)" rollout status deployment/kleym-controller-manager -n kleym-system --timeout=120s; \
+	mkdir -p "$(CHAINSAW_REPORT_DIR)"; \
+	"$(CHAINSAW)" test "$(CHAINSAW_TEST_DIR)" \
+		--fail-fast \
+		--report-format JUNIT-TEST \
+		--report-path "$(CHAINSAW_REPORT_DIR)" \
+		--report-name chainsaw-e2e
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
@@ -206,16 +242,19 @@ $(LOCALBIN):
 
 ## Tool Binaries
 KUBECTL ?= kubectl
-KIND ?= kind
+KIND ?= $(LOCALBIN)/kind
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+CHAINSAW ?= $(LOCALBIN)/chainsaw
 LINT_GOFLAGS ?= -buildvcs=false -p=2
 LINT_GOCACHE ?= $(LOCALBIN)/.cache/go-build
 LINT_GOLANGCI_LINT_CACHE ?= $(LOCALBIN)/.cache/golangci-lint
 
 ## Tool Versions
+KIND_VERSION ?= v0.30.0
+CHAINSAW_VERSION ?= v0.2.13
 KUSTOMIZE_VERSION ?= v5.7.1
 CONTROLLER_TOOLS_VERSION ?= v0.19.0
 
@@ -230,6 +269,33 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
 GOLANGCI_LINT_VERSION ?= v2.11.4
+.PHONY: kind
+kind: $(KIND) ## Download kind locally if necessary.
+$(KIND): $(LOCALBIN)
+	$(call go-install-tool,$(KIND),sigs.k8s.io/kind,$(KIND_VERSION))
+
+.PHONY: chainsaw
+chainsaw: $(CHAINSAW) ## Download Chainsaw locally if necessary.
+$(CHAINSAW): $(LOCALBIN)
+	@[ -f "$(CHAINSAW)-$(CHAINSAW_VERSION)" ] && [ "$$(readlink -- "$(CHAINSAW)" 2>/dev/null)" = "$(CHAINSAW)-$(CHAINSAW_VERSION)" ] || { \
+	set -e; \
+	os="$$(uname | tr '[:upper:]' '[:lower:]')"; \
+	arch="$$(uname -m)"; \
+	case "$$arch" in \
+		x86_64|amd64) arch=amd64 ;; \
+		aarch64|arm64) arch=arm64 ;; \
+		*) echo "Unsupported Chainsaw architecture: $$arch"; exit 1 ;; \
+	esac; \
+	tmp="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmp"' EXIT; \
+	url="https://github.com/kyverno/chainsaw/releases/download/$(CHAINSAW_VERSION)/chainsaw_$${os}_$${arch}.tar.gz"; \
+	echo "Downloading $${url}"; \
+	curl -L --max-time 120 -o "$$tmp/chainsaw.tar.gz" "$$url"; \
+	tar -xzf "$$tmp/chainsaw.tar.gz" -C "$$tmp"; \
+	install -m 0755 "$$tmp/chainsaw" "$(CHAINSAW)-$(CHAINSAW_VERSION)"; \
+	}; \
+	ln -sf "$$(realpath "$(CHAINSAW)-$(CHAINSAW_VERSION)")" "$(CHAINSAW)"
+
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Prerequisites:
 - `kubectl`
 - Access to a Kubernetes cluster with the Gateway API Inference Extension [`InferenceObjective`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferenceobjective/) and [`InferencePool`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/) CRDs
 - SPIRE Controller Manager with the `ClusterSPIFFEID` CRD
-- `kind` for `make test-e2e`
+- Docker for Kind-backed e2e; the e2e targets bootstrap `kind` and Chainsaw under `bin/`
 
 Run the controller locally:
 
@@ -80,6 +80,7 @@ Run validation:
 ```sh
 make test
 make lint
+make test-e2e-chainsaw KEEP_KIND=true
 ```
 
 ## Reconcile Flow

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -38,10 +38,10 @@ Keep that review narrow. Read the issue or PR that motivated the change and any 
 - Docker
 - `kubectl`
 - Access to a Kubernetes cluster for deployment testing
-- `kind` for local e2e testing
+- Docker for local Kind-backed e2e testing; the e2e targets bootstrap `kind` and Chainsaw under `bin/`
 - Hugo Extended `0.146+` for docs preview/build
 
-The repository bootstraps local tool binaries under `bin/` through `make` targets, so global installs of `controller-gen`, `kustomize`, `setup-envtest`, and `golangci-lint` are not required.
+The repository bootstraps local tool binaries under `bin/` through `make` targets, so global installs of `controller-gen`, `kustomize`, `setup-envtest`, `golangci-lint`, `kind`, and Chainsaw are not required.
 
 ## Repository Map
 
@@ -50,6 +50,7 @@ The repository bootstraps local tool binaries under `bin/` through `make` target
 - `internal/controller`: reconciliation logic and controller-focused tests
 - `config/`: CRD, RBAC, manager deployment, samples, and kustomize overlays
 - `test/e2e`: Kind-backed end-to-end coverage
+- `test/chainsaw`: Chainsaw scenarios for declarative cluster reconciliation checks
 - `.github/workflows`: CI, release, and maintenance automation
 
 ## Common Commands
@@ -62,6 +63,7 @@ The repository bootstraps local tool binaries under `bin/` through `make` target
 - `make test`: run non-e2e tests with envtest setup
 - `make lint`: run `golangci-lint`
 - `make test-e2e`: run Kind-backed end-to-end tests
+- `make test-e2e-chainsaw`: run Kind-backed Chainsaw tests
 - `make install`: install CRDs into the current cluster
 - `make deploy IMG=<registry>/kleym:<tag>`: deploy the controller image to the current cluster
 - `make build-installer`: render `dist/install.yaml`
@@ -115,6 +117,7 @@ Run `make lint` as well when you touch Go code, build logic, or CI-sensitive beh
 - Prefer the smallest command set that proves the change.
 - Use `make test` for normal API and controller work.
 - Use `make test-e2e` for cluster behavior, Kind setup, deployment flows, or bugs that only reproduce against a live control plane.
+- Use `make test-e2e-chainsaw` for binding-to-`ClusterSPIFFEID` reconciliation coverage that can be expressed as Kubernetes resources and assertions.
 - If you skip a relevant test, say so in your handoff.
 
 ## Docs Workflow
@@ -139,5 +142,6 @@ Docs-related pull requests and pushes to `main` run a dedicated docs workflow th
 
 - CI workflows run on GitHub-hosted runners (`ubuntu-latest`) and must not depend on local or self-hosted infrastructure.
 - `.github/workflows/ci.yml` runs separate `Lint` and `Test` jobs on pull requests and pushes to `main`
+- `.github/workflows/chainsaw-e2e.yml` runs the Kind-backed Chainsaw reconciliation check on pull requests, pushes to `main`, and manual dispatch
 - `.github/workflows/release.yml` runs by manual `workflow_dispatch` from the GitHub Actions UI, builds artifacts and images, creates the release tag, and creates a GitHub Release
 - Follow Conventional Commits for PR titles. See `RELEASING.md` for the manual release procedure

--- a/docs/install.md
+++ b/docs/install.md
@@ -13,10 +13,10 @@ This page covers the practical commands for running `kleym`, deploying it, testi
 - Access to a Kubernetes cluster
 - Gateway API Inference Extension (GAIE) CRDs for [`InferenceObjective`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferenceobjective/) and [`InferencePool`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/)
 - SPIFFE Runtime Environment (SPIRE) Controller Manager with the [`ClusterSPIFFEID` CRD](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md)
-- `kind` for `make test-e2e`
+- Docker for Kind-backed e2e; the e2e targets bootstrap `kind` and Chainsaw under `bin/`
 - Hugo Extended `0.146+` for docs preview/build
 
-The repository bootstraps local tool binaries under `bin/` through `make` targets, so you do not need to install `controller-gen`, `kustomize`, `setup-envtest`, or `golangci-lint` globally.
+The repository bootstraps local tool binaries under `bin/` through `make` targets, so you do not need to install `controller-gen`, `kustomize`, `setup-envtest`, `golangci-lint`, `kind`, or Chainsaw globally.
 
 For identity-system background, see [SPIFFE overview](https://spiffe.io/docs/latest/spiffe-about/overview/) and [SPIRE concepts](https://spiffe.io/docs/latest/spire-about/spire-concepts/).
 
@@ -72,6 +72,18 @@ Run Kind-backed end-to-end coverage:
 
 ```sh
 make test-e2e
+```
+
+Run the Kind-backed Chainsaw reconciliation check:
+
+```sh
+make test-e2e-chainsaw
+```
+
+Keep the Kind cluster for faster local iteration:
+
+```sh
+make test-e2e-chainsaw KEEP_KIND=true
 ```
 
 Use the smallest command set that proves the change. See [contributing](contributing) for the repository validation expectations.

--- a/test/chainsaw/binding-reconciliation/binding-ready.yaml
+++ b/test/chainsaw/binding-reconciliation/binding-ready.yaml
@@ -1,0 +1,33 @@
+apiVersion: kleym.sonda.red/v1alpha1
+kind: InferenceIdentityBinding
+metadata:
+  name: binding
+  namespace: kleym-reference-inference
+status:
+  computedSpiffeIDs:
+    - mode: PerObjective
+      spiffeID: spiffe://kleym.sonda.red/ns/kleym-reference-inference/objective/reference-objective
+  renderedSelectors:
+    - spiffeID: spiffe://kleym.sonda.red/ns/kleym-reference-inference/objective/reference-objective
+      selectors:
+        - k8s:container-name:model-server
+        - k8s:ns:kleym-reference-inference
+        - k8s:pod-label:app.kubernetes.io/name:reference-model-server
+        - k8s:pod-label:app.kubernetes.io/part-of:kleym-reference-inference
+        - k8s:sa:reference-inference
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Reconciled
+    - type: Conflict
+      status: "False"
+      reason: Resolved
+    - type: InvalidRef
+      status: "False"
+      reason: Resolved
+    - type: UnsafeSelector
+      status: "False"
+      reason: Resolved
+    - type: RenderFailure
+      status: "False"
+      reason: Resolved

--- a/test/chainsaw/binding-reconciliation/binding.yaml
+++ b/test/chainsaw/binding-reconciliation/binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: kleym.sonda.red/v1alpha1
+kind: InferenceIdentityBinding
+metadata:
+  name: binding
+  namespace: kleym-reference-inference
+spec:
+  targetRef:
+    name: reference-objective
+  selectorSource: DerivedFromPool
+  workloadSelectorTemplates:
+    - k8s:ns:kleym-reference-inference
+    - k8s:sa:reference-inference
+  mode: PerObjective
+  containerDiscriminator:
+    type: ContainerName
+    value: model-server

--- a/test/chainsaw/binding-reconciliation/chainsaw-test.yaml
+++ b/test/chainsaw/binding-reconciliation/chainsaw-test.yaml
@@ -1,0 +1,82 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: binding-reconciliation
+spec:
+  description: Verifies that reference PerObjective and PoolOnly bindings reconcile to stable managed ClusterSPIFFEIDs.
+  timeouts:
+    apply: 30s
+    assert: 2m
+    cleanup: 45s
+    delete: 30s
+    exec: 2m
+  steps:
+    - name: apply-reference-environment
+      try:
+        - script:
+            workDir: ../../..
+            content: kubectl apply -k test/reference/inference-environment
+
+    - name: apply-binding
+      try:
+        - apply:
+            file: binding.yaml
+        - assert:
+            file: binding-ready.yaml
+        - assert:
+            file: clusterspiffeid.yaml
+
+    - name: reapply-binding
+      try:
+        - apply:
+            file: binding.yaml
+        - assert:
+            file: binding-ready.yaml
+        - assert:
+            file: clusterspiffeid.yaml
+
+    - name: delete-binding
+      try:
+        - delete:
+            file: binding.yaml
+        - script:
+            content: |
+              kubectl wait --for=delete inferenceidentitybinding/binding \
+                -n kleym-reference-inference \
+                --timeout=60s
+              kubectl wait --for=delete clusterspiffeid/kleym-kleym-reference-inference-binding-objective-3b2d9110 \
+                --timeout=60s
+
+    - name: apply-pool-binding
+      try:
+        - apply:
+            file: pool-binding.yaml
+        - assert:
+            file: pool-binding-ready.yaml
+        - assert:
+            file: pool-clusterspiffeid.yaml
+
+    - name: reapply-pool-binding
+      try:
+        - apply:
+            file: pool-binding.yaml
+        - assert:
+            file: pool-binding-ready.yaml
+        - assert:
+            file: pool-clusterspiffeid.yaml
+
+    - name: delete-pool-binding
+      try:
+        - delete:
+            file: pool-binding.yaml
+        - script:
+            content: |
+              kubectl wait --for=delete inferenceidentitybinding/pool-binding \
+                -n kleym-reference-inference \
+                --timeout=60s
+              kubectl wait --for=delete clusterspiffeid/kleym-kleym-reference-inference-pool-binding-pool-e2d8bd8d \
+                --timeout=60s
+        - script:
+            workDir: ../../..
+            content: kubectl delete -k test/reference/inference-environment --ignore-not-found=true

--- a/test/chainsaw/binding-reconciliation/clusterspiffeid.yaml
+++ b/test/chainsaw/binding-reconciliation/clusterspiffeid.yaml
@@ -1,0 +1,22 @@
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterSPIFFEID
+metadata:
+  name: kleym-kleym-reference-inference-binding-objective-3b2d9110
+  labels:
+    kleym.sonda.red/managed-by: kleym
+    kleym.sonda.red/binding-name: binding
+    kleym.sonda.red/binding-namespace: kleym-reference-inference
+spec:
+  spiffeIDTemplate: spiffe://kleym.sonda.red/ns/kleym-reference-inference/objective/reference-objective
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: reference-model-server
+      app.kubernetes.io/part-of: kleym-reference-inference
+  workloadSelectorTemplates:
+    - k8s:container-name:model-server
+    - k8s:ns:kleym-reference-inference
+    - k8s:pod-label:app.kubernetes.io/name:reference-model-server
+    - k8s:pod-label:app.kubernetes.io/part-of:kleym-reference-inference
+    - k8s:sa:reference-inference
+  fallback: false
+  hint: kleym-reference-inference/binding

--- a/test/chainsaw/binding-reconciliation/pool-binding-ready.yaml
+++ b/test/chainsaw/binding-reconciliation/pool-binding-ready.yaml
@@ -1,0 +1,32 @@
+apiVersion: kleym.sonda.red/v1alpha1
+kind: InferenceIdentityBinding
+metadata:
+  name: pool-binding
+  namespace: kleym-reference-inference
+status:
+  computedSpiffeIDs:
+    - mode: PoolOnly
+      spiffeID: spiffe://kleym.sonda.red/ns/kleym-reference-inference/pool/reference-pool
+  renderedSelectors:
+    - spiffeID: spiffe://kleym.sonda.red/ns/kleym-reference-inference/pool/reference-pool
+      selectors:
+        - k8s:ns:kleym-reference-inference
+        - k8s:pod-label:app.kubernetes.io/name:reference-model-server
+        - k8s:pod-label:app.kubernetes.io/part-of:kleym-reference-inference
+        - k8s:sa:reference-inference
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Reconciled
+    - type: Conflict
+      status: "False"
+      reason: Resolved
+    - type: InvalidRef
+      status: "False"
+      reason: Resolved
+    - type: UnsafeSelector
+      status: "False"
+      reason: Resolved
+    - type: RenderFailure
+      status: "False"
+      reason: Resolved

--- a/test/chainsaw/binding-reconciliation/pool-binding.yaml
+++ b/test/chainsaw/binding-reconciliation/pool-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: kleym.sonda.red/v1alpha1
+kind: InferenceIdentityBinding
+metadata:
+  name: pool-binding
+  namespace: kleym-reference-inference
+spec:
+  targetRef:
+    name: reference-objective
+  selectorSource: DerivedFromPool
+  workloadSelectorTemplates:
+    - k8s:ns:kleym-reference-inference
+    - k8s:sa:reference-inference
+  mode: PoolOnly

--- a/test/chainsaw/binding-reconciliation/pool-clusterspiffeid.yaml
+++ b/test/chainsaw/binding-reconciliation/pool-clusterspiffeid.yaml
@@ -1,0 +1,21 @@
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterSPIFFEID
+metadata:
+  name: kleym-kleym-reference-inference-pool-binding-pool-e2d8bd8d
+  labels:
+    kleym.sonda.red/managed-by: kleym
+    kleym.sonda.red/binding-name: pool-binding
+    kleym.sonda.red/binding-namespace: kleym-reference-inference
+spec:
+  spiffeIDTemplate: spiffe://kleym.sonda.red/ns/kleym-reference-inference/pool/reference-pool
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: reference-model-server
+      app.kubernetes.io/part-of: kleym-reference-inference
+  workloadSelectorTemplates:
+    - k8s:ns:kleym-reference-inference
+    - k8s:pod-label:app.kubernetes.io/name:reference-model-server
+    - k8s:pod-label:app.kubernetes.io/part-of:kleym-reference-inference
+    - k8s:sa:reference-inference
+  fallback: false
+  hint: kleym-reference-inference/pool-binding


### PR DESCRIPTION
## Summary

- Add a Kind-backed Chainsaw e2e path for `InferenceIdentityBinding` reconciliation.
- Cover both `PerObjective` and `PoolOnly` bindings against the reference inference environment.
- Assert `Ready=True`, computed SPIFFE IDs, rendered selectors, managed `ClusterSPIFFEID` shape, reapply stability, and cleanup after binding deletion.
- Add a GitHub Actions workflow that runs the same `make test-e2e-chainsaw` command used locally.

## Related Issue

- Fixes #113

## Scope Check

- This follows #113 by adding focused Kind-backed e2e coverage for binding reconciliation.
- The test installs only the minimal external CRDs needed for GAIE inputs and `ClusterSPIFFEID`.
- It reuses `test/reference/inference-environment/`.
- It does not test SPIRE/SVID issuance, Envoy, mTLS enforcement, OPA, Gateway routes, or downstream policy resources.
- I added `PoolOnly` alongside `PerObjective` because it is the other supported identity mode and has materially different output: pool SPIFFE ID, pool-mode name, and no container selector.

## Follow-Up Work

- Proposed follow-up issue: retire or rename the scaffolded Kubebuilder Go e2e suite once the Chainsaw workflow has been stable in CI.
- Proposed follow-up issue: add targeted Chainsaw negative cases only if a live-cluster regression appears; invalid refs, unsafe selectors, and collisions remain better covered by Go/envtest for now.

## Verification

- Commands run:
  - `bin/chainsaw lint test -f test/chainsaw/binding-reconciliation/chainsaw-test.yaml`
  - `make lint`
  - `make test`
  - `make test-e2e-chainsaw`
  - `make docs-build`
- Tests not run and why:
  - None relevant skipped.

## Security Review

- This PR touches GitHub Actions/CI.
- The workflow uses normal `pull_request`, `push`, and `workflow_dispatch`; it does not use `pull_request_target`.
- Workflow permissions are limited to `contents: read`.
- The e2e image is built from the checked-out commit and loaded into Kind locally as `example.com/kleym:e2e`; it is not pushed to a registry and does not require package write permissions.
- Chainsaw reports are uploaded as artifacts only; no secrets or write tokens are exposed.
