### PR TITLE
feat: add initial kleym CLI scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,10 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 build-operator: manifests generate fmt vet ## Build the kleym-operator binary.
 	go build -o bin/kleym-operator ./cmd/kleym-operator
 
+.PHONY: build-cli
+build-cli: fmt vet ## Build the kleym CLI binary.
+	go build -o bin/kleym ./cmd/kleym
+
 .PHONY: build
 build: build-operator ## Compatibility alias for build-operator.
 

--- a/cmd/kleym/main.go
+++ b/cmd/kleym/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/sonda-red/kleym/internal/cli"
+)
+
+func main() {
+	os.Exit(cli.Execute(os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -34,7 +34,7 @@ The command inspects one `InferenceIdentityBinding` end to end.
 --timeout
 ```
 
-Default output is `text`. Stable machine output is `json`.
+Default namespace is `default`. Default output is `text`. Stable machine output is `json`. `--timeout` must be greater than zero.
 
 ## Output Contract
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0
+	github.com/spf13/cobra v1.10.2
 	k8s.io/api v0.36.1
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1
@@ -51,7 +52,6 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/internal/cli/execute.go
+++ b/internal/cli/execute.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	exitOK       = 0
+	exitGeneric  = 1
+	exitUsage    = 4
+	exitInternal = 5
+)
+
+type exitError struct {
+	code int
+	err  error
+}
+
+func (e *exitError) Error() string {
+	return e.err.Error()
+}
+
+func (e *exitError) Unwrap() error {
+	return e.err
+}
+
+// Execute runs the CLI and returns the process exit code defined by docs/spec/cli.md.
+func Execute(args []string, stdout io.Writer, stderr io.Writer) int {
+	cmd := NewRootCommand()
+	cmd.SetArgs(args)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+		return codeForError(err)
+	}
+	return exitOK
+}
+
+func withExitCode(code int, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &exitError{code: code, err: err}
+}
+
+func codeForError(err error) int {
+	var coded *exitError
+	if errors.As(err, &coded) {
+		return coded.code
+	}
+	if strings.HasPrefix(err.Error(), "unknown command ") {
+		return exitUsage
+	}
+	return exitGeneric
+}

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+var errInspectBindingNotImplemented = errors.New("inspect binding is not implemented")
+
+// newInspectCommand creates the inspect command group under the root CLI.
+func newInspectCommand(opts *Options) *cobra.Command {
+	inspectCmd := &cobra.Command{
+		Use:   "inspect",
+		Short: "Inspect Kleym resources",
+	}
+
+	bindingCmd := &cobra.Command{
+		Use:   "binding <name>",
+		Short: "Inspect one InferenceIdentityBinding",
+		Args: func(cmd *cobra.Command, args []string) error {
+			return withExitCode(exitUsage, cobra.ExactArgs(1)(cmd, args))
+		},
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			return validateRunnableOptions(opts)
+		},
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return withExitCode(exitInternal, errInspectBindingNotImplemented)
+		},
+	}
+
+	inspectCmd.AddCommand(bindingCmd)
+	return inspectCmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultNamespace = "default"
+	outputText       = "text"
+	outputJSON       = "json"
+)
+
+// Options holds top-level CLI flags for the kleym command tree.
+type Options struct {
+	Namespace  string
+	Output     string
+	Strict     bool
+	Context    string
+	Kubeconfig string
+	Timeout    time.Duration
+}
+
+// NewRootCommand builds the kleym root command defined by the CLI spec.
+func NewRootCommand() *cobra.Command {
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use:           "kleym",
+		Short:         "Read-only inspection CLI for Kleym bindings",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+	cmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		return withExitCode(exitUsage, err)
+	})
+
+	cmd.PersistentFlags().StringVarP(&opts.Namespace, "namespace", "n", defaultNamespace, "Namespace for binding lookup")
+	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", outputText, "Output format: text|json")
+	cmd.PersistentFlags().BoolVar(&opts.Strict, "strict", false, "Treat warning findings as errors")
+	cmd.PersistentFlags().StringVar(&opts.Context, "context", "", "Name of the kubeconfig context to use")
+	cmd.PersistentFlags().StringVar(&opts.Kubeconfig, "kubeconfig", "", "Path to the kubeconfig file")
+	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", 30*time.Second, "Inspection timeout")
+
+	cmd.AddCommand(newInspectCommand(opts))
+	return cmd
+}
+
+func validateRunnableOptions(opts *Options) error {
+	if opts.Output != outputText && opts.Output != outputJSON {
+		return withExitCode(exitUsage, fmt.Errorf("invalid --output %q: must be one of %s|%s", opts.Output, outputText, outputJSON))
+	}
+	if opts.Timeout <= 0 {
+		return withExitCode(exitUsage, fmt.Errorf("invalid --timeout %s: must be greater than 0", opts.Timeout))
+	}
+	return nil
+}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRootHelpSucceeds(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"--help"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected root help to succeed: %v", err)
+	}
+}
+
+func TestInspectBindingHelpIncludesMVPFlags(t *testing.T) {
+	cmd := NewRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"inspect", "binding", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected inspect binding help to succeed: %v", err)
+	}
+
+	help := stdout.String() + "\n" + stderr.String()
+	for _, want := range []string{"--namespace", "--output", "--strict", "--context", "--kubeconfig", "--timeout"} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("help output missing %q\n%s", want, help)
+		}
+	}
+	if !strings.Contains(help, `(default "default")`) {
+		t.Fatalf("help output missing default namespace\n%s", help)
+	}
+}
+
+func TestInspectBindingReturnsNotImplemented(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	stderr := &bytes.Buffer{}
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"inspect", "binding", "my-binding", "-n", "default"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected inspect binding to return an error")
+	}
+	if !errors.Is(err, errInspectBindingNotImplemented) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected command execution to leave error printing to main, got stderr:\n%s", stderr.String())
+	}
+}
+
+func TestInvalidOutputRejected(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"inspect", "binding", "my-binding", "--output", "yaml"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected invalid output to fail")
+	}
+	if !strings.Contains(err.Error(), "invalid --output") {
+		t.Fatalf("expected invalid --output error, got: %v", err)
+	}
+	if got := codeForError(err); got != exitUsage {
+		t.Fatalf("expected invalid output to return exit code %d, got %d", exitUsage, got)
+	}
+}
+
+func TestInvalidOutputNotRejectedForHelp(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--output", "yaml", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected help to bypass runnable output validation: %v", err)
+	}
+}
+
+func TestInvalidTimeoutRejected(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"inspect", "binding", "my-binding", "--timeout", "0s"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected invalid timeout to fail")
+	}
+	if !strings.Contains(err.Error(), "invalid --timeout") {
+		t.Fatalf("expected invalid --timeout error, got: %v", err)
+	}
+	if got := codeForError(err); got != exitUsage {
+		t.Fatalf("expected invalid timeout to return exit code %d, got %d", exitUsage, got)
+	}
+}
+
+func TestUsageErrorsReturnUsageExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "missing binding name", args: []string{"inspect", "binding"}},
+		{name: "invalid flag", args: []string{"inspect", "binding", "my-binding", "--not-a-flag"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewRootCommand()
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected usage error")
+			}
+			if got := codeForError(err); got != exitUsage {
+				t.Fatalf("expected usage error to return exit code %d, got %d", exitUsage, got)
+			}
+		})
+	}
+}
+
+func TestExecuteMapsErrorsToExitCodes(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    int
+		wantErr string
+	}{
+		{
+			name: "success",
+			args: []string{"--help"},
+			want: exitOK,
+		},
+		{
+			name:    "usage",
+			args:    []string{"inspect", "binding", "my-binding", "--output", "yaml"},
+			want:    exitUsage,
+			wantErr: "invalid --output",
+		},
+		{
+			name:    "unknown command",
+			args:    []string{"nope"},
+			want:    exitUsage,
+			wantErr: "unknown command",
+		},
+		{
+			name:    "internal",
+			args:    []string{"inspect", "binding", "my-binding"},
+			want:    exitInternal,
+			wantErr: errInspectBindingNotImplemented.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+
+			got := Execute(tt.args, stdout, stderr)
+			if got != tt.want {
+				t.Fatalf("expected exit code %d, got %d", tt.want, got)
+			}
+			if tt.wantErr == "" && stderr.Len() != 0 {
+				t.Fatalf("expected no stderr, got:\n%s", stderr.String())
+			}
+			if tt.wantErr != "" && !strings.Contains(stderr.String(), tt.wantErr) {
+				t.Fatalf("expected stderr to contain %q, got:\n%s", tt.wantErr, stderr.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add the initial `kleym` CLI entry point and Cobra command scaffold.
- Add a `build-cli` target for producing `bin/kleym`.

## What I Changed And Why

- Added `cmd/kleym` so the project has a dedicated CLI binary beside `kleym-operator`.
- Added root command plumbing plus an `inspect binding` command stub with the MVP flags from the CLI spec.
- Added CLI execution helpers and focused tests for help/usage behavior.
- Updated the CLI spec wording around default namespace and timeout requirements.
- Updated the Cobra dependency wiring needed by the CLI scaffold.

## Related Issue

Fixes #159

## Scope Check

- This PR follows the issue scope for CLI scaffolding and does not add Kubernetes mutation behavior.
- Real inspection, Kubernetes API reads, and full report rendering are intentionally left for follow-up CLI work.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because this only adds CLI scaffolding.
- CLI Spec (`docs/spec/cli.md`): updated to clarify default namespace and timeout requirements.
- Other docs: not needed because user-facing install/release docs are unchanged.

## Follow-Up Work

- Implement real `kleym inspect binding` inspection behavior against Kubernetes state.

## Verification

- Commands run:
  - `go test ./...`
  - `make build-cli`
- Notes:
  - `make build-cli` completed successfully after `fmt`, `vet`, and build. The Go tool emitted a non-fatal stat-cache warning because `/home/scribe/go/pkg/mod/cache` is read-only in this environment.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.
- The new CLI command is read-only scaffolding and does not contact the Kubernetes API yet.