### PR TITLE
test(cli): cover pool-only workload eligibility

### DIFF
--- a/internal/inspection/inspection_test.go
+++ b/internal/inspection/inspection_test.go
@@ -68,6 +68,40 @@ func TestInspectBindingSuccessReport(t *testing.T) {
 	}
 }
 
+func TestInspectBindingPoolOnlyEligibleWorkload(t *testing.T) {
+	binding := testInspectionPoolOnlyBinding()
+	pool := testInspectionPool("pool-a")
+	rendered, err := identity.RenderIdentity(binding, nil, pool)
+	if err != nil {
+		t.Fatalf("render test identity: %v", err)
+	}
+	managed := identity.DesiredClusterSPIFFEID(binding, rendered)
+	pod := testInspectionPod("model-server-a", "model-server")
+
+	inspector := newTestBindingInspector(t, nil, binding, pool, managed, pod)
+	report, err := inspector.InspectBinding(context.Background(), "tenant-a", "binding-a")
+	if err != nil {
+		t.Fatalf("InspectBinding returned error: %v", err)
+	}
+
+	if report.BindingRef.Mode != string(kleymv1alpha1.InferenceIdentityBindingModePoolOnly) {
+		t.Fatalf("bindingRef mode = %q, want PoolOnly", report.BindingRef.Mode)
+	}
+	if len(report.Observed.EligibleWorkloads) != 1 {
+		t.Fatalf("eligible workloads = %#v, want one pod", report.Observed.EligibleWorkloads)
+	}
+	workload := report.Observed.EligibleWorkloads[0]
+	if workload.Namespace != "tenant-a" || workload.Pod != "model-server-a" || workload.Container != "" {
+		t.Fatalf("eligible workload = %#v, want pod-level workload without container", workload)
+	}
+	if len(report.Findings) != 0 {
+		t.Fatalf("expected no findings, got %#v", report.Findings)
+	}
+	if report.Capabilities.Pods != BindingInspectionCapabilityFull {
+		t.Fatalf("pods capability = %q, want full", report.Capabilities.Pods)
+	}
+}
+
 func TestInspectBindingMissingBindingReport(t *testing.T) {
 	inspector := newTestBindingInspector(t, nil)
 
@@ -402,6 +436,14 @@ func testInspectionBinding() *kleymv1alpha1.InferenceIdentityBinding {
 			},
 		},
 	}
+}
+
+func testInspectionPoolOnlyBinding() *kleymv1alpha1.InferenceIdentityBinding {
+	binding := testInspectionBinding()
+	binding.Spec.ObjectiveRef = nil
+	binding.Spec.Mode = kleymv1alpha1.InferenceIdentityBindingModePoolOnly
+	binding.Spec.ContainerDiscriminator = nil
+	return binding
 }
 
 func testInspectionPool(name string) *unstructured.Unstructured {


### PR DESCRIPTION
## Summary

- Add focused PoolOnly coverage for eligible workload reporting in `kleym inspect binding`.
- Link the already-implemented workload eligibility behavior to prior PR #179 so this PR is scoped to the remaining acceptance-test gap.

## What I Changed And Why

- Added `TestInspectBindingPoolOnlyEligibleWorkload` to verify PoolOnly reports an eligible pod at pod scope, without a container field.
- Added a small `testInspectionPoolOnlyBinding` helper by reusing the existing binding fixture and removing PerObjective-only fields.
- This closes the issue coverage gap: PR #179 already implemented the live pod eligibility logic, PerObjective narrowing, RBAC-limited pod capabilities, `zero-eligible-workloads`, and `ambiguous-container-match` behavior.

## Related Issue

- Fixes #170
- Prior implementation scope: #179

## Scope Check

- This PR follows #170 by adding the missing PoolOnly eligibility coverage requested in the acceptance criteria.
- The already-implemented CLI behavior remains in PR #179; this PR intentionally does not refactor inspection logic, change output shape, or expand live cluster coverage.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because this PR does not change operator API or reconciliation behavior.
- CLI Spec (`docs/spec/cli.md`): not needed because the workload eligibility contract, finding severities, and pod capability states are already documented.
- Other docs: not needed because this is a focused test-only coverage addition.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `go test ./internal/inspection ./internal/cli`
  - `make test`
  - `make lint`
  - `git diff --check`
- Tests not run and why: none.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.
- It is test-only and does not alter Kubernetes read paths, RBAC handling, or command execution behavior.