### PR TITLE
feat(cli): add YAML and Markdown output formats

### DIFF
--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -33,19 +33,19 @@ The command inspects one `InferenceIdentityBinding` end to end.
 
 ```bash
 -n, --namespace
--o, --output text|json
+-o, --output text|json|yaml|markdown
 --strict
 --context
 --kubeconfig
 --timeout
 ```
 
-Default namespace is `default`. Default output is `text`. Stable machine output is `json`. `--timeout` must be greater than zero.
+Default namespace is `default`. Default output is `text`. Stable machine output is `json`. YAML is a JSON-equivalent encoding of the same report shape for tools and documentation. Markdown is human-oriented for documentation and PR comments and may change between releases. `--timeout` must be greater than zero.
 
 ## Output Contract
 
-JSON is the stable contract. Text is human-oriented and may change between releases.
-Automation must consume `kleym inspect binding <name> -n <namespace> -o json`; the default text output is optimized for quick human diagnosis and leads with a summary before detailed sections.
+JSON is the stable contract. YAML encodes the same normalized report data and field names as JSON. Text and Markdown are human-oriented and may change between releases.
+Automation must consume `kleym inspect binding <name> -n <namespace> -o json`; the default text output is optimized for quick human diagnosis and leads with a summary before detailed sections. Markdown output is intended for documentation and PR comments, and must not introduce inspection semantics that are absent from the canonical report data.
 
 `kleym inspect binding` emits a `BindingInspectionReport` with four core sections:
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/client-go v0.36.1
 	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2
 	sigs.k8s.io/controller-runtime v0.24.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -96,5 +97,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/internal/cli/inspect_test.go
+++ b/internal/cli/inspect_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/sonda-red/kleym/internal/inspection"
+	"sigs.k8s.io/yaml"
 )
 
 func TestInspectBindingJSONUsesRunner(t *testing.T) {
@@ -42,6 +43,88 @@ func TestInspectBindingJSONUsesRunner(t *testing.T) {
 	}
 	if got.BindingRef.Namespace != "tenant-a" || got.BindingRef.Name != "binding-a" {
 		t.Fatalf("bindingRef = %#v, want tenant-a/binding-a", got.BindingRef)
+	}
+}
+
+func TestInspectBindingYAMLUsesRunner(t *testing.T) {
+	originalFactory := newBindingInspectionRunner
+	t.Cleanup(func() { newBindingInspectionRunner = originalFactory })
+
+	fakeReport := inspection.NewBindingInspectionReport()
+	fakeReport.GeneratedAt = "2026-05-18T10:11:12Z"
+	fakeReport.BindingRef = inspection.BindingInspectionBindingRef{Namespace: "tenant-a", Name: "binding-a"}
+	newBindingInspectionRunner = func(_ *Options) (inspection.BindingInspector, error) {
+		return fixedInspectionRunner{report: fakeReport}, nil
+	}
+
+	cmd := NewRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"inspect", "binding", "binding-a", "-n", "tenant-a", "-o", "yaml"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("inspect binding returned error: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr, got:\n%s", stderr.String())
+	}
+
+	yamlAsJSON, err := yaml.YAMLToJSON(stdout.Bytes())
+	if err != nil {
+		t.Fatalf("convert inspect YAML output: %v\n%s", err, stdout.String())
+	}
+	var got inspection.BindingInspectionReport
+	if err := json.Unmarshal(yamlAsJSON, &got); err != nil {
+		t.Fatalf("unmarshal inspect YAML output: %v\n%s", err, stdout.String())
+	}
+	if got.BindingRef.Namespace != "tenant-a" || got.BindingRef.Name != "binding-a" {
+		t.Fatalf("bindingRef = %#v, want tenant-a/binding-a", got.BindingRef)
+	}
+}
+
+func TestInspectBindingMarkdownUsesRunner(t *testing.T) {
+	originalFactory := newBindingInspectionRunner
+	t.Cleanup(func() { newBindingInspectionRunner = originalFactory })
+
+	fakeReport := inspection.NewBindingInspectionReport()
+	fakeReport.GeneratedAt = "2026-05-18T10:11:12Z"
+	fakeReport.BindingRef = inspection.BindingInspectionBindingRef{Namespace: "tenant-a", Name: "binding-a", Mode: "PerObjective"}
+	fakeReport.Desired = inspection.BindingInspectionDesiredState{
+		ClusterSPIFFEIDName: "tenant-a-binding-a-1234abcd",
+		SPIFFEID:            "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
+	}
+	newBindingInspectionRunner = func(_ *Options) (inspection.BindingInspector, error) {
+		return fixedInspectionRunner{report: fakeReport}, nil
+	}
+
+	cmd := NewRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"inspect", "binding", "binding-a", "-n", "tenant-a", "-o", "markdown"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("inspect binding returned error: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr, got:\n%s", stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"# BindingInspectionReport",
+		"| Name | tenant-a/binding-a |",
+		"| Mode | PerObjective |",
+		"| ClusterSPIFFEID | tenant-a-binding-a-1234abcd |",
+		"| SPIFFE ID | spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a |",
+		"<summary>Canonical JSON report</summary>",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("markdown output missing %q\n%s", want, out)
+		}
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/sonda-red/kleym/internal/version"
@@ -12,7 +13,11 @@ const (
 	defaultNamespace = "default"
 	outputText       = "text"
 	outputJSON       = "json"
+	outputYAML       = "yaml"
+	outputMarkdown   = "markdown"
 )
+
+var validOutputFormats = []string{outputText, outputJSON, outputYAML, outputMarkdown}
 
 // Options holds top-level CLI flags for the kleym command tree.
 type Options struct {
@@ -41,7 +46,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.SetVersionTemplate("{{printf \"%s\\n\" .Version}}")
 
 	cmd.PersistentFlags().StringVarP(&opts.Namespace, "namespace", "n", defaultNamespace, "Namespace for binding lookup")
-	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", outputText, "Output format: text|json")
+	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", outputText, "Output format: "+strings.Join(validOutputFormats, "|"))
 	cmd.PersistentFlags().BoolVar(&opts.Strict, "strict", false, "Treat warning findings as errors")
 	cmd.PersistentFlags().StringVar(&opts.Context, "context", "", "Name of the kubeconfig context to use")
 	cmd.PersistentFlags().StringVar(&opts.Kubeconfig, "kubeconfig", "", "Path to the kubeconfig file")
@@ -52,11 +57,20 @@ func NewRootCommand() *cobra.Command {
 }
 
 func validateRunnableOptions(opts *Options) error {
-	if opts.Output != outputText && opts.Output != outputJSON {
-		return withExitCode(exitUsage, fmt.Errorf("invalid --output %q: must be one of %s|%s", opts.Output, outputText, outputJSON))
+	if !isValidOutputFormat(opts.Output) {
+		return withExitCode(exitUsage, fmt.Errorf("invalid --output %q: must be one of %s", opts.Output, strings.Join(validOutputFormats, "|")))
 	}
 	if opts.Timeout <= 0 {
 		return withExitCode(exitUsage, fmt.Errorf("invalid --timeout %s: must be greater than 0", opts.Timeout))
 	}
 	return nil
+}
+
+func isValidOutputFormat(output string) bool {
+	for _, valid := range validOutputFormats {
+		if output == valid {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -95,7 +95,7 @@ func TestInvalidOutputRejected(t *testing.T) {
 	cmd := NewRootCommand()
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs([]string{"inspect", "binding", "my-binding", "--output", "yaml"})
+	cmd.SetArgs([]string{"inspect", "binding", "my-binding", "--output", "xml"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -113,7 +113,7 @@ func TestInvalidOutputNotRejectedForHelp(t *testing.T) {
 	cmd := NewRootCommand()
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs([]string{"--output", "yaml", "--help"})
+	cmd.SetArgs([]string{"--output", "xml", "--help"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("expected help to bypass runnable output validation: %v", err)
@@ -184,7 +184,7 @@ func TestExecuteMapsErrorsToExitCodes(t *testing.T) {
 		},
 		{
 			name:    "usage",
-			args:    []string{"inspect", "binding", "my-binding", "--output", "yaml"},
+			args:    []string{"inspect", "binding", "my-binding", "--output", "xml"},
 			want:    exitUsage,
 			wantErr: "invalid --output",
 		},

--- a/internal/inspection/report.go
+++ b/internal/inspection/report.go
@@ -7,11 +7,14 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 const (
-	outputText = "text"
-	outputJSON = "json"
+	outputText     = "text"
+	outputJSON     = "json"
+	outputYAML     = "yaml"
+	outputMarkdown = "markdown"
 )
 
 const (
@@ -196,6 +199,103 @@ func writeBindingInspectionReportJSON(w io.Writer, report BindingInspectionRepor
 	return encoder.Encode(normalizeBindingInspectionReport(report))
 }
 
+// writeBindingInspectionReportYAML writes the normalized JSON report as equivalent YAML.
+func writeBindingInspectionReportYAML(w io.Writer, report BindingInspectionReport) error {
+	data, err := json.Marshal(normalizeBindingInspectionReport(report))
+	if err != nil {
+		return err
+	}
+	yamlData, err := yaml.JSONToYAML(data)
+	if err != nil {
+		return err
+	}
+	if len(yamlData) == 0 || yamlData[len(yamlData)-1] != '\n' {
+		yamlData = append(yamlData, '\n')
+	}
+	_, err = w.Write(yamlData)
+	return err
+}
+
+// writeBindingInspectionReportMarkdown writes a PR-comment-friendly view backed by canonical JSON.
+func writeBindingInspectionReportMarkdown(w io.Writer, report BindingInspectionReport) error {
+	report = normalizeBindingInspectionReport(report)
+	canonical, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	var builder strings.Builder
+	appendMarkdownLine(&builder, "# BindingInspectionReport")
+	appendMarkdownLine(&builder, "")
+	appendMarkdownLine(&builder, "## Summary")
+	appendMarkdownTable(&builder, []string{"Field", "Value"}, [][]string{
+		{"Status", inspectionTextStatus(report.Findings)},
+		{"Findings", textCountOrNone(len(report.Findings))},
+		{"Drift", textCountOrNone(len(report.Observed.Drift))},
+		{"Eligible workloads", fmt.Sprintf("%d", len(report.Observed.EligibleWorkloads))},
+		{"Inspection completeness", inspectionTextCompleteness(report.Capabilities)},
+	})
+
+	appendMarkdownLine(&builder, "")
+	appendMarkdownLine(&builder, "## Binding")
+	appendMarkdownTable(&builder, []string{"Field", "Value"}, [][]string{
+		{"Name", textNamespacedName(report.BindingRef.Namespace, report.BindingRef.Name)},
+		{"Generation", fmt.Sprintf("%d", report.BindingRef.Generation)},
+		{"Mode", textString(report.BindingRef.Mode)},
+		{"PoolRef", textTargetRef(report.BindingRef.PoolRef)},
+		{"ObjectiveRef", textTargetRef(report.BindingRef.ObjectiveRef)},
+	})
+
+	appendMarkdownLine(&builder, "")
+	appendMarkdownLine(&builder, "## Identity")
+	appendMarkdownTable(&builder, []string{"Field", "Value"}, [][]string{
+		{"ClusterSPIFFEID", textString(report.Desired.ClusterSPIFFEIDName)},
+		{"SPIFFE ID", textString(report.Desired.SPIFFEID)},
+		{"Hint", textString(report.Desired.Hint)},
+		{"Fallback", textBool(report.Desired.Fallback)},
+	})
+
+	appendMarkdownLine(&builder, "")
+	appendMarkdownLine(&builder, "## Findings")
+	if len(report.Findings) == 0 {
+		appendMarkdownLine(&builder, "No findings.")
+	} else {
+		rows := make([][]string, 0, len(report.Findings))
+		for _, finding := range report.Findings {
+			rows = append(rows, []string{
+				textString(finding.ID),
+				textString(string(finding.Severity)),
+				textString(finding.Reason),
+				textString(finding.Message),
+				markdownTargetRefs(finding.AffectedRefs),
+			})
+		}
+		appendMarkdownTable(&builder, []string{"ID", "Severity", "Reason", "Message", "Affected refs"}, rows)
+	}
+
+	appendMarkdownLine(&builder, "")
+	appendMarkdownLine(&builder, "## Capabilities")
+	appendMarkdownTable(&builder, []string{"Check", "Completeness"}, [][]string{
+		{"Binding", textString(string(report.Capabilities.Binding))},
+		{"GAIE resources", textString(string(report.Capabilities.GAIEResources))},
+		{"ClusterSPIFFEIDs", textString(string(report.Capabilities.ClusterSPIFFEIDs))},
+		{"Peer bindings", textString(string(report.Capabilities.PeerBindings))},
+		{"Pods", textString(string(report.Capabilities.Pods))},
+	})
+
+	appendMarkdownLine(&builder, "")
+	appendMarkdownLine(&builder, "<details>")
+	appendMarkdownLine(&builder, "<summary>Canonical JSON report</summary>")
+	appendMarkdownLine(&builder, "")
+	appendMarkdownLine(&builder, "```json")
+	appendMarkdownLine(&builder, "%s", canonical)
+	appendMarkdownLine(&builder, "```")
+	appendMarkdownLine(&builder, "</details>")
+
+	_, err = io.WriteString(w, builder.String())
+	return err
+}
+
 // writeBindingInspectionReportText writes deterministic human-oriented inspection output.
 func writeBindingInspectionReportText(w io.Writer, report BindingInspectionReport) error {
 	report = normalizeBindingInspectionReport(report)
@@ -295,9 +395,57 @@ func WriteBindingInspectionReport(w io.Writer, output string, report BindingInsp
 		return writeBindingInspectionReportText(w, report)
 	case outputJSON:
 		return writeBindingInspectionReportJSON(w, report)
+	case outputYAML:
+		return writeBindingInspectionReportYAML(w, report)
+	case outputMarkdown:
+		return writeBindingInspectionReportMarkdown(w, report)
 	default:
 		return fmt.Errorf("invalid binding inspection output %q", output)
 	}
+}
+
+func appendMarkdownLine(builder *strings.Builder, format string, args ...any) {
+	_, _ = fmt.Fprintf(builder, format, args...)
+	_ = builder.WriteByte('\n')
+}
+
+func appendMarkdownTable(builder *strings.Builder, headers []string, rows [][]string) {
+	appendMarkdownLine(builder, "| %s |", strings.Join(markdownEscapedCells(headers), " | "))
+	separators := make([]string, len(headers))
+	for i := range separators {
+		separators[i] = "---"
+	}
+	appendMarkdownLine(builder, "| %s |", strings.Join(separators, " | "))
+	for _, row := range rows {
+		appendMarkdownLine(builder, "| %s |", strings.Join(markdownEscapedCells(row), " | "))
+	}
+}
+
+func markdownEscapedCells(values []string) []string {
+	escaped := make([]string, len(values))
+	for i, value := range values {
+		escaped[i] = markdownEscapeCell(value)
+	}
+	return escaped
+}
+
+func markdownEscapeCell(value string) string {
+	value = strings.ReplaceAll(value, "\\", "\\\\")
+	value = strings.ReplaceAll(value, "|", "\\|")
+	value = strings.ReplaceAll(value, "\r\n", "<br>")
+	value = strings.ReplaceAll(value, "\n", "<br>")
+	return value
+}
+
+func markdownTargetRefs(refs []BindingInspectionTargetRef) string {
+	if len(refs) == 0 {
+		return "none"
+	}
+	values := make([]string, 0, len(refs))
+	for i := range refs {
+		values = append(values, textTargetRef(&refs[i]))
+	}
+	return strings.Join(values, "<br>")
 }
 
 func appendTextLine(builder *strings.Builder, format string, args ...any) {

--- a/internal/inspection/report_test.go
+++ b/internal/inspection/report_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 func TestBindingInspectionReportJSONMinimalShape(t *testing.T) {
@@ -291,6 +292,84 @@ func TestWriteBindingInspectionReportJSONWritesCompactJSONWithNewline(t *testing
 	}
 }
 
+func TestWriteBindingInspectionReportYAMLMatchesCanonicalJSON(t *testing.T) {
+	report := representativeBindingInspectionReport()
+
+	var out bytes.Buffer
+	if err := WriteBindingInspectionReport(&out, outputYAML, report); err != nil {
+		t.Fatalf("write yaml report: %v", err)
+	}
+	if got := out.String(); got == "" || got[len(got)-1] != '\n' {
+		t.Fatalf("expected newline-terminated YAML, got %q", got)
+	}
+
+	yamlAsJSON, err := yaml.YAMLToJSON(out.Bytes())
+	if err != nil {
+		t.Fatalf("convert YAML to JSON: %v\n%s", err, out.String())
+	}
+	assertJSONEquivalent(t, yamlAsJSON, canonicalReportJSON(t, report))
+}
+
+func TestWriteBindingInspectionReportYAMLReturnsWriterError(t *testing.T) {
+	wantErr := errors.New("write failed")
+	err := WriteBindingInspectionReport(errWriter{err: wantErr}, outputYAML, NewBindingInspectionReport())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected writer error %v, got %v", wantErr, err)
+	}
+}
+
+func TestWriteBindingInspectionReportMarkdownRepresentativeReport(t *testing.T) {
+	report := representativeBindingInspectionReport()
+
+	var out bytes.Buffer
+	if err := WriteBindingInspectionReport(&out, outputMarkdown, report); err != nil {
+		t.Fatalf("write markdown report: %v", err)
+	}
+	markdown := out.String()
+	for _, want := range []string{
+		"# BindingInspectionReport",
+		"## Summary",
+		"| Status | Warning |",
+		"| Findings | 1 |",
+		"| Drift | 1 |",
+		"| Eligible workloads | 1 |",
+		"| Inspection completeness | partial |",
+		"## Binding",
+		"| Name | tenant-a/binding-a |",
+		"## Identity",
+		"| ClusterSPIFFEID | tenant-a-binding-a-1234abcd |",
+		"## Findings",
+		"| observed-drift | warning | ObservedDrift | observed managed ClusterSPIFFEID state differs from desired state | none |",
+		"## Capabilities",
+		"<summary>Canonical JSON report</summary>",
+		"```json",
+	} {
+		if !strings.Contains(markdown, want) {
+			t.Fatalf("markdown output missing %q\n%s", want, markdown)
+		}
+	}
+
+	assertJSONEquivalent(t, []byte(extractCanonicalJSONBlock(t, markdown)), canonicalReportJSON(t, report))
+}
+
+func TestWriteBindingInspectionReportMarkdownEmptyFindings(t *testing.T) {
+	var out bytes.Buffer
+	if err := WriteBindingInspectionReport(&out, outputMarkdown, NewBindingInspectionReport()); err != nil {
+		t.Fatalf("write markdown report: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "No findings.") {
+		t.Fatalf("expected empty findings markdown, got:\n%s", got)
+	}
+}
+
+func TestWriteBindingInspectionReportMarkdownReturnsWriterError(t *testing.T) {
+	wantErr := errors.New("write failed")
+	err := WriteBindingInspectionReport(errWriter{err: wantErr}, outputMarkdown, NewBindingInspectionReport())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected writer error %v, got %v", wantErr, err)
+	}
+}
+
 func TestWriteBindingInspectionReportTextRepresentativeReport(t *testing.T) {
 	fallbackFalse := false
 	report := BindingInspectionReport{
@@ -549,4 +628,114 @@ func assertObjectKeys(t *testing.T, value any, want ...string) {
 	if got := sortedKeys(object); !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected object keys (-want +got):\nwant %v\ngot  %v", want, got)
 	}
+}
+
+func representativeBindingInspectionReport() BindingInspectionReport {
+	fallbackFalse := false
+	return BindingInspectionReport{
+		GeneratedAt: "2026-05-18T09:10:11Z",
+		BindingRef: BindingInspectionBindingRef{
+			Namespace:  "tenant-a",
+			Name:       "binding-a",
+			Generation: 7,
+			Mode:       "PerObjective",
+			PoolRef: &BindingInspectionTargetRef{
+				Namespace: "tenant-a",
+				Name:      "pool-a",
+				Group:     "inference.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "InferencePool",
+			},
+			ObjectiveRef: &BindingInspectionTargetRef{
+				Namespace: "tenant-a",
+				Name:      "objective-a",
+				Group:     "inference.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "InferenceObjective",
+			},
+		},
+		Desired: BindingInspectionDesiredState{
+			ClusterSPIFFEIDName: "tenant-a-binding-a-1234abcd",
+			SPIFFEID:            "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
+			PodSelector:         map[string]any{"matchLabels": map[string]any{"app": "pool-a"}},
+			WorkloadSelectors:   []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
+			Hint:                "tenant-a/binding-a",
+			Fallback:            &fallbackFalse,
+		},
+		Observed: BindingInspectionObservedState{
+			ManagedClusterSPIFFEIDs: []BindingInspectionManagedClusterSPIFFEID{{
+				Name:              "tenant-a-binding-a-1234abcd",
+				SPIFFEID:          "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
+				PodSelector:       map[string]any{"matchLabels": map[string]any{"app": "pool-a"}},
+				WorkloadSelectors: []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
+				Hint:              "tenant-a/binding-a",
+				Fallback:          &fallbackFalse,
+			}},
+			Drift: []BindingInspectionDriftEntry{{
+				Field:    "spec.workloadSelectorTemplates",
+				Desired:  "k8s:container-name:model-server",
+				Observed: "k8s:container-name:old-server",
+			}},
+			EligibleWorkloads: []BindingInspectionEligibleWorkload{{
+				Namespace: "tenant-a",
+				Pod:       "pool-a-12345",
+				Container: "model-server",
+			}},
+		},
+		Findings: []BindingInspectionFinding{{
+			ID:       findingObservedDrift,
+			Severity: BindingInspectionFindingSeverityWarning,
+			Reason:   reasonObservedDrift,
+			Message:  "observed managed ClusterSPIFFEID state differs from desired state",
+		}},
+		Capabilities: BindingInspectionCapabilities{
+			Binding:          BindingInspectionCapabilityFull,
+			GAIEResources:    BindingInspectionCapabilityFull,
+			ClusterSPIFFEIDs: BindingInspectionCapabilityFull,
+			PeerBindings:     BindingInspectionCapabilityPartial,
+			Pods:             BindingInspectionCapabilitySkipped,
+		},
+	}
+}
+
+func canonicalReportJSON(t *testing.T, report BindingInspectionReport) []byte {
+	t.Helper()
+
+	data, err := json.Marshal(normalizeBindingInspectionReport(report))
+	if err != nil {
+		t.Fatalf("marshal canonical report: %v", err)
+	}
+	return data
+}
+
+func assertJSONEquivalent(t *testing.T, gotJSON []byte, wantJSON []byte) {
+	t.Helper()
+
+	var got any
+	if err := json.Unmarshal(gotJSON, &got); err != nil {
+		t.Fatalf("unmarshal got JSON: %v\n%s", err, string(gotJSON))
+	}
+	var want any
+	if err := json.Unmarshal(wantJSON, &want); err != nil {
+		t.Fatalf("unmarshal want JSON: %v\n%s", err, string(wantJSON))
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("JSON mismatch (-want +got):\nwant %s\ngot  %s", string(wantJSON), string(gotJSON))
+	}
+}
+
+func extractCanonicalJSONBlock(t *testing.T, markdown string) string {
+	t.Helper()
+
+	const startMarker = "```json\n"
+	start := strings.LastIndex(markdown, startMarker)
+	if start == -1 {
+		t.Fatalf("markdown missing canonical JSON block:\n%s", markdown)
+	}
+	start += len(startMarker)
+	end := strings.Index(markdown[start:], "\n```")
+	if end == -1 {
+		t.Fatalf("markdown missing canonical JSON closing fence:\n%s", markdown)
+	}
+	return markdown[start : start+end]
 }


### PR DESCRIPTION
## Summary

- Add `yaml` and `markdown` as supported `kleym inspect binding --output` formats.
- Keep JSON as the stable automation contract while deriving YAML and Markdown from the same normalized report data.

## What I Changed And Why

- Documented the new output modes in `docs/spec/cli.md`, including stability expectations for JSON, YAML, text, and Markdown.
- Added CLI output validation for `text|json|yaml|markdown` and updated invalid-output tests to use `xml`.
- Added YAML rendering through `sigs.k8s.io/yaml` from normalized JSON data.
- Added Markdown rendering for documentation and PR comments, including a canonical JSON details block.
- Added focused CLI and inspection report tests proving YAML and Markdown stay tied to canonical report data.

## Related Issue

- Fixes #156

## Scope Check

- This PR follows the issue instructions explicitly: it adds YAML and Markdown output formats without changing the core `BindingInspectionReport` schema.
- Left out graph output, advanced diagnostics, new inspection commands, and release packaging because they are out of scope for the issue.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because this is CLI output behavior only.
- CLI Spec (`docs/spec/cli.md`): updated to document the new output modes and output contract.
- Other docs: not needed because the README and contributor workflow are unchanged.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `go test ./internal/cli ./internal/inspection`
  - `go test ./...`
  - `make lint`
  - `make docs-build`
- Tests not run and why: `make test-e2e-chainsaw` was not run because this change does not affect cluster reconciliation behavior.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.
- GitHub issue and PR text were treated as untrusted context; no untrusted instructions were executed.