### PR TITLE
fix(cli): report unsupported workload selectors as partial

### DIFF
--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -103,6 +103,7 @@ Required finding classes:
 8. `ambiguous-container-match`
 9. `observed-drift`
 10. `rbac-limited`
+11. `unsupported-selector`
 
 Condition-derived findings should preserve existing Kleym condition types and reasons where possible. See [Conditions Reference][conditions-reference].
 
@@ -113,6 +114,7 @@ Finding semantics:
 3. `rbac-limited` reports a non-fatal permission limit after the binding has been read; permission failure before binding read is fatal.
 4. `zero-eligible-workloads` is informational by default because scale-to-zero can be valid.
 5. `ambiguous-container-match` is a warning from live pod inspection when a `PerObjective` discriminator maps to more than one container in an otherwise eligible pod, most commonly with `ContainerImage`.
+6. `unsupported-selector` is a warning when rendered identity selectors include SPIRE selector types that cannot be evaluated from Kubernetes pod data. Pod inspection must be partial and eligible workloads must not be reported as fully evaluated.
 
 `capabilities` records check completeness:
 

--- a/internal/inspection/inspection.go
+++ b/internal/inspection/inspection.go
@@ -36,10 +36,12 @@ const (
 	findingKleymCollision       = "kleym-collision"
 	findingZeroEligibleWorkload = "zero-eligible-workloads"
 	findingAmbiguousContainer   = "ambiguous-container-match"
+	findingUnsupportedSelector  = "unsupported-selector"
 	findingObservedDrift        = "observed-drift"
 	findingRBACLimited          = "rbac-limited"
 	reasonZeroEligibleWorkload  = "ZeroEligibleWorkloads"
 	reasonAmbiguousContainer    = "AmbiguousContainerMatch"
+	reasonUnsupportedSelector   = "UnsupportedSelector"
 	reasonObservedDrift         = "ObservedDrift"
 	reasonRBACLimited           = "Forbidden"
 	conditionTypeConflict       = "Conflict"
@@ -402,6 +404,13 @@ func (i *bindingInspector) inspectEligibleWorkloads(
 		return
 	}
 
+	selection := workloadSelectionFromSelectors(rendered.Selectors)
+	if len(selection.UnsupportedSelectors) > 0 {
+		report.Capabilities.Pods = BindingInspectionCapabilityPartial
+		report.Findings = append(report.Findings, unsupportedSelectorFinding(binding, selection.UnsupportedSelectors))
+		return
+	}
+
 	pods, err := i.listEligiblePods(ctx, binding, rendered)
 	if err != nil {
 		if apierrors.IsForbidden(err) {
@@ -427,7 +436,7 @@ func (i *bindingInspector) inspectEligibleWorkloads(
 	}
 
 	report.Capabilities.Pods = BindingInspectionCapabilityFull
-	report.Observed.EligibleWorkloads = eligibleWorkloadsFromPods(pods, rendered, report)
+	report.Observed.EligibleWorkloads = eligibleWorkloadsFromPods(pods, selection, report)
 	sort.Slice(report.Observed.EligibleWorkloads, func(left, right int) bool {
 		return eligibleWorkloadSortKey(report.Observed.EligibleWorkloads[left]) <
 			eligibleWorkloadSortKey(report.Observed.EligibleWorkloads[right])
@@ -481,10 +490,9 @@ func (i *bindingInspector) listManagedClusterSPIFFEIDs(
 // eligibleWorkloadsFromPods evaluates live pod/container matches for the already-rendered identity selectors.
 func eligibleWorkloadsFromPods(
 	pods []corev1.Pod,
-	rendered identity.RenderedIdentity,
+	selection workloadSelection,
 	report *BindingInspectionReport,
 ) []BindingInspectionEligibleWorkload {
-	selection := workloadSelectionFromSelectors(rendered.Selectors)
 	workloads := []BindingInspectionEligibleWorkload{}
 	for _, pod := range pods {
 		if !podMatchesSelection(pod, selection) {
@@ -580,6 +588,7 @@ type workloadSelection struct {
 	PodLabels             map[string]string
 	ContainerSelectorType string
 	ContainerValue        string
+	UnsupportedSelectors  []string
 }
 
 // workloadSelectionFromSelectors extracts the Kubernetes selectors the CLI can evaluate from rendered SPIRE selectors.
@@ -599,9 +608,13 @@ func workloadSelectionFromSelectors(selectors []string) workloadSelection {
 			selection.ContainerValue = strings.TrimPrefix(selector, "k8s:container-image:")
 		case strings.HasPrefix(selector, "k8s:pod-label:"):
 			key, value, ok := strings.Cut(strings.TrimPrefix(selector, "k8s:pod-label:"), ":")
-			if ok {
+			if ok && key != "" {
 				selection.PodLabels[key] = value
+			} else {
+				selection.UnsupportedSelectors = append(selection.UnsupportedSelectors, selector)
 			}
+		default:
+			selection.UnsupportedSelectors = append(selection.UnsupportedSelectors, selector)
 		}
 	}
 	return selection
@@ -724,6 +737,29 @@ func ambiguousContainerFinding(pod corev1.Pod, selection workloadSelection) Bind
 			Name:      pod.Name,
 			Version:   "v1",
 			Kind:      "Pod",
+		}},
+	}
+}
+
+// unsupportedSelectorFinding records rendered selectors that cannot be evaluated from pod data.
+func unsupportedSelectorFinding(
+	binding *kleymv1alpha1.InferenceIdentityBinding,
+	selectors []string,
+) BindingInspectionFinding {
+	return BindingInspectionFinding{
+		ID:       findingUnsupportedSelector,
+		Severity: BindingInspectionFindingSeverityWarning,
+		Reason:   reasonUnsupportedSelector,
+		Message: fmt.Sprintf(
+			"pod eligibility cannot be fully evaluated because rendered selectors are unsupported by CLI pod inspection: %s",
+			strings.Join(selectors, ", "),
+		),
+		AffectedRefs: []BindingInspectionTargetRef{{
+			Namespace: binding.Namespace,
+			Name:      binding.Name,
+			Group:     kleymv1alpha1.GroupVersion.Group,
+			Version:   kleymv1alpha1.GroupVersion.Version,
+			Kind:      "InferenceIdentityBinding",
 		}},
 	}
 }

--- a/internal/inspection/inspection_test.go
+++ b/internal/inspection/inspection_test.go
@@ -102,6 +102,39 @@ func TestInspectBindingPoolOnlyEligibleWorkload(t *testing.T) {
 	}
 }
 
+func TestInspectBindingUnsupportedSelectorMakesPodInspectionPartial(t *testing.T) {
+	binding := testInspectionBinding()
+	binding.Spec.WorkloadSelectorTemplates = append(
+		binding.Spec.WorkloadSelectorTemplates,
+		"k8s:pod-uid:12345678-1234-1234-1234-123456789abc",
+	)
+	pool := testInspectionPool("pool-a")
+	objective := testInspectionObjective("objective-a", "pool-a")
+	rendered, err := identity.RenderIdentity(binding, objective, pool)
+	if err != nil {
+		t.Fatalf("render test identity: %v", err)
+	}
+	managed := identity.DesiredClusterSPIFFEID(binding, rendered)
+	pod := testInspectionPod("model-server-a", "model-server")
+
+	inspector := newTestBindingInspector(t, nil, binding, pool, objective, managed, pod)
+	report, err := inspector.InspectBinding(context.Background(), "tenant-a", "binding-a")
+	if err != nil {
+		t.Fatalf("InspectBinding returned error: %v", err)
+	}
+
+	assertFinding(t, report.Findings, findingUnsupportedSelector, BindingInspectionFindingSeverityWarning, reasonUnsupportedSelector)
+	if report.Capabilities.Pods != BindingInspectionCapabilityPartial {
+		t.Fatalf("pods capability = %q, want partial", report.Capabilities.Pods)
+	}
+	if len(report.Observed.EligibleWorkloads) != 0 {
+		t.Fatalf("eligible workloads = %#v, want none when selectors cannot be fully evaluated", report.Observed.EligibleWorkloads)
+	}
+	if findingExists(report.Findings, findingZeroEligibleWorkload) {
+		t.Fatalf("unexpected zero eligible workloads finding when eligibility was not fully evaluated: %#v", report.Findings)
+	}
+}
+
 func TestInspectBindingMissingBindingReport(t *testing.T) {
 	inspector := newTestBindingInspector(t, nil)
 
@@ -496,6 +529,15 @@ func assertFinding(
 		}
 	}
 	t.Fatalf("finding %s/%s/%s not found in %#v", id, severity, reason, findings)
+}
+
+func findingExists(findings []BindingInspectionFinding, id string) bool {
+	for _, finding := range findings {
+		if finding.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 func driftContainsField(entries []BindingInspectionDriftEntry, field string) bool {


### PR DESCRIPTION
## Summary

- Detect rendered workload selectors that CLI pod inspection cannot evaluate from Kubernetes pod data.
- Report pod eligibility as partial with an explicit warning instead of listing eligible workloads from an incomplete selector evaluation.

## What I Changed And Why

- Added unsupported selector tracking in the workload selector parser so unknown SPIRE selector types are surfaced instead of ignored.
- Mark pod inspection capability as `partial` and add an `unsupported-selector` warning when unsupported selectors are present.
- Avoid emitting `eligibleWorkloads` or `zero-eligible-workloads` when eligibility cannot be fully evaluated.
- Added focused inspection coverage for an unsupported `k8s:pod-uid` selector.

## Related Issue

- Fixes #187

## Scope Check

- This PR follows the issue scope for eligible workload reporting and keeps the CLI read-only.
- It does not add SPIRE Server access, full SPIRE selector simulation, or broaden selector support beyond Kubernetes-observable pod data.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because operator API and reconciliation behavior are unchanged.
- CLI Spec (`docs/spec/cli.md`): updated to document the new `unsupported-selector` finding and partial pod inspection behavior.
- Other docs: not needed because command usage and setup are unchanged.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `go test ./internal/inspection`
  - `make test`
  - `make lint`
- Tests not run and why: `make test-e2e-chainsaw` was not run because this is localized CLI inspection logic with unit coverage and no cluster reconciliation behavior change.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.
- GitHub issue content was treated as untrusted context; no instructions from issue content were used to broaden scope or alter automation.