### PR TITLE
feat: add GitOps deployment entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ make install
 make deploy IMG=ghcr.io/sonda-red/kleym:latest
 ```
 
+Install the latest kleym operator from the root GitOps path:
+
+```sh
+kubectl apply -k https://github.com/sonda-red/kleym//deployment?ref=main
+```
+
+For release-pinned installs, pin the manifest ref and controller image tag
+together. See [`docs/install.md`](docs/install.md) for Kustomize, Flux, and Argo
+CD examples.
+
 Run validation:
 
 ```sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,12 +20,17 @@ kleym uses workflow-dispatch publishing. The release workflow is triggered manua
 5. The workflow:
    - Validates the version format and that the tag does not already exist.
    - Runs tests.
-   - Builds `dist/install.yaml` and `dist/kleym-crds.yaml`.
+   - Builds generated release artifacts under `dist/`: `install.yaml` and
+     `kleym-crds.yaml`.
    - Builds and pushes a multi-arch container image to GHCR (`ghcr.io/sonda-red/kleym:vX.Y.Z` and `latest`).
    - Creates an annotated git tag and pushes it.
    - Creates a GitHub Release with auto-generated release notes from merged PR titles.
 
-6. Consume `install.yaml` or the GHCR image from the release.
+6. Consume the generated `install.yaml` release asset, the GHCR image, or the
+   root GitOps kustomization from the release. GitOps users can pin the root
+   kustomization to the release tag, for example
+   `https://github.com/sonda-red/kleym//deployment?ref=vX.Y.Z`, and override the
+   controller image tag to the same `vX.Y.Z` version.
 
 ## Why workflow_dispatch
 
@@ -49,13 +54,19 @@ Dependency-only updates use `chore(deps)` and do not trigger a release unless yo
 
 ## Release Artifacts
 
-Each release includes:
+Each release includes generated artifacts. They are uploaded to the GitHub
+Release and are not committed to the repository.
 
 | Artifact | Description |
 |----------|-------------|
 | `install.yaml` | Full operator deployment manifest (CRDs + controller + RBAC) |
 | `kleym-crds.yaml` | CRD-only bundle for standalone CRD installation |
 | GHCR image | `ghcr.io/sonda-red/kleym:vX.Y.Z` and `latest` |
+
+The repository also exposes the `deployment/` kustomization for GitOps
+controllers. On `main` it tracks latest content and the `latest` controller
+image. For release-pinned GitOps installs, pin the Git ref to the release tag
+and override the controller image tag to the same `vX.Y.Z` version.
 
 ## What Does Not Trigger a Release
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,12 @@
+# kleym GitOps deployment
+
+This directory is the root GitOps entry point for installing the kleym operator.
+It renders the kleym CRD, namespace, RBAC, controller Deployment, and metrics
+Service through `config/default`.
+
+External dependency CRDs are not included. Install Gateway API Inference
+Extension CRDs and SPIRE Controller Manager, including the `ClusterSPIFFEID`
+CRD, before starting kleym.
+
+For Kustomize, Flux, Argo CD, release pinning, and Helm guidance, see
+[`docs/install.md`](../docs/install.md#gitops-install).

--- a/deployment/kustomization.yaml
+++ b/deployment/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Root GitOps entry point for installing the kleym operator.
+# Keep this pointed at config/default so generated CRDs, RBAC, and controller
+# deployment changes flow here without duplicating manifests in this directory.
+resources:
+- ../config/default

--- a/docs/install.md
+++ b/docs/install.md
@@ -48,11 +48,173 @@ Deploy the controller image:
 make deploy IMG=<registry>/kleym:<tag>
 ```
 
-Render the consolidated installer manifest:
+Render the local consolidated installer manifest into `dist/install.yaml`:
 
 ```sh
 make build-installer
 ```
+
+`dist/install.yaml` is generated output and is not committed to the repository.
+
+For Kustomize, Flux, or Argo CD installs, use the root `deployment/`
+kustomization described below.
+
+## GitOps Install
+
+Use the root `deployment/` kustomization when Flux or Argo CD should manage the
+kleym operator.
+
+The path installs the kleym CRD, namespace, RBAC, controller Deployment, and
+metrics Service. It does not install external dependency CRDs: Gateway API
+Inference Extension CRDs and SPIRE Controller Manager, including the
+`ClusterSPIFFEID` CRD, must already be installed.
+
+Install the latest operator manifests directly from `main`:
+
+```sh
+kubectl apply -k https://github.com/sonda-red/kleym//deployment?ref=main
+```
+
+For release-pinned installs, pin both the manifest ref and controller image tag
+with a Kustomize overlay:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/sonda-red/kleym//deployment?ref=vX.Y.Z
+images:
+- name: ghcr.io/sonda-red/kleym
+  newTag: vX.Y.Z
+```
+
+Apply that overlay:
+
+```sh
+kubectl apply -k .
+```
+
+Flux example using latest manifests from `main`:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: kleym
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://github.com/sonda-red/kleym
+  ref:
+    branch: main
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kleym
+  namespace: flux-system
+spec:
+  interval: 1h
+  path: ./deployment
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: kleym
+  wait: true
+```
+
+Argo CD example using latest manifests from `main`:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kleym
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/sonda-red/kleym.git
+    targetRevision: main
+    path: deployment
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kleym-system
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+```
+
+The examples leave pruning disabled because deleting a CRD also deletes its
+custom resources.
+
+Pinned Flux example using release manifests and a matching controller image tag:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: kleym
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://github.com/sonda-red/kleym
+  ref:
+    tag: vX.Y.Z
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kleym
+  namespace: flux-system
+spec:
+  interval: 1h
+  path: ./deployment
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: kleym
+  images:
+  - name: ghcr.io/sonda-red/kleym
+    newTag: vX.Y.Z
+  wait: true
+```
+
+Pinned Argo CD example using release manifests and a matching controller image
+tag:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kleym
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/sonda-red/kleym.git
+    targetRevision: vX.Y.Z
+    path: deployment
+    kustomize:
+      images:
+      - ghcr.io/sonda-red/kleym:vX.Y.Z
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kleym-system
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+```
+
+A raw commit SHA pins manifest content at that commit. Use an image override
+when the controller image must also be pinned.
+
+Helm is not needed for this installation path. The manifests are static, GitOps
+tools can pin the manifest ref and image tag directly, and Flux or Argo CD can
+consume the kustomization without a chart. A chart should be revisited when
+kleym needs a larger templated install surface for operator-specific options.
 
 ## Test
 


### PR DESCRIPTION
## What I changed and why

Closes #93.

This adds a root `deployment/` kustomization as the stable GitOps entry point for installing kleym. It points at `config/default` so the install path includes the current kleym CRD, namespace, RBAC, controller Deployment, and metrics Service without duplicating generated manifests.

I also updated the install and release docs to explain latest installs, release-pinned installs, and the image-tag override needed when consuming `deployment/?ref=vX.Y.Z`.

## Docs

Updated:
- `README.md`
- `docs/install.md`
- `RELEASING.md`
- `deployment/README.md`

Not needed:
- `docs/spec.md`, because this changes installation packaging and guidance, not API or controller behavior.

## Verification

- `kustomize build deployment`
- `kustomize build deployment --load-restrictor=LoadRestrictionsRootOnly`
- `kubectl kustomize deployment`
- `make docs-build`
