### PR TITLE
feat(cli): add binding inspection report JSON model

### DIFF
--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -57,7 +57,7 @@ Top-level JSON shape:
 
 ```json
 {
-  "apiVersion": "cli.kleym.sonda.red/v1alpha1",
+  "schemaVersion": "v1alpha1",
   "kind": "BindingInspectionReport",
   "generatedAt": "",
   "bindingRef": {},

--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -1,0 +1,199 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// BindingInspectionReportSchemaVersion is the stable machine-readable report version from docs/spec/cli.md.
+	BindingInspectionReportSchemaVersion = "v1alpha1"
+	// BindingInspectionReportKind is the stable report kind from docs/spec/cli.md.
+	BindingInspectionReportKind = "BindingInspectionReport"
+)
+
+const (
+	BindingInspectionFindingSeverityInfo    BindingInspectionFindingSeverity = "info"
+	BindingInspectionFindingSeverityWarning BindingInspectionFindingSeverity = "warning"
+	BindingInspectionFindingSeverityError   BindingInspectionFindingSeverity = "error"
+)
+
+const (
+	BindingInspectionCapabilityFull    BindingInspectionCapability = "full"
+	BindingInspectionCapabilityPartial BindingInspectionCapability = "partial"
+	BindingInspectionCapabilitySkipped BindingInspectionCapability = "skipped"
+	BindingInspectionCapabilityUnknown BindingInspectionCapability = "unknown"
+)
+
+// BindingInspectionFindingSeverity is the stable severity enum for machine-readable findings.
+type BindingInspectionFindingSeverity string
+
+// BindingInspectionCapability is the stable completeness enum for machine-readable capabilities.
+type BindingInspectionCapability string
+
+// BindingInspectionReport captures the JSON contract for `kleym inspect binding -o json`.
+type BindingInspectionReport struct {
+	SchemaVersion string                         `json:"schemaVersion"`
+	Kind          string                         `json:"kind"`
+	GeneratedAt   string                         `json:"generatedAt"`
+	BindingRef    BindingInspectionBindingRef    `json:"bindingRef"`
+	Resolved      BindingInspectionResolvedInput `json:"resolvedInput"`
+	Desired       BindingInspectionDesiredState  `json:"desired"`
+	Observed      BindingInspectionObservedState `json:"observed"`
+	Findings      []BindingInspectionFinding     `json:"findings"`
+	Capabilities  BindingInspectionCapabilities  `json:"capabilities"`
+}
+
+// BindingInspectionBindingRef identifies the binding being inspected.
+type BindingInspectionBindingRef struct {
+	Namespace    string                      `json:"namespace,omitempty"`
+	Name         string                      `json:"name,omitempty"`
+	Generation   int64                       `json:"generation,omitempty"`
+	Mode         string                      `json:"mode,omitempty"`
+	PoolRef      *BindingInspectionTargetRef `json:"poolRef,omitempty"`
+	ObjectiveRef *BindingInspectionTargetRef `json:"objectiveRef,omitempty"`
+	Conditions   []metav1.Condition          `json:"conditions,omitempty"`
+}
+
+// BindingInspectionTargetRef is a stable compact reference shape for binding inputs.
+type BindingInspectionTargetRef struct {
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Group     string `json:"group,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+}
+
+// BindingInspectionResolvedInput captures the resolved resources and selector inputs.
+type BindingInspectionResolvedInput struct {
+	PoolRef                *BindingInspectionTargetRef              `json:"poolRef,omitempty"`
+	ObjectiveRef           *BindingInspectionTargetRef              `json:"objectiveRef,omitempty"`
+	ServedGVKs             []BindingInspectionGVK                   `json:"servedGVKs,omitempty"`
+	PoolSelector           map[string]any                           `json:"poolSelector,omitempty"`
+	ContainerDiscriminator *BindingInspectionContainerDiscriminator `json:"containerDiscriminator,omitempty"`
+	SelectorProvenance     *BindingInspectionSelectorProvenance     `json:"selectorProvenance,omitempty"`
+}
+
+// BindingInspectionGVK describes one discovered served input kind.
+type BindingInspectionGVK struct {
+	Group   string `json:"group,omitempty"`
+	Version string `json:"version,omitempty"`
+	Kind    string `json:"kind,omitempty"`
+}
+
+// BindingInspectionContainerDiscriminator records the resolved container narrowing input.
+type BindingInspectionContainerDiscriminator struct {
+	Type  string `json:"type,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+// BindingInspectionSelectorProvenance records how the effective selector set was assembled.
+type BindingInspectionSelectorProvenance struct {
+	SelectorSource       string   `json:"selectorSource,omitempty"`
+	PoolDerivedSelectors []string `json:"poolDerivedSelectors,omitempty"`
+	WorkloadSelectors    []string `json:"workloadSelectors,omitempty"`
+	ContainerSelector    string   `json:"containerSelector,omitempty"`
+	SafetySelectors      []string `json:"safetySelectors,omitempty"`
+}
+
+// BindingInspectionDesiredState captures the deterministic output kleym would render.
+type BindingInspectionDesiredState struct {
+	ClusterSPIFFEIDName string                               `json:"clusterSPIFFEIDName,omitempty"`
+	SPIFFEID            string                               `json:"spiffeID,omitempty"`
+	PodSelector         map[string]any                       `json:"podSelector,omitempty"`
+	WorkloadSelectors   []string                             `json:"workloadSelectors,omitempty"`
+	SelectorProvenance  *BindingInspectionSelectorProvenance `json:"selectorProvenance,omitempty"`
+	Hint                string                               `json:"hint,omitempty"`
+	Fallback            *bool                                `json:"fallback,omitempty"`
+}
+
+// BindingInspectionObservedState captures current cluster state relevant to the binding.
+type BindingInspectionObservedState struct {
+	ManagedClusterSPIFFEIDs []BindingInspectionManagedClusterSPIFFEID `json:"managedClusterSPIFFEIDs,omitempty"`
+	Drift                   []BindingInspectionDriftEntry             `json:"drift,omitempty"`
+	EligibleWorkloads       []BindingInspectionEligibleWorkload       `json:"eligibleWorkloads,omitempty"`
+}
+
+// BindingInspectionManagedClusterSPIFFEID summarizes one managed rendered object.
+type BindingInspectionManagedClusterSPIFFEID struct {
+	Name              string             `json:"name,omitempty"`
+	SPIFFEID          string             `json:"spiffeID,omitempty"`
+	PodSelector       map[string]any     `json:"podSelector,omitempty"`
+	WorkloadSelectors []string           `json:"workloadSelectors,omitempty"`
+	Hint              string             `json:"hint,omitempty"`
+	Fallback          *bool              `json:"fallback,omitempty"`
+	Conditions        []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// BindingInspectionDriftEntry summarizes one desired-versus-observed mismatch.
+type BindingInspectionDriftEntry struct {
+	Field    string `json:"field,omitempty"`
+	Desired  string `json:"desired,omitempty"`
+	Observed string `json:"observed,omitempty"`
+}
+
+// BindingInspectionEligibleWorkload records one currently matching pod or container.
+type BindingInspectionEligibleWorkload struct {
+	Namespace string `json:"namespace,omitempty"`
+	Pod       string `json:"pod,omitempty"`
+	Container string `json:"container,omitempty"`
+}
+
+// BindingInspectionFinding is the stable machine-readable issue shape from docs/spec/cli.md.
+type BindingInspectionFinding struct {
+	ID           string                           `json:"id"`
+	Severity     BindingInspectionFindingSeverity `json:"severity"`
+	Reason       string                           `json:"reason"`
+	Message      string                           `json:"message"`
+	AffectedRefs []BindingInspectionTargetRef     `json:"affectedRefs"`
+}
+
+// BindingInspectionCapabilities records which inspection areas were complete.
+type BindingInspectionCapabilities struct {
+	Binding          BindingInspectionCapability `json:"binding,omitempty"`
+	GAIEResources    BindingInspectionCapability `json:"gaieResources,omitempty"`
+	ClusterSPIFFEIDs BindingInspectionCapability `json:"clusterspiffeids,omitempty"`
+	PeerBindings     BindingInspectionCapability `json:"peerBindings,omitempty"`
+	Pods             BindingInspectionCapability `json:"pods,omitempty"`
+}
+
+// NewBindingInspectionReport returns the stable report scaffold from docs/spec/cli.md.
+func NewBindingInspectionReport() BindingInspectionReport {
+	return normalizeBindingInspectionReport(BindingInspectionReport{})
+}
+
+func normalizeBindingInspectionReport(report BindingInspectionReport) BindingInspectionReport {
+	if report.SchemaVersion == "" {
+		report.SchemaVersion = BindingInspectionReportSchemaVersion
+	}
+	if report.Kind == "" {
+		report.Kind = BindingInspectionReportKind
+	}
+	if report.Findings == nil {
+		report.Findings = []BindingInspectionFinding{}
+	}
+	for i := range report.Findings {
+		if report.Findings[i].AffectedRefs == nil {
+			report.Findings[i].AffectedRefs = []BindingInspectionTargetRef{}
+		}
+	}
+	return report
+}
+
+// writeBindingInspectionReportJSON writes newline-terminated compact JSON for the stable CLI contract.
+func writeBindingInspectionReportJSON(w io.Writer, report BindingInspectionReport) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(normalizeBindingInspectionReport(report))
+}
+
+// WriteBindingInspectionReport selects the stable machine-readable binding inspection output.
+func WriteBindingInspectionReport(w io.Writer, output string, report BindingInspectionReport) error {
+	if output != outputJSON {
+		return fmt.Errorf("binding inspection output %q is not implemented", output)
+	}
+	return writeBindingInspectionReportJSON(w, report)
+}

--- a/internal/cli/report_test.go
+++ b/internal/cli/report_test.go
@@ -1,0 +1,320 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBindingInspectionReportJSONMinimalShape(t *testing.T) {
+	report := NewBindingInspectionReport()
+
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+
+	wantTopLevelKeys := []string{
+		"bindingRef",
+		"capabilities",
+		"desired",
+		"findings",
+		"generatedAt",
+		"kind",
+		"observed",
+		"resolvedInput",
+		"schemaVersion",
+	}
+	if keys := sortedKeys(got); !reflect.DeepEqual(keys, wantTopLevelKeys) {
+		t.Fatalf("unexpected top-level keys (-want +got):\nwant %v\ngot  %v", wantTopLevelKeys, keys)
+	}
+
+	if got["schemaVersion"] != BindingInspectionReportSchemaVersion {
+		t.Fatalf("expected schemaVersion %q, got %#v", BindingInspectionReportSchemaVersion, got["schemaVersion"])
+	}
+	if got["kind"] != BindingInspectionReportKind {
+		t.Fatalf("expected kind %q, got %#v", BindingInspectionReportKind, got["kind"])
+	}
+	if got["generatedAt"] != "" {
+		t.Fatalf("expected empty generatedAt, got %#v", got["generatedAt"])
+	}
+	for _, key := range []string{"bindingRef", "resolvedInput", "desired", "observed", "capabilities"} {
+		section, ok := got[key].(map[string]any)
+		if !ok {
+			t.Fatalf("expected %s to encode as object, got %#v", key, got[key])
+		}
+		if len(section) != 0 {
+			t.Fatalf("expected empty %s object, got %#v", key, section)
+		}
+	}
+	findings, ok := got["findings"].([]any)
+	if !ok {
+		t.Fatalf("expected findings array, got %#v", got["findings"])
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected empty findings array, got %#v", findings)
+	}
+}
+
+func TestBindingInspectionReportJSONRepresentativeShape(t *testing.T) {
+	fallbackFalse := false
+	report := BindingInspectionReport{
+		GeneratedAt: "2026-05-18T09:10:11Z",
+		BindingRef: BindingInspectionBindingRef{
+			Namespace:  "tenant-a",
+			Name:       "binding-a",
+			Generation: 7,
+			Mode:       "PerObjective",
+			PoolRef: &BindingInspectionTargetRef{
+				Name:  "pool-a",
+				Group: "inference.networking.k8s.io",
+			},
+			ObjectiveRef: &BindingInspectionTargetRef{
+				Name:  "objective-a",
+				Group: "inference.networking.k8s.io",
+			},
+			Conditions: []metav1.Condition{{
+				Type:    "Ready",
+				Status:  metav1.ConditionTrue,
+				Reason:  "Rendered",
+				Message: "binding rendered successfully",
+			}},
+		},
+		Resolved: BindingInspectionResolvedInput{
+			PoolRef: &BindingInspectionTargetRef{
+				Namespace: "tenant-a",
+				Name:      "pool-a",
+				Group:     "inference.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "InferencePool",
+			},
+			ObjectiveRef: &BindingInspectionTargetRef{
+				Namespace: "tenant-a",
+				Name:      "objective-a",
+				Group:     "inference.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "InferenceObjective",
+			},
+			ServedGVKs: []BindingInspectionGVK{
+				{Group: "inference.networking.k8s.io", Version: "v1", Kind: "InferencePool"},
+				{Group: "inference.networking.k8s.io", Version: "v1", Kind: "InferenceObjective"},
+			},
+			PoolSelector: map[string]any{
+				"matchLabels": map[string]any{"app": "pool-a"},
+			},
+			ContainerDiscriminator: &BindingInspectionContainerDiscriminator{
+				Type:  "ContainerName",
+				Value: "model-server",
+			},
+			SelectorProvenance: &BindingInspectionSelectorProvenance{
+				SelectorSource:       "DerivedFromPool",
+				PoolDerivedSelectors: []string{"k8s:pod-label:app:pool-a"},
+				WorkloadSelectors:    []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
+				ContainerSelector:    "k8s:container-name:model-server",
+				SafetySelectors:      []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
+			},
+		},
+		Desired: BindingInspectionDesiredState{
+			ClusterSPIFFEIDName: "tenant-a-binding-a-1234abcd",
+			SPIFFEID:            "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
+			PodSelector: map[string]any{
+				"matchLabels": map[string]any{"app": "pool-a"},
+			},
+			WorkloadSelectors: []string{
+				"k8s:ns:tenant-a",
+				"k8s:sa:model-sa",
+				"k8s:pod-label:app:pool-a",
+				"k8s:container-name:model-server",
+			},
+			SelectorProvenance: &BindingInspectionSelectorProvenance{
+				SelectorSource:       "DerivedFromPool",
+				PoolDerivedSelectors: []string{"k8s:pod-label:app:pool-a"},
+				WorkloadSelectors:    []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
+				ContainerSelector:    "k8s:container-name:model-server",
+				SafetySelectors:      []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
+			},
+			Hint:     "tenant-a/binding-a",
+			Fallback: &fallbackFalse,
+		},
+		Observed: BindingInspectionObservedState{
+			ManagedClusterSPIFFEIDs: []BindingInspectionManagedClusterSPIFFEID{{
+				Name:     "tenant-a-binding-a-1234abcd",
+				SPIFFEID: "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
+				PodSelector: map[string]any{
+					"matchLabels": map[string]any{"app": "pool-a"},
+				},
+				WorkloadSelectors: []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
+				Hint:              "tenant-a/binding-a",
+				Fallback:          &fallbackFalse,
+			}},
+			Drift: []BindingInspectionDriftEntry{{
+				Field:    "spec.workloadSelectorTemplates",
+				Desired:  "k8s:container-name:model-server",
+				Observed: "k8s:container-name:old-server",
+			}},
+			EligibleWorkloads: []BindingInspectionEligibleWorkload{{
+				Namespace: "tenant-a",
+				Pod:       "pool-a-5f9488d7fb-q1w2e",
+				Container: "model-server",
+			}},
+		},
+		Findings: []BindingInspectionFinding{{
+			ID:       "observed-drift",
+			Severity: BindingInspectionFindingSeverityWarning,
+			Reason:   "SelectorDrift",
+			Message:  "observed workload selectors differ from desired state",
+			AffectedRefs: []BindingInspectionTargetRef{{
+				Name: "tenant-a-binding-a-1234abcd",
+				Kind: "ClusterSPIFFEID",
+			}},
+		}},
+		Capabilities: BindingInspectionCapabilities{
+			Binding:          BindingInspectionCapabilityFull,
+			GAIEResources:    BindingInspectionCapabilityFull,
+			ClusterSPIFFEIDs: BindingInspectionCapabilityFull,
+			PeerBindings:     BindingInspectionCapabilityPartial,
+			Pods:             BindingInspectionCapabilitySkipped,
+		},
+	}
+
+	data, err := json.Marshal(normalizeBindingInspectionReport(report))
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+
+	assertObjectKeys(t, got["bindingRef"], "conditions", "generation", "mode", "name", "namespace", "objectiveRef", "poolRef")
+	assertObjectKeys(t, got["resolvedInput"], "containerDiscriminator", "objectiveRef", "poolRef", "poolSelector", "selectorProvenance", "servedGVKs")
+	assertObjectKeys(t, got["desired"], "clusterSPIFFEIDName", "fallback", "hint", "podSelector", "selectorProvenance", "spiffeID", "workloadSelectors")
+	assertObjectKeys(t, got["observed"], "drift", "eligibleWorkloads", "managedClusterSPIFFEIDs")
+	assertObjectKeys(t, got["capabilities"], "binding", "clusterspiffeids", "gaieResources", "peerBindings", "pods")
+
+	resolved := got["resolvedInput"].(map[string]any)
+	assertObjectKeys(t, resolved["selectorProvenance"], "containerSelector", "poolDerivedSelectors", "safetySelectors", "selectorSource", "workloadSelectors")
+}
+
+func TestBindingInspectionFindingJSONFields(t *testing.T) {
+	data, err := json.Marshal(normalizeBindingInspectionReport(BindingInspectionReport{
+		Findings: []BindingInspectionFinding{{
+			ID:       "rbac-limited",
+			Severity: BindingInspectionFindingSeverityWarning,
+			Reason:   "Forbidden",
+			Message:  "pods are not readable",
+			AffectedRefs: []BindingInspectionTargetRef{{
+				Name:      "pods",
+				Namespace: "tenant-a",
+			}},
+		}},
+	}))
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+
+	findings := got["findings"].([]any)
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %#v", findings)
+	}
+	assertObjectKeys(t, findings[0], "affectedRefs", "id", "message", "reason", "severity")
+}
+
+func TestBindingInspectionReportNormalizesNilSlices(t *testing.T) {
+	data, err := json.Marshal(normalizeBindingInspectionReport(BindingInspectionReport{
+		Findings: []BindingInspectionFinding{{
+			ID:       "binding-not-found",
+			Severity: BindingInspectionFindingSeverityError,
+			Reason:   "NotFound",
+			Message:  "binding not found",
+		}},
+	}))
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+
+	findings := got["findings"].([]any)
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %#v", findings)
+	}
+
+	finding := findings[0].(map[string]any)
+	affectedRefs, ok := finding["affectedRefs"].([]any)
+	if !ok {
+		t.Fatalf("expected affectedRefs array, got %#v", finding["affectedRefs"])
+	}
+	if len(affectedRefs) != 0 {
+		t.Fatalf("expected empty affectedRefs, got %#v", affectedRefs)
+	}
+}
+
+func TestWriteBindingInspectionReportJSONReturnsWriterError(t *testing.T) {
+	wantErr := errors.New("write failed")
+	err := writeBindingInspectionReportJSON(errWriter{err: wantErr}, NewBindingInspectionReport())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected writer error %v, got %v", wantErr, err)
+	}
+}
+
+func TestWriteBindingInspectionReportJSONWritesCompactJSONWithNewline(t *testing.T) {
+	var out bytes.Buffer
+	if err := writeBindingInspectionReportJSON(&out, NewBindingInspectionReport()); err != nil {
+		t.Fatalf("write report: %v", err)
+	}
+	if got := out.String(); got == "" || got[len(got)-1] != '\n' {
+		t.Fatalf("expected newline-terminated JSON, got %q", got)
+	}
+	if bytes.Contains(out.Bytes(), []byte("\n\n")) {
+		t.Fatalf("expected compact JSON, got %q", out.String())
+	}
+}
+
+type errWriter struct {
+	err error
+}
+
+func (w errWriter) Write(_ []byte) (int, error) {
+	return 0, w.err
+}
+
+func sortedKeys(value map[string]any) []string {
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func assertObjectKeys(t *testing.T, value any, want ...string) {
+	t.Helper()
+
+	object, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("expected object, got %#v", value)
+	}
+	if got := sortedKeys(object); !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected object keys (-want +got):\nwant %v\ngot  %v", want, got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add the `BindingInspectionReport` Go model and compact JSON encoder for `kleym inspect binding -o json`.
- Add focused JSON shape tests for empty and representative reports.
- Update the CLI spec to use `schemaVersion: "v1alpha1"` for the CLI report contract instead of a Kubernetes-looking `apiVersion` group.

## What I Changed And Why

- Added typed report structs for the MVP binding inspection sections: `bindingRef`, `resolvedInput`, `desired`, `observed`, `findings`, and `capabilities`.
- Added normalization so new reports consistently include `schemaVersion`, `kind`, and non-null `findings` / `affectedRefs` arrays for stable machine parsing.
- Added a JSON writer that emits compact newline-terminated JSON and returns writer errors directly.
- Used `schemaVersion` rather than `apiVersion` to avoid implying that the CLI report is another Kubernetes API extension or served CRD.

## Related Issue

- Fixes #158

## Scope Check

- This PR follows #158 by adding the JSON report model, serialization helper, and focused tests.
- Full Kubernetes inspection, YAML output, Markdown output, and text report rendering are intentionally left out of scope.
- The issue acceptance criteria originally named `apiVersion`; this PR updates the spec and implementation to `schemaVersion` after review because the report is a CLI output schema, not a Kubernetes API object.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because this does not change operator API or reconciliation behavior.
- CLI Spec (`docs/spec/cli.md`): updated to document `schemaVersion: "v1alpha1"` in the top-level JSON shape.
- Other docs: not needed because README/setup/command examples are unchanged.

## Follow-Up Work

- Proposed follow-up issue(s), if any: wire the report model into the eventual live `inspect binding` implementation when Kubernetes inspection is implemented.

## Verification

- Commands run:
  - `go test ./internal/cli`
  - `go test ./...`
  - `make test`
  - `make lint`
- Tests not run and why: no e2e/cluster tests run because this change is limited to CLI JSON model serialization and docs.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or runtime trust boundaries.
- It only adds local CLI data types, JSON serialization, tests, and CLI spec documentation, so no new secret exposure or untrusted-code execution path is introduced.