### PR TITLE
feat(operator): add identity binding outcome metrics

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -224,20 +224,22 @@ controller-runtime metrics surface; Kleym status conditions and events remain
 the per-object debugging surface for a specific
 `InferenceIdentityBinding`.
 
-To enable the shipped `ServiceMonitor`, add `config/prometheus` to the existing
-default kustomize flow:
+To enable the shipped `ServiceMonitor` from a remote GitOps overlay, add
+`config/prometheus` next to the default install and set the install namespace so
+the `ServiceMonitor` and metrics `Service` are rendered together:
 
 ```yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kleym-system
 resources:
 - github.com/sonda-red/kleym/config/default?ref=main
 - github.com/sonda-red/kleym/config/prometheus?ref=main
 ```
 
-If you build from a local checkout, uncomment the `../prometheus` entry in
-`config/default/kustomization.yaml` and keep the metrics deployment patch
-enabled.
+If you build from a local checkout, you can instead uncomment the
+`../prometheus` entry in `config/default/kustomization.yaml` and keep the
+metrics deployment patch enabled.
 
 Prometheus still needs RBAC to read the authenticated metrics endpoint. The
 default install publishes the `kleym-metrics-reader` `ClusterRole`, so bind

--- a/docs/install.md
+++ b/docs/install.md
@@ -216,6 +216,53 @@ tools can pin the manifest ref and image tag directly, and Flux or Argo CD can
 consume the kustomization without a chart. A chart should be revisited when
 kleym needs a larger templated install surface for operator-specific options.
 
+## Operator Metrics
+
+`kleym-operator` publishes Kleym-owned Prometheus metrics on the existing
+controller-runtime `/metrics` endpoint. The endpoint remains the authenticated
+controller-runtime metrics surface; Kleym status conditions and events remain
+the per-object debugging surface for a specific
+`InferenceIdentityBinding`.
+
+To enable the shipped `ServiceMonitor`, add `config/prometheus` to the existing
+default kustomize flow:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- github.com/sonda-red/kleym/config/default?ref=main
+- github.com/sonda-red/kleym/config/prometheus?ref=main
+```
+
+If you build from a local checkout, uncomment the `../prometheus` entry in
+`config/default/kustomization.yaml` and keep the metrics deployment patch
+enabled.
+
+Prometheus still needs RBAC to read the authenticated metrics endpoint. The
+default install publishes the `kleym-metrics-reader` `ClusterRole`, so bind
+your Prometheus service account to it:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-kleym-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kleym-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: monitoring
+```
+
+The public Kleym metrics are:
+
+- `kleym_identity_binding_outcomes_total{condition,reason,mode}`: counter of terminal reconcile outcomes.
+- `kleym_identity_bindings{condition,reason,mode}`: scrape-time gauge of current binding outcomes aggregated from status.
+
 ## Test
 
 Run controller and API tests:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.29.0
 	github.com/onsi/gomega v1.41.0
+	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
 	k8s.io/api v0.36.1
 	k8s.io/apimachinery v0.36.1
@@ -48,7 +49,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/internal/controller/inferenceidentitybinding_controller.go
+++ b/internal/controller/inferenceidentitybinding_controller.go
@@ -92,6 +92,7 @@ type InferenceIdentityBindingReconciler struct {
 	client.Client
 	Scheme                 *runtime.Scheme
 	Recorder               events.EventRecorder
+	MetricsRecorder        bindingOutcomeRecorder
 	availableObjectiveGVKs []schema.GroupVersionKind
 	availablePoolGVKs      []schema.GroupVersionKind
 }
@@ -194,6 +195,7 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(
 		if err := r.patchStatusFromBase(ctx, statusBase, binding); err != nil {
 			return ctrl.Result{}, err
 		}
+		r.recordTerminalOutcome(binding)
 		logger.Info(
 			"applied failure status",
 			logKeyCondition, stateErr.conditionType,
@@ -224,6 +226,7 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(
 		if err := r.patchStatusFromBase(ctx, statusBase, binding); err != nil {
 			return ctrl.Result{}, err
 		}
+		r.recordTerminalOutcome(binding)
 		if collisionResult.currentDetected {
 			r.recordEventf(binding, corev1.EventTypeWarning, "IdentityCollision", "%s", collisionResult.currentMessage)
 		}
@@ -249,6 +252,7 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(
 			if err := r.patchStatusFromBase(ctx, statusBase, binding); err != nil {
 				return ctrl.Result{}, err
 			}
+			r.recordTerminalOutcome(binding)
 			logger.Info(
 				"applied failure status",
 				logKeyCondition, stateErr.conditionType,
@@ -269,6 +273,7 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(
 	if err := r.patchStatusFromBase(ctx, statusBase, binding); err != nil {
 		return ctrl.Result{}, err
 	}
+	r.recordTerminalOutcome(binding)
 	logger.Info(
 		"applied success status",
 		logKeyCondition, conditionTypeReady,
@@ -295,6 +300,12 @@ func (r *InferenceIdentityBindingReconciler) SetupWithManager(mgr ctrl.Manager) 
 	setupLogger := logf.Log.WithName("setup").WithName("inferenceidentitybinding")
 
 	r.Recorder = mgr.GetEventRecorder("inferenceidentitybinding-controller")
+	if r.MetricsRecorder == nil {
+		r.MetricsRecorder = defaultBindingMetrics.outcomeRecorder
+	}
+	if err := defaultBindingMetrics.register(mgr.GetClient()); err != nil {
+		return err
+	}
 
 	if err := r.setupFieldIndexes(mgr); err != nil {
 		return err

--- a/internal/controller/inferenceidentitybinding_metrics.go
+++ b/internal/controller/inferenceidentitybinding_metrics.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2026 Kalin Daskalov.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controller
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	kleymv1alpha1 "github.com/sonda-red/kleym/api/v1alpha1"
+)
+
+const (
+	metricNameIdentityBindingOutcomes = "kleym_identity_binding_outcomes_total"
+	metricNameIdentityBindings        = "kleym_identity_bindings"
+	metricLabelCondition              = "condition"
+	metricLabelReason                 = "reason"
+	metricLabelMode                   = "mode"
+	metricReasonInitializing          = "Initializing"
+)
+
+var failureOutcomeConditionOrder = []string{
+	conditionTypeConflict,
+	conditionTypeInvalidRef,
+	conditionTypeUnsafeSelector,
+	conditionTypeRenderFailure,
+}
+
+var defaultBindingMetrics = newInferenceIdentityBindingMetrics()
+
+type bindingOutcomeLabels struct {
+	condition string
+	reason    string
+	mode      string
+}
+
+type bindingOutcomeRecorder interface {
+	RecordTerminalOutcome(binding *kleymv1alpha1.InferenceIdentityBinding)
+}
+
+type prometheusBindingOutcomeRecorder struct {
+	counter *prometheus.CounterVec
+}
+
+type inferenceIdentityBindingMetrics struct {
+	outcomeRecorder *prometheusBindingOutcomeRecorder
+	gaugeCollector  *identityBindingGaugeCollector
+}
+
+type bindingsListFunc func(context.Context) ([]kleymv1alpha1.InferenceIdentityBinding, error)
+
+type identityBindingGaugeCollector struct {
+	mu       sync.RWMutex
+	desc     *prometheus.Desc
+	listFunc bindingsListFunc
+}
+
+func newInferenceIdentityBindingMetrics() *inferenceIdentityBindingMetrics {
+	return &inferenceIdentityBindingMetrics{
+		outcomeRecorder: &prometheusBindingOutcomeRecorder{
+			counter: prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Name: metricNameIdentityBindingOutcomes,
+					Help: "Terminal reconcile outcomes for InferenceIdentityBinding resources.",
+				},
+				[]string{metricLabelCondition, metricLabelReason, metricLabelMode},
+			),
+		},
+		gaugeCollector: newIdentityBindingGaugeCollector(),
+	}
+}
+
+func newIdentityBindingGaugeCollector() *identityBindingGaugeCollector {
+	return &identityBindingGaugeCollector{
+		desc: prometheus.NewDesc(
+			metricNameIdentityBindings,
+			"Current InferenceIdentityBinding outcomes aggregated from object status.",
+			[]string{metricLabelCondition, metricLabelReason, metricLabelMode},
+			nil,
+		),
+	}
+}
+
+// register wires the public controller metrics into controller-runtime's shared
+// registry and updates the scrape-time binding lister used by the gauge.
+func (m *inferenceIdentityBindingMetrics) register(k8sClient client.Client) error {
+	m.gaugeCollector.setListFunc(func(ctx context.Context) ([]kleymv1alpha1.InferenceIdentityBinding, error) {
+		bindingList := &kleymv1alpha1.InferenceIdentityBindingList{}
+		if err := k8sClient.List(ctx, bindingList); err != nil {
+			return nil, err
+		}
+		return bindingList.Items, nil
+	})
+
+	if err := registerMetricsCollector(m.outcomeRecorder.counter); err != nil {
+		return err
+	}
+	return registerMetricsCollector(m.gaugeCollector)
+}
+
+func registerMetricsCollector(collector prometheus.Collector) error {
+	if err := metrics.Registry.Register(collector); err != nil {
+		var alreadyRegistered prometheus.AlreadyRegisteredError
+		if errors.As(err, &alreadyRegistered) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (r *prometheusBindingOutcomeRecorder) RecordTerminalOutcome(binding *kleymv1alpha1.InferenceIdentityBinding) {
+	labels, ok := deriveBindingOutcomeLabels(binding, false)
+	if !ok {
+		return
+	}
+
+	r.counter.WithLabelValues(labels.condition, labels.reason, labels.mode).Inc()
+}
+
+func (c *identityBindingGaugeCollector) setListFunc(listFunc bindingsListFunc) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.listFunc = listFunc
+}
+
+func (c *identityBindingGaugeCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.desc
+}
+
+func (c *identityBindingGaugeCollector) Collect(ch chan<- prometheus.Metric) {
+	listFunc := c.currentListFunc()
+	if listFunc == nil {
+		return
+	}
+
+	bindings, err := listFunc(context.Background())
+	if err != nil {
+		return
+	}
+
+	aggregated := make(map[bindingOutcomeLabels]float64)
+	for i := range bindings {
+		labels, ok := deriveBindingOutcomeLabels(&bindings[i], true)
+		if !ok {
+			continue
+		}
+		aggregated[labels]++
+	}
+
+	for labels, value := range aggregated {
+		ch <- prometheus.MustNewConstMetric(
+			c.desc,
+			prometheus.GaugeValue,
+			value,
+			labels.condition,
+			labels.reason,
+			labels.mode,
+		)
+	}
+}
+
+func (c *identityBindingGaugeCollector) currentListFunc() bindingsListFunc {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.listFunc
+}
+
+// deriveBindingOutcomeLabels reduces a binding's status to one bounded outcome
+// tuple so status conditions remain the per-object debugging surface while
+// metrics expose only low-cardinality aggregate labels.
+func deriveBindingOutcomeLabels(
+	binding *kleymv1alpha1.InferenceIdentityBinding,
+	allowInitializing bool,
+) (bindingOutcomeLabels, bool) {
+	mode := string(effectiveMode(binding.Spec.Mode))
+	ready := meta.FindStatusCondition(binding.Status.Conditions, conditionTypeReady)
+	if ready != nil {
+		if ready.Status == metav1.ConditionTrue {
+			return bindingOutcomeLabels{
+				condition: conditionTypeReady,
+				reason:    ready.Reason,
+				mode:      mode,
+			}, true
+		}
+		if allowInitializing && ready.Status == metav1.ConditionUnknown && ready.Reason == metricReasonInitializing {
+			return bindingOutcomeLabels{
+				condition: conditionTypeReady,
+				reason:    metricReasonInitializing,
+				mode:      mode,
+			}, true
+		}
+	}
+
+	for _, conditionType := range failureOutcomeConditionOrder {
+		condition := meta.FindStatusCondition(binding.Status.Conditions, conditionType)
+		if condition != nil && condition.Status == metav1.ConditionTrue {
+			return bindingOutcomeLabels{
+				condition: condition.Type,
+				reason:    condition.Reason,
+				mode:      mode,
+			}, true
+		}
+	}
+
+	return bindingOutcomeLabels{}, false
+}
+
+func (r *InferenceIdentityBindingReconciler) recordTerminalOutcome(binding *kleymv1alpha1.InferenceIdentityBinding) {
+	if r.MetricsRecorder == nil {
+		return
+	}
+	r.MetricsRecorder.RecordTerminalOutcome(binding)
+}

--- a/internal/controller/inferenceidentitybinding_metrics_test.go
+++ b/internal/controller/inferenceidentitybinding_metrics_test.go
@@ -1,0 +1,295 @@
+/*
+Copyright 2026 Kalin Daskalov.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controller
+
+import (
+	"context"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	kleymv1alpha1 "github.com/sonda-red/kleym/api/v1alpha1"
+)
+
+func TestDeriveBindingOutcomeLabelsReady(t *testing.T) {
+	t.Parallel()
+
+	binding := newPoolOnlyBinding("binding-ready", "")
+	initializeConditions(&binding.Status, 1)
+	applySuccessStatus(&binding.Status, binding.Generation, []renderedIdentity{{
+		Mode: kleymv1alpha1.InferenceIdentityBindingModePoolOnly,
+	}})
+
+	labels, ok := deriveBindingOutcomeLabels(binding, false)
+	if !ok {
+		t.Fatal("expected outcome labels")
+	}
+	if labels.condition != conditionTypeReady {
+		t.Fatalf("condition = %q, want %q", labels.condition, conditionTypeReady)
+	}
+	if labels.reason != "Reconciled" {
+		t.Fatalf("reason = %q, want %q", labels.reason, "Reconciled")
+	}
+	if labels.mode != string(kleymv1alpha1.InferenceIdentityBindingModePoolOnly) {
+		t.Fatalf("mode = %q, want %q", labels.mode, kleymv1alpha1.InferenceIdentityBindingModePoolOnly)
+	}
+}
+
+func TestDeriveBindingOutcomeLabelsFailure(t *testing.T) {
+	t.Parallel()
+
+	binding := newPerObjectiveBinding("binding-failure", "objective-a")
+	initializeConditions(&binding.Status, 1)
+	applyFailureStatus(&binding.Status, binding.Generation, newStateError(
+		conditionTypeRenderFailure,
+		"MissingObjectiveRef",
+		"objectiveRef is required when mode is PerObjective",
+	))
+
+	labels, ok := deriveBindingOutcomeLabels(binding, false)
+	if !ok {
+		t.Fatal("expected outcome labels")
+	}
+	if labels.condition != conditionTypeRenderFailure {
+		t.Fatalf("condition = %q, want %q", labels.condition, conditionTypeRenderFailure)
+	}
+	if labels.reason != "MissingObjectiveRef" {
+		t.Fatalf("reason = %q, want %q", labels.reason, "MissingObjectiveRef")
+	}
+	if labels.mode != string(kleymv1alpha1.InferenceIdentityBindingModePerObjective) {
+		t.Fatalf("mode = %q, want %q", labels.mode, kleymv1alpha1.InferenceIdentityBindingModePerObjective)
+	}
+}
+
+func TestDeriveBindingOutcomeLabelsCollision(t *testing.T) {
+	t.Parallel()
+
+	binding := newPerObjectiveBinding("binding-collision", "objective-a")
+	initializeConditions(&binding.Status, 1)
+	applyCollisionStatus(&binding.Status, binding.Generation, true, "identity collision with bindings default/peer")
+
+	labels, ok := deriveBindingOutcomeLabels(binding, false)
+	if !ok {
+		t.Fatal("expected outcome labels")
+	}
+	if labels.condition != conditionTypeConflict {
+		t.Fatalf("condition = %q, want %q", labels.condition, conditionTypeConflict)
+	}
+	if labels.reason != "IdentityCollision" {
+		t.Fatalf("reason = %q, want %q", labels.reason, "IdentityCollision")
+	}
+	if labels.mode != string(kleymv1alpha1.InferenceIdentityBindingModePerObjective) {
+		t.Fatalf("mode = %q, want %q", labels.mode, kleymv1alpha1.InferenceIdentityBindingModePerObjective)
+	}
+}
+
+func TestReconcileRecordsSuccessfulTerminalOutcomeAfterStatusPatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newCollisionTestScheme(t)
+
+	binding := newPoolOnlyBinding("binding-ready-metric", "")
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+		WithObjects(newTestPool(), binding).
+		Build()
+	recorder := &persistedBindingOutcomeRecorder{
+		client: k8sClient,
+		key:    types.NamespacedName{Namespace: testNamespace, Name: binding.Name},
+	}
+
+	reconciler := &InferenceIdentityBindingReconciler{
+		Client:          k8sClient,
+		Scheme:          scheme,
+		MetricsRecorder: recorder,
+	}
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: recorder.key})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	if len(recorder.outcomes) != 1 {
+		t.Fatalf("recorded outcomes = %d, want 1", len(recorder.outcomes))
+	}
+	outcome := recorder.outcomes[0]
+	if outcome.condition != conditionTypeReady || outcome.reason != "Reconciled" || outcome.mode != string(kleymv1alpha1.InferenceIdentityBindingModePoolOnly) {
+		t.Fatalf("unexpected outcome: %+v", outcome)
+	}
+}
+
+func TestReconcileRecordsFailureTerminalOutcomeAfterStatusPatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newCollisionTestScheme(t)
+
+	binding := newPerObjectiveBinding("binding-failure-metric", "objective-a")
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+		WithObjects(newTestObjective("objective-a"), binding).
+		Build()
+	recorder := &persistedBindingOutcomeRecorder{
+		client: k8sClient,
+		key:    types.NamespacedName{Namespace: testNamespace, Name: binding.Name},
+	}
+
+	reconciler := &InferenceIdentityBindingReconciler{
+		Client:          k8sClient,
+		Scheme:          scheme,
+		MetricsRecorder: recorder,
+	}
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: recorder.key})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	if len(recorder.outcomes) != 1 {
+		t.Fatalf("recorded outcomes = %d, want 1", len(recorder.outcomes))
+	}
+	outcome := recorder.outcomes[0]
+	if outcome.condition != conditionTypeInvalidRef || outcome.reason != "TargetPoolNotFound" || outcome.mode != string(kleymv1alpha1.InferenceIdentityBindingModePerObjective) {
+		t.Fatalf("unexpected outcome: %+v", outcome)
+	}
+}
+
+func TestIdentityBindingGaugeCollectorAggregatesOutcomes(t *testing.T) {
+	t.Parallel()
+
+	scheme := newCollisionTestScheme(t)
+
+	readyA := newPoolOnlyBinding("binding-ready-a", "")
+	readyB := newPoolOnlyBinding("binding-ready-b", "")
+	collision := newPerObjectiveBinding("binding-collision", "objective-a")
+	initializing := newPoolOnlyBinding("binding-initializing", "")
+
+	initializeConditions(&readyA.Status, 1)
+	initializeConditions(&readyB.Status, 1)
+	initializeConditions(&collision.Status, 1)
+	initializeConditions(&initializing.Status, 1)
+
+	applySuccessStatus(&readyA.Status, readyA.Generation, []renderedIdentity{{Mode: kleymv1alpha1.InferenceIdentityBindingModePoolOnly}})
+	applySuccessStatus(&readyB.Status, readyB.Generation, []renderedIdentity{{Mode: kleymv1alpha1.InferenceIdentityBindingModePoolOnly}})
+	applyCollisionStatus(&collision.Status, collision.Generation, true, "identity collision with bindings default/peer")
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(readyA, readyB, collision, initializing).
+		Build()
+
+	collector := newIdentityBindingGaugeCollector()
+	collector.setListFunc(func(ctx context.Context) ([]kleymv1alpha1.InferenceIdentityBinding, error) {
+		bindingList := &kleymv1alpha1.InferenceIdentityBindingList{}
+		if err := k8sClient.List(ctx, bindingList); err != nil {
+			return nil, err
+		}
+		return bindingList.Items, nil
+	})
+
+	registry := prometheus.NewRegistry()
+	if err := registry.Register(collector); err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather returned error: %v", err)
+	}
+
+	values := gatherMetricLabels(t, families, metricNameIdentityBindings)
+	assertMetricValue(t, values, bindingOutcomeLabels{
+		condition: conditionTypeReady,
+		reason:    "Reconciled",
+		mode:      string(kleymv1alpha1.InferenceIdentityBindingModePoolOnly),
+	}, 2)
+	assertMetricValue(t, values, bindingOutcomeLabels{
+		condition: conditionTypeConflict,
+		reason:    "IdentityCollision",
+		mode:      string(kleymv1alpha1.InferenceIdentityBindingModePerObjective),
+	}, 1)
+	assertMetricValue(t, values, bindingOutcomeLabels{
+		condition: conditionTypeReady,
+		reason:    metricReasonInitializing,
+		mode:      string(kleymv1alpha1.InferenceIdentityBindingModePoolOnly),
+	}, 1)
+}
+
+type persistedBindingOutcomeRecorder struct {
+	client   client.Client
+	key      types.NamespacedName
+	outcomes []bindingOutcomeLabels
+}
+
+func (r *persistedBindingOutcomeRecorder) RecordTerminalOutcome(binding *kleymv1alpha1.InferenceIdentityBinding) {
+	current := &kleymv1alpha1.InferenceIdentityBinding{}
+	if err := r.client.Get(context.Background(), r.key, current); err != nil {
+		panic(err)
+	}
+
+	outcome, ok := deriveBindingOutcomeLabels(current, false)
+	if !ok {
+		panic("expected persisted terminal outcome")
+	}
+	r.outcomes = append(r.outcomes, outcome)
+}
+
+func gatherMetricLabels(t *testing.T, families []*dto.MetricFamily, metricName string) map[bindingOutcomeLabels]float64 {
+	t.Helper()
+
+	values := map[bindingOutcomeLabels]float64{}
+	for _, family := range families {
+		if family.GetName() != metricName {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			labels := bindingOutcomeLabels{}
+			for _, pair := range metric.GetLabel() {
+				switch pair.GetName() {
+				case metricLabelCondition:
+					labels.condition = pair.GetValue()
+				case metricLabelReason:
+					labels.reason = pair.GetValue()
+				case metricLabelMode:
+					labels.mode = pair.GetValue()
+				}
+			}
+			values[labels] = metric.GetGauge().GetValue()
+		}
+	}
+	return values
+}
+
+func assertMetricValue(t *testing.T, values map[bindingOutcomeLabels]float64, labels bindingOutcomeLabels, want float64) {
+	t.Helper()
+
+	got, ok := values[labels]
+	if !ok {
+		t.Fatalf("missing metric for labels %+v", labels)
+	}
+	if got != want {
+		t.Fatalf("metric value for %+v = %v, want %v", labels, got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Add Kleym-owned Prometheus metrics for `InferenceIdentityBinding` reconcile outcomes on the existing controller-runtime metrics endpoint.
- Document Prometheus `ServiceMonitor` enablement and metrics-reader RBAC for the GitOps install path.

## What I Changed And Why

- Added a bounded-label outcome counter, `kleym_identity_binding_outcomes_total{condition,reason,mode}`, for terminal reconcile outcomes.
- Added a scrape-time gauge, `kleym_identity_bindings{condition,reason,mode}`, aggregated from current binding status conditions.
- Kept labels intentionally low-cardinality: no binding name, namespace, SPIFFE ID, objective name, or pool name labels.
- Wired metrics registration through controller-runtime's shared metrics registry without changing the existing metrics endpoint, authn/authz filter, API shape, or reconciliation status contract.
- Added tests for label derivation, successful and failed reconcile outcome recording after status patching, and gauge aggregation.
- Added install docs for enabling `config/prometheus` and binding Prometheus to `kleym-metrics-reader`.

## Related Issue

- Fixes #140

## Scope Check

- This PR follows #140 by adding domain metrics only on the existing metrics endpoint.
- It intentionally does not add namespace labels, per-object labels, Helm packaging, dashboards, e2e expansion, or new install modes.
- Helm packaging criteria were split into follow-up #183.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because the operator API and reconciliation contract are unchanged.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI behavior is unchanged.
- Other docs: updated `docs/install.md` with Prometheus enablement, metrics-reader RBAC, and the public metric names.

## Follow-Up Work

- Proposed follow-up issue(s), if any: #183 tracks when to revisit Helm chart packaging.

## Verification

- Commands run:
  - `kustomize build --load-restrictor=LoadRestrictionsNone /tmp/kgw`
  - `make docs-build`
  - `make test`
  - `make lint`
- Tests not run and why: `make test-e2e-chainsaw` was not run because #140 asks to keep e2e expansion constrained and the change is covered by controller/unit tests plus rendered install validation.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or secret handling.
- It does touch observability output, but preserves the existing authenticated controller-runtime `/metrics` endpoint and avoids high-cardinality or sensitive per-object labels.