### PR TITLE
test(cli): add live inspect binding coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ prepare-e2e-namespace: ## Create the operator namespace with restricted Pod Secu
 	"$(KUBECTL)" label namespace kleym-system pod-security.kubernetes.io/enforce=restricted --overwrite
 
 .PHONY: test-e2e-chainsaw
-test-e2e-chainsaw: setup-test-e2e chainsaw manifests generate fmt vet ## Run Chainsaw e2e tests against a Kind cluster.
+test-e2e-chainsaw: setup-test-e2e chainsaw manifests generate fmt vet build-cli ## Run Chainsaw e2e tests against a Kind cluster.
 	@operator_kustomization="config/manager/kustomization.yaml"; \
 	saved_operator_kustomization="$$(mktemp)"; \
 	cp "$$operator_kustomization" "$$saved_operator_kustomization"; \

--- a/test/chainsaw/binding-reconciliation/chainsaw-test.yaml
+++ b/test/chainsaw/binding-reconciliation/chainsaw-test.yaml
@@ -98,7 +98,11 @@ spec:
       try:
         - script:
             workDir: ../../..
-            content: kubectl apply -k test/reference/inference-environment
+            content: |
+              kubectl apply -k test/reference/inference-environment
+              kubectl rollout status deployment/reference-model-server \
+                -n kleym-reference-inference \
+                --timeout=120s
 
     - name: apply-binding
       try:
@@ -108,6 +112,39 @@ spec:
             file: binding-ready.yaml
         - assert:
             file: clusterspiffeid.yaml
+
+    - name: inspect-binding-json
+      try:
+        - script:
+            workDir: ../../..
+            content: |
+              set -eu
+
+              report="$(mktemp)"
+              bin/kleym inspect binding binding \
+                -n kleym-reference-inference \
+                -o json > "${report}"
+              go run ./test/e2e/inspectbindingassert "${report}" success
+
+    - name: inspect-missing-binding-json
+      try:
+        - script:
+            workDir: ../../..
+            content: |
+              set -eu
+
+              report="$(mktemp)"
+              set +e
+              bin/kleym inspect binding missing-binding \
+                -n kleym-reference-inference \
+                -o json > "${report}"
+              status="$?"
+              set -e
+              if [ "${status}" -ne 3 ]; then
+                echo "expected exit code 3 for missing binding, got ${status}" >&2
+                exit 1
+              fi
+              go run ./test/e2e/inspectbindingassert "${report}" not-found
 
     - name: reapply-binding
       try:

--- a/test/e2e/inspectbindingassert/main.go
+++ b/test/e2e/inspectbindingassert/main.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/sonda-red/kleym/internal/inspection"
+)
+
+const (
+	referenceNamespace             = "kleym-reference-inference"
+	referenceBinding               = "binding"
+	referenceSPIFFEID              = "spiffe://kleym.sonda.red/ns/kleym-reference-inference/objective/reference-objective"
+	referenceClusterSPIFFEID       = "kleym-kleym-reference-inference-binding-objective-3b2d9110"
+	referenceEligibleContainerName = "model-server"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		failf("usage: inspectbindingassert <report.json> <success|not-found>")
+	}
+
+	report, err := readReport(os.Args[1])
+	if err != nil {
+		failf("%v", err)
+	}
+
+	switch os.Args[2] {
+	case "success":
+		assertSuccess(report)
+	case "not-found":
+		assertNotFound(report)
+	default:
+		failf("unknown assertion mode %q", os.Args[2])
+	}
+}
+
+// readReport decodes the CLI JSON report so Chainsaw can assert stable fields.
+func readReport(path string) (inspection.BindingInspectionReport, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return inspection.BindingInspectionReport{}, fmt.Errorf("read report: %w", err)
+	}
+
+	var report inspection.BindingInspectionReport
+	if err := json.Unmarshal(content, &report); err != nil {
+		return inspection.BindingInspectionReport{}, fmt.Errorf("decode report JSON: %w", err)
+	}
+	return report, nil
+}
+
+// assertSuccess verifies live inspection saw the reconciled binding and workload.
+func assertSuccess(report inspection.BindingInspectionReport) {
+	assertCommonShape(report)
+	assertEqual("bindingRef.namespace", report.BindingRef.Namespace, referenceNamespace)
+	assertEqual("bindingRef.name", report.BindingRef.Name, referenceBinding)
+	assertEqual("bindingRef.mode", report.BindingRef.Mode, "PerObjective")
+	assertEqual("desired.clusterSPIFFEIDName", report.Desired.ClusterSPIFFEIDName, referenceClusterSPIFFEID)
+	assertEqual("desired.spiffeID", report.Desired.SPIFFEID, referenceSPIFFEID)
+	assertEqual("capabilities.clusterspiffeids", string(report.Capabilities.ClusterSPIFFEIDs), "full")
+	assertEqual("capabilities.pods", string(report.Capabilities.Pods), "full")
+
+	if len(report.Findings) != 0 {
+		failf("findings = %d, want 0: %#v", len(report.Findings), report.Findings)
+	}
+	if len(report.Observed.Drift) != 0 {
+		failf("observed.drift = %d, want 0: %#v", len(report.Observed.Drift), report.Observed.Drift)
+	}
+	if len(report.Observed.ManagedClusterSPIFFEIDs) != 1 {
+		failf("managed ClusterSPIFFEIDs = %d, want 1", len(report.Observed.ManagedClusterSPIFFEIDs))
+	}
+	assertEqual("observed.managedClusterSPIFFEIDs[0].name", report.Observed.ManagedClusterSPIFFEIDs[0].Name, referenceClusterSPIFFEID)
+	assertEqual("observed.managedClusterSPIFFEIDs[0].spiffeID", report.Observed.ManagedClusterSPIFFEIDs[0].SPIFFEID, referenceSPIFFEID)
+	assertEligibleContainer(report)
+}
+
+// assertNotFound verifies the CLI still emits machine-readable JSON for a missing binding.
+func assertNotFound(report inspection.BindingInspectionReport) {
+	assertCommonShape(report)
+	assertEqual("bindingRef.namespace", report.BindingRef.Namespace, referenceNamespace)
+	assertEqual("capabilities.binding", string(report.Capabilities.Binding), "full")
+
+	for _, finding := range report.Findings {
+		if finding.ID == "binding-not-found" && finding.Severity == inspection.BindingInspectionFindingSeverityError {
+			return
+		}
+	}
+	failf("missing error binding-not-found finding: %#v", report.Findings)
+}
+
+// assertCommonShape covers report fields every JSON inspection result must include.
+func assertCommonShape(report inspection.BindingInspectionReport) {
+	assertEqual("schemaVersion", report.SchemaVersion, inspection.BindingInspectionReportSchemaVersion)
+	assertEqual("kind", report.Kind, inspection.BindingInspectionReportKind)
+	if report.GeneratedAt == "" {
+		failf("generatedAt is empty")
+	}
+}
+
+// assertEligibleContainer proves live pod visibility contributed to the inspection result.
+func assertEligibleContainer(report inspection.BindingInspectionReport) {
+	for _, workload := range report.Observed.EligibleWorkloads {
+		if workload.Namespace == referenceNamespace && workload.Container == referenceEligibleContainerName {
+			return
+		}
+	}
+	failf("missing eligible %q container workload: %#v", referenceEligibleContainerName, report.Observed.EligibleWorkloads)
+}
+
+func assertEqual(field string, got string, want string) {
+	if got != want {
+		failf("%s = %q, want %q", field, got, want)
+	}
+}
+
+func failf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

- Add live Kind/Chainsaw coverage for `kleym inspect binding -o json`.
- Validate both a reconciled binding report and a missing-binding failure report.

## What I Changed And Why

- Built `bin/kleym` as part of `make test-e2e-chainsaw` so the existing Kind e2e path can exercise the CLI against live cluster state.
- Extended the `binding-reconciliation` Chainsaw scenario to wait for the reference workload rollout, inspect the reconciled `binding`, and assert stable JSON fields for desired state, observed managed `ClusterSPIFFEID`, and eligible workload visibility.
- Added `test/e2e/inspectbindingassert` as a small Go helper so the e2e test can validate structured JSON without adding a new external JSON assertion dependency.

## Related Issue

- Fixes #164

## Scope Check

- Follows the issue scope by reusing the existing Kind/Chainsaw target and reference inference fixtures.
- Intentionally leaves broader CLI e2e matrix coverage and additional RBAC-partial cases out of scope.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because operator behavior and API contracts are unchanged.
- CLI Spec (`docs/spec/cli.md`): not needed because the CLI command, output, and exit-code contract are unchanged.
- Other docs: not needed because no new e2e command was added; the existing `make test-e2e-chainsaw` target now includes the CLI check.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `go test ./test/e2e/inspectbindingassert`
  - `make build-cli`
  - `make test`
  - `make test-e2e-chainsaw`
  - `git diff --check`
  - `make lint`
- Tests not run and why: none relevant.

## Security Review

- This PR does not change GitHub Actions, release automation, credentials, or workflow token permissions.
- It changes CI runtime behavior only through the existing `make test-e2e-chainsaw` command by running the local CLI against Kind fixtures. The new shell inputs are fixed test resource names, and no secrets or untrusted PR-provided values are introduced.