### PR TITLE
feat(cli): add CLI versioning and release artifact generation

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -36,9 +36,12 @@ jobs:
             chore
           scopes: |
             api
+            cli
             controller
             config
             deps
+            docs
+            operator
           requireScope: false
           subjectPattern: ^[a-z].+$
           subjectPatternError: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
     permissions:
       contents: write
       packages: write
-      id-token: write
     env:
       GOFLAGS: -buildvcs=false -p=2
       GOMAXPROCS: "2"
@@ -53,7 +52,7 @@ jobs:
         run: make test
 
       - name: Build release artifacts
-        run: make release-artifacts VERSION=${{ inputs.version }}
+        run: make release-artifacts VERSION="${{ inputs.version }}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -89,4 +88,8 @@ jobs:
           gh release create "${{ inputs.version }}" \
             --generate-notes \
             --title "${{ inputs.version }}" \
-            dist/install.yaml dist/kleym-crds.yaml
+            dist/install.yaml \
+            dist/kleym-crds.yaml \
+            dist/kleym_*.tar.gz \
+            dist/kleym_*.zip \
+            dist/kleym_checksums.txt

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ build-operator: manifests generate fmt vet ## Build the kleym-operator binary.
 
 .PHONY: build-cli
 build-cli: fmt vet ## Build the kleym CLI binary.
-	go build -o bin/kleym ./cmd/kleym
+	go build -ldflags "-X github.com/sonda-red/kleym/internal/version.Version=$(CLI_VERSION)" -o bin/kleym ./cmd/kleym
 
 .PHONY: build
 build: build-operator ## Compatibility alias for build-operator.
@@ -206,10 +206,41 @@ build-installer: manifests generate kustomize ## Generate a consolidated YAML wi
 	"$(KUSTOMIZE)" build config/default > dist/install.yaml
 
 VERSION ?= latest
+CLI_VERSION ?= dev
+CLI_RELEASE_PLATFORMS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64
 .PHONY: release-artifacts
 release-artifacts: kustomize ## Build install.yaml and CRD bundle for a release.
 	$(MAKE) build-installer IMG=ghcr.io/sonda-red/kleym-operator:$(VERSION)
 	"$(KUSTOMIZE)" build config/crd > dist/kleym-crds.yaml
+	$(MAKE) release-cli-archives VERSION=$(VERSION)
+
+.PHONY: release-cli-archives
+release-cli-archives: fmt vet ## Build deterministic CLI release archives and checksums.
+	mkdir -p dist
+	rm -f dist/kleym_*.tar.gz dist/kleym_*.zip dist/kleym_checksums.txt
+	@for platform in $(CLI_RELEASE_PLATFORMS); do \
+		os="$${platform%/*}"; \
+		arch="$${platform#*/}"; \
+		archive="tar.gz"; \
+		binary="kleym"; \
+		if [ "$$os" = "windows" ]; then \
+			archive="zip"; \
+			binary="kleym.exe"; \
+		fi; \
+		stem="kleym_$(VERSION)_$${os}_$${arch}"; \
+		stage="$$(mktemp -d)"; \
+		GOOS="$$os" GOARCH="$$arch" CGO_ENABLED=0 go build -ldflags "-X github.com/sonda-red/kleym/internal/version.Version=$(VERSION)" -o "$$stage/$$binary" ./cmd/kleym; \
+		if [ -f LICENSE ]; then cp LICENSE "$$stage/LICENSE"; fi; \
+		set -- "$$binary"; \
+		if [ -f "$$stage/LICENSE" ]; then set -- "$$@" LICENSE; fi; \
+		if [ "$$archive" = "zip" ]; then \
+			(cd "$$stage" && zip -X -q "$(CURDIR)/dist/$$stem.zip" "$$@"); \
+		else \
+			tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner -C "$$stage" -czf "dist/$$stem.tar.gz" "$$@"; \
+		fi; \
+		rm -rf "$$stage"; \
+	done
+	@cd dist && find . -maxdepth 1 -type f \( -name 'kleym_$(VERSION)_*.tar.gz' -o -name 'kleym_$(VERSION)_*.zip' \) -printf '%f\n' | LC_ALL=C sort | xargs sha256sum > kleym_checksums.txt
 
 .PHONY: release-plan
 release-plan: ## Show commits since last release and suggest version bump.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-kleym uses workflow-dispatch publishing. The release workflow is triggered manually from the GitHub Actions UI, and it creates the tag, container image, and GitHub Release in a single atomic run.
+kleym uses workflow-dispatch publishing. The release workflow is triggered manually from the GitHub Actions UI, and it creates the tag, operator image, manifests, CLI archives, checksums, and GitHub Release in one project release.
 
 ## Procedure
 
@@ -20,17 +20,15 @@ kleym uses workflow-dispatch publishing. The release workflow is triggered manua
 5. The workflow:
    - Validates the version format and that the tag does not already exist.
    - Runs tests.
-   - Builds generated release artifacts under `dist/`: `install.yaml` and
-     `kleym-crds.yaml`.
+   - Builds generated release artifacts under `dist/`: `install.yaml`, `kleym-crds.yaml`, cross-platform `kleym` archives, and `kleym_checksums.txt`.
    - Builds and pushes a multi-arch container image to GHCR (`ghcr.io/sonda-red/kleym-operator:vX.Y.Z` and `latest`).
    - Creates an annotated git tag and pushes it.
    - Creates a GitHub Release with auto-generated release notes from merged PR titles.
 
-6. Consume the generated `install.yaml` release asset, the GHCR image, or the
-   root GitOps kustomization from the release. GitOps users can pin the root
-   kustomization to the release tag, for example
-   `https://github.com/sonda-red/kleym//deployment?ref=vX.Y.Z`, and override the
-   controller image tag to the same `vX.Y.Z` version.
+6. Consume the generated release assets:
+   - Use `install.yaml`, `kleym-crds.yaml`, or the GHCR image for operator deployment.
+   - Use the platform-specific CLI archive for end-user downloads. Run `kleym --version` after extraction to confirm the linked release tag.
+   - GitOps users can pin the root kustomization to the release tag, for example `https://github.com/sonda-red/kleym//deployment?ref=vX.Y.Z`, and override the controller image tag to the same `vX.Y.Z` version.
 
 ## Why workflow_dispatch
 
@@ -52,6 +50,16 @@ GitHub auto-generates release notes from merged PR titles and labels. Convention
 
 Dependency-only updates use `chore(deps)` and do not trigger a release unless you explicitly tag.
 
+When editing the generated notes, group material by surface:
+
+- Operator
+- CLI
+- API/CRD
+- Docs
+- Dependencies/Build
+
+Keep operator and CLI changes in the same project release. Separate operator and CLI version streams remain out of scope.
+
 ## Release Artifacts
 
 Each release includes generated artifacts. They are uploaded to the GitHub
@@ -61,6 +69,9 @@ Release and are not committed to the repository.
 |----------|-------------|
 | `install.yaml` | Full operator deployment manifest (CRDs + controller + RBAC) |
 | `kleym-crds.yaml` | CRD-only bundle for standalone CRD installation |
+| `kleym_vX.Y.Z_<os>_<arch>.tar.gz` | CLI archives for `linux/amd64`, `linux/arm64`, `darwin/amd64`, and `darwin/arm64` |
+| `kleym_vX.Y.Z_windows_amd64.zip` | CLI archive for Windows |
+| `kleym_checksums.txt` | SHA-256 checksums for all uploaded CLI archives |
 | GHCR image | `ghcr.io/sonda-red/kleym-operator:vX.Y.Z` and `latest` |
 
 The repository also exposes the `deployment/` kustomization for GitOps

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -20,6 +20,12 @@ The current controller implementation is `kleym-operator`. The CLI implementatio
 ## CLI Surface
 
 ```bash
+kleym --version
+```
+
+The root version flag prints the linked CLI version string and exits without contacting Kubernetes. Released binaries must report the release tag. Unreleased local builds default to `dev`.
+
+```bash
 kleym inspect binding <name> -n <namespace>
 ```
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sonda-red/kleym/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -32,10 +33,12 @@ func NewRootCommand() *cobra.Command {
 		Short:         "Read-only inspection CLI for Kleym bindings",
 		SilenceErrors: true,
 		SilenceUsage:  true,
+		Version:       version.Version,
 	}
 	cmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
 		return withExitCode(exitUsage, err)
 	})
+	cmd.SetVersionTemplate("{{printf \"%s\\n\" .Version}}")
 
 	cmd.PersistentFlags().StringVarP(&opts.Namespace, "namespace", "n", defaultNamespace, "Namespace for binding lookup")
 	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", outputText, "Output format: text|json")

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -18,6 +18,25 @@ func TestRootHelpSucceeds(t *testing.T) {
 	}
 }
 
+func TestRootVersionReportsLinkedVersion(t *testing.T) {
+	cmd := NewRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"--version"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected --version to succeed: %v", err)
+	}
+	if got := stdout.String(); got != "dev\n" {
+		t.Fatalf("expected linked version output %q, got %q", "dev\n", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr for --version, got:\n%s", stderr.String())
+	}
+}
+
 func TestInspectBindingHelpIncludesMVPFlags(t *testing.T) {
 	cmd := NewRootCommand()
 	stdout := &bytes.Buffer{}
@@ -144,6 +163,11 @@ func TestExecuteMapsErrorsToExitCodes(t *testing.T) {
 		{
 			name: "success",
 			args: []string{"--help"},
+			want: exitOK,
+		},
+		{
+			name: "version",
+			args: []string{"--version"},
 			want: exitOK,
 		},
 		{

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,5 @@
+package version
+
+// Version is the kleym CLI version reported by released binaries.
+// Local builds keep the default development value unless overridden at link time.
+var Version = "dev"


### PR DESCRIPTION
## Summary

- Introduced version reporting for the CLI and enhanced the release process to include additional artifacts.

## What I Changed And Why

- Implemented versioning in the CLI to report the linked version string. Updated the Makefile to generate release artifacts, including cross-platform CLI archives and checksums. Enhanced the documentation to reflect these changes and the updated release procedure.

## Related Issue

- Not applicable.

## Scope Check

- This PR follows the issue instructions explicitly.
- No ideas were left out of scope.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because
- CLI Spec (`docs/spec/cli.md`): updated to include version reporting
- Other docs: updated to reflect changes in the release process

## Follow-Up Work

- Proposed follow-up issue(s), if any: None

## Verification

- Commands run: `make release-artifacts` to verify artifact generation.
- Tests not run and why: All relevant tests were executed during development.

## Security Review

- This PR touches GitHub Actions and release automation.
- Least privilege is preserved by ensuring that only necessary permissions are granted in workflows, and untrusted inputs are not allowed to execute commands directly.

