### PR TITLE
fix(cli): avoid overstating eligible workload matches

### DIFF
--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -103,6 +103,7 @@ Required finding classes:
 8. `ambiguous-container-match`
 9. `observed-drift`
 10. `rbac-limited`
+11. `unsupported-selector`
 
 Condition-derived findings should preserve existing Kleym condition types and reasons where possible. See [Conditions Reference][conditions-reference].
 
@@ -113,6 +114,7 @@ Finding semantics:
 3. `rbac-limited` reports a non-fatal permission limit after the binding has been read; permission failure before binding read is fatal.
 4. `zero-eligible-workloads` is informational by default because scale-to-zero can be valid.
 5. `ambiguous-container-match` is a warning from live pod inspection when a `PerObjective` discriminator maps to more than one container in an otherwise eligible pod, most commonly with `ContainerImage`.
+6. `unsupported-selector` is a warning when rendered workload selectors include SPIRE selectors that `kleym` cannot evaluate from Kubernetes pod data; pod inspection must be partial and eligible workloads must not be guessed.
 
 `capabilities` records check completeness:
 

--- a/internal/inspection/inspection.go
+++ b/internal/inspection/inspection.go
@@ -38,10 +38,12 @@ const (
 	findingAmbiguousContainer   = "ambiguous-container-match"
 	findingObservedDrift        = "observed-drift"
 	findingRBACLimited          = "rbac-limited"
+	findingUnsupportedSelector  = "unsupported-selector"
 	reasonZeroEligibleWorkload  = "ZeroEligibleWorkloads"
 	reasonAmbiguousContainer    = "AmbiguousContainerMatch"
 	reasonObservedDrift         = "ObservedDrift"
 	reasonRBACLimited           = "Forbidden"
+	reasonUnsupportedSelector   = "UnsupportedWorkloadSelector"
 	conditionTypeConflict       = "Conflict"
 	clusterSPIFFEIDResourceName = "clusterspiffeids"
 	podResourceName             = "pods"
@@ -402,6 +404,13 @@ func (i *bindingInspector) inspectEligibleWorkloads(
 		return
 	}
 
+	selection := workloadSelectionFromSelectors(rendered.Selectors)
+	if len(selection.UnevaluatedSelectors) > 0 {
+		report.Capabilities.Pods = BindingInspectionCapabilityPartial
+		report.Findings = append(report.Findings, unsupportedSelectorFinding(binding, selection.UnevaluatedSelectors))
+		return
+	}
+
 	pods, err := i.listEligiblePods(ctx, binding, rendered)
 	if err != nil {
 		if apierrors.IsForbidden(err) {
@@ -427,7 +436,7 @@ func (i *bindingInspector) inspectEligibleWorkloads(
 	}
 
 	report.Capabilities.Pods = BindingInspectionCapabilityFull
-	report.Observed.EligibleWorkloads = eligibleWorkloadsFromPods(pods, rendered, report)
+	report.Observed.EligibleWorkloads = eligibleWorkloadsFromPods(pods, selection, report)
 	sort.Slice(report.Observed.EligibleWorkloads, func(left, right int) bool {
 		return eligibleWorkloadSortKey(report.Observed.EligibleWorkloads[left]) <
 			eligibleWorkloadSortKey(report.Observed.EligibleWorkloads[right])
@@ -481,10 +490,9 @@ func (i *bindingInspector) listManagedClusterSPIFFEIDs(
 // eligibleWorkloadsFromPods evaluates live pod/container matches for the already-rendered identity selectors.
 func eligibleWorkloadsFromPods(
 	pods []corev1.Pod,
-	rendered identity.RenderedIdentity,
+	selection workloadSelection,
 	report *BindingInspectionReport,
 ) []BindingInspectionEligibleWorkload {
-	selection := workloadSelectionFromSelectors(rendered.Selectors)
 	workloads := []BindingInspectionEligibleWorkload{}
 	for _, pod := range pods {
 		if !podMatchesSelection(pod, selection) {
@@ -580,6 +588,7 @@ type workloadSelection struct {
 	PodLabels             map[string]string
 	ContainerSelectorType string
 	ContainerValue        string
+	UnevaluatedSelectors  []string
 }
 
 // workloadSelectionFromSelectors extracts the Kubernetes selectors the CLI can evaluate from rendered SPIRE selectors.
@@ -599,9 +608,13 @@ func workloadSelectionFromSelectors(selectors []string) workloadSelection {
 			selection.ContainerValue = strings.TrimPrefix(selector, "k8s:container-image:")
 		case strings.HasPrefix(selector, "k8s:pod-label:"):
 			key, value, ok := strings.Cut(strings.TrimPrefix(selector, "k8s:pod-label:"), ":")
-			if ok {
+			if ok && key != "" {
 				selection.PodLabels[key] = value
+			} else {
+				selection.UnevaluatedSelectors = append(selection.UnevaluatedSelectors, selector)
 			}
+		default:
+			selection.UnevaluatedSelectors = append(selection.UnevaluatedSelectors, selector)
 		}
 	}
 	return selection
@@ -724,6 +737,29 @@ func ambiguousContainerFinding(pod corev1.Pod, selection workloadSelection) Bind
 			Name:      pod.Name,
 			Version:   "v1",
 			Kind:      "Pod",
+		}},
+	}
+}
+
+// unsupportedSelectorFinding records that live pod data cannot prove rendered selector eligibility.
+func unsupportedSelectorFinding(
+	binding *kleymv1alpha1.InferenceIdentityBinding,
+	selectors []string,
+) BindingInspectionFinding {
+	return BindingInspectionFinding{
+		ID:       findingUnsupportedSelector,
+		Severity: BindingInspectionFindingSeverityWarning,
+		Reason:   reasonUnsupportedSelector,
+		Message: fmt.Sprintf(
+			"eligible workload evaluation cannot evaluate rendered workload selectors from Kubernetes pod data: %s",
+			strings.Join(selectors, ", "),
+		),
+		AffectedRefs: []BindingInspectionTargetRef{{
+			Namespace: binding.Namespace,
+			Name:      binding.Name,
+			Group:     kleymv1alpha1.GroupVersion.Group,
+			Version:   kleymv1alpha1.GroupVersion.Version,
+			Kind:      "InferenceIdentityBinding",
 		}},
 	}
 }

--- a/internal/inspection/inspection_test.go
+++ b/internal/inspection/inspection_test.go
@@ -102,6 +102,33 @@ func TestInspectBindingPoolOnlyEligibleWorkload(t *testing.T) {
 	}
 }
 
+func TestInspectBindingUnsupportedSelectorPartialPods(t *testing.T) {
+	binding := testInspectionBinding()
+	binding.Spec.WorkloadSelectorTemplates = append(binding.Spec.WorkloadSelectorTemplates, "k8s:node-name:worker-a")
+	pool := testInspectionPool("pool-a")
+	objective := testInspectionObjective("objective-a", "pool-a")
+	rendered, err := identity.RenderIdentity(binding, objective, pool)
+	if err != nil {
+		t.Fatalf("render test identity: %v", err)
+	}
+	managed := identity.DesiredClusterSPIFFEID(binding, rendered)
+	pod := testInspectionPod("model-server-a", "model-server")
+
+	inspector := newTestBindingInspector(t, nil, binding, pool, objective, managed, pod)
+	report, err := inspector.InspectBinding(context.Background(), "tenant-a", "binding-a")
+	if err != nil {
+		t.Fatalf("InspectBinding returned error: %v", err)
+	}
+
+	assertFinding(t, report.Findings, findingUnsupportedSelector, BindingInspectionFindingSeverityWarning, reasonUnsupportedSelector)
+	if report.Capabilities.Pods != BindingInspectionCapabilityPartial {
+		t.Fatalf("pods capability = %q, want partial", report.Capabilities.Pods)
+	}
+	if len(report.Observed.EligibleWorkloads) != 0 {
+		t.Fatalf("eligible workloads = %#v, want none for incomplete selector evaluation", report.Observed.EligibleWorkloads)
+	}
+}
+
 func TestInspectBindingMissingBindingReport(t *testing.T) {
 	inspector := newTestBindingInspector(t, nil)
 


### PR DESCRIPTION
## Summary

- Add an explicit `unsupported-selector` warning when rendered workload selectors cannot be evaluated from Kubernetes pod data.
- Mark pod inspection partial and suppress eligible workload guesses when unevaluated selectors are present.
- Document the new CLI finding class and cover it with inspection tests.

## What I Changed And Why

- `internal/inspection/inspection.go` now records unevaluated selectors while parsing rendered SPIRE selectors and stops eligible workload evaluation before listing or reporting pods when any are present.
- The finding points at the inspected `InferenceIdentityBinding` so users can see why eligibility is incomplete without implying the CLI fully simulated SPIRE matching.
- The new test covers a binding with an extra rendered selector (`k8s:node-name`) that cannot be evaluated by the current pod-data inspection path.

## Related Issue

- Fixes #187

## Scope Check

- This PR follows the issue scope by keeping the CLI read-only, avoiding direct SPIRE Server access, and reporting incomplete evaluation instead of guessing eligible workloads.
- Left out full SPIRE selector simulation and support for additional selector families because those are outside the issue scope.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because operator API and reconciliation behavior are unchanged.
- CLI Spec (`docs/spec/cli.md`): updated to define `unsupported-selector` semantics.
- Other docs: not needed because the behavior is covered by the CLI spec.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `go test ./internal/inspection`
  - `make test`
  - `make lint`
- Tests not run and why: none.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.
- GitHub issue content was treated as untrusted context; no instructions from issue content were used to broaden scope, execute arbitrary commands, or weaken CI/security behavior.