### PR TITLE
fix(cli): suppress reports for fatal inspect failures

### DIFF
--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -47,10 +47,16 @@ func newInspectCommand(opts *Options) *cobra.Command {
 			defer cancel()
 
 			report, inspectErr := inspector.InspectBinding(ctx, opts.Namespace, args[0])
-			if err := inspection.WriteBindingInspectionReport(cmd.OutOrStdout(), opts.Output, report); err != nil {
-				return withExitCode(exitInternal, err)
-			}
 			code, err := inspectionExitCode(report, inspectErr, opts.Strict)
+			if !shouldWriteBindingInspectionReport(inspectErr) {
+				if err != nil {
+					return withExitCode(code, err)
+				}
+				return nil
+			}
+			if writeErr := inspection.WriteBindingInspectionReport(cmd.OutOrStdout(), opts.Output, report); writeErr != nil {
+				return withExitCode(exitInternal, writeErr)
+			}
 			if err != nil {
 				return withExitCode(code, err)
 			}
@@ -60,6 +66,14 @@ func newInspectCommand(opts *Options) *cobra.Command {
 
 	inspectCmd.AddCommand(bindingCmd)
 	return inspectCmd
+}
+
+func shouldWriteBindingInspectionReport(inspectErr error) bool {
+	if inspectErr == nil {
+		return true
+	}
+	return errors.Is(inspectErr, inspection.ErrBindingInspectionNotFound) ||
+		errors.Is(inspectErr, inspection.ErrBindingInspectionErrorFindings)
 }
 
 func inspectionExitCode(report inspection.BindingInspectionReport, inspectErr error, strict bool) (int, error) {

--- a/internal/cli/inspect_test.go
+++ b/internal/cli/inspect_test.go
@@ -172,6 +172,134 @@ func TestInspectBindingDefaultTextUsesRunner(t *testing.T) {
 	}
 }
 
+func TestInspectBindingFatalErrorDoesNotWriteReport(t *testing.T) {
+	originalFactory := newBindingInspectionRunner
+	t.Cleanup(func() { newBindingInspectionRunner = originalFactory })
+
+	fakeReport := inspection.NewBindingInspectionReport()
+	fakeReport.GeneratedAt = "2026-05-18T10:11:12Z"
+	wantErr := errors.New("discover served GAIE resources")
+	newBindingInspectionRunner = func(_ *Options) (inspection.BindingInspector, error) {
+		return fixedInspectionRunner{report: fakeReport, err: wantErr}, nil
+	}
+
+	cmd := NewRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"inspect", "binding", "binding-a", "-n", "tenant-a", "-o", "json"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected inspect binding to return an error")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := codeForError(err); got != exitUsage {
+		t.Fatalf("exit code = %d, want %d", got, exitUsage)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout for fatal inspection error, got:\n%s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr, got:\n%s", stderr.String())
+	}
+}
+
+func TestInspectBindingNotFoundWritesReport(t *testing.T) {
+	originalFactory := newBindingInspectionRunner
+	t.Cleanup(func() { newBindingInspectionRunner = originalFactory })
+
+	fakeReport := inspection.NewBindingInspectionReport()
+	fakeReport.GeneratedAt = "2026-05-18T10:11:12Z"
+	fakeReport.BindingRef = inspection.BindingInspectionBindingRef{Namespace: "tenant-a", Name: "missing"}
+	fakeReport.Findings = []inspection.BindingInspectionFinding{{
+		ID:       "binding-not-found",
+		Severity: inspection.BindingInspectionFindingSeverityError,
+		Reason:   "NotFound",
+		Message:  "missing",
+	}}
+	newBindingInspectionRunner = func(_ *Options) (inspection.BindingInspector, error) {
+		return fixedInspectionRunner{report: fakeReport, err: inspection.ErrBindingInspectionNotFound}, nil
+	}
+
+	cmd := NewRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"inspect", "binding", "missing", "-n", "tenant-a", "-o", "json"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected inspect binding to return an error")
+	}
+	if !errors.Is(err, inspection.ErrBindingInspectionNotFound) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := codeForError(err); got != exitBindingNotFound {
+		t.Fatalf("exit code = %d, want %d", got, exitBindingNotFound)
+	}
+	var got inspection.BindingInspectionReport
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal inspect output: %v\n%s", err, stdout.String())
+	}
+	if got.BindingRef.Name != "missing" || len(got.Findings) != 1 || got.Findings[0].ID != "binding-not-found" {
+		t.Fatalf("unexpected binding-not-found report: %#v", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr, got:\n%s", stderr.String())
+	}
+}
+
+func TestInspectBindingErrorFindingsWriteReport(t *testing.T) {
+	originalFactory := newBindingInspectionRunner
+	t.Cleanup(func() { newBindingInspectionRunner = originalFactory })
+
+	fakeReport := inspection.NewBindingInspectionReport()
+	fakeReport.GeneratedAt = "2026-05-18T10:11:12Z"
+	fakeReport.BindingRef = inspection.BindingInspectionBindingRef{Namespace: "tenant-a", Name: "binding-a"}
+	fakeReport.Findings = []inspection.BindingInspectionFinding{{
+		ID:       "dependency-missing",
+		Severity: inspection.BindingInspectionFindingSeverityError,
+		Reason:   "TargetPoolNotFound",
+		Message:  "pool missing",
+	}}
+	newBindingInspectionRunner = func(_ *Options) (inspection.BindingInspector, error) {
+		return fixedInspectionRunner{report: fakeReport, err: inspection.ErrBindingInspectionErrorFindings}, nil
+	}
+
+	cmd := NewRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"inspect", "binding", "binding-a", "-n", "tenant-a", "-o", "json"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected inspect binding to return an error")
+	}
+	if !errors.Is(err, errInspectBindingHasErrorFindings) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := codeForError(err); got != exitInspectionIssue {
+		t.Fatalf("exit code = %d, want %d", got, exitInspectionIssue)
+	}
+	var got inspection.BindingInspectionReport
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal inspect output: %v\n%s", err, stdout.String())
+	}
+	if got.BindingRef.Name != "binding-a" || len(got.Findings) != 1 || got.Findings[0].ID != "dependency-missing" {
+		t.Fatalf("unexpected error findings report: %#v", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr, got:\n%s", stderr.String())
+	}
+}
+
 func TestInspectionExitCodeMapping(t *testing.T) {
 	setupErr := errors.New("load Kubernetes config")
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Classify `kleym inspect binding` inspection errors before serializing output so fatal pre-read failures do not emit scaffold reports.
- Preserve report output for completed inspections with error findings and explicit `binding-not-found` reports.

## What I Changed And Why

- Moved exit-code classification ahead of report serialization in `internal/cli/inspect.go`.
- Added `shouldWriteBindingInspectionReport` so only completed inspections, `binding-not-found`, and completed error-finding reports are serialized.
- Added CLI tests for fatal setup/discovery-style errors, `binding-not-found` output, and completed error-finding output.

## Related Issue

- Fixes #188

## Scope Check

- This follows the issue scope: fatal setup/discovery/connection/permission-style errors before binding read no longer print a normal inspection report.
- Left out changes to inspection semantics, JSON report schema, and Kubernetes inspection logic because the bug is in CLI error/output ordering.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because this is CLI-only output handling.
- CLI Spec (`docs/spec/cli.md`): not needed because the change aligns behavior to the existing fatal failure contract.
- Other docs: not needed because command surface, flags, and documented examples did not change.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `go test ./internal/cli`
  - `make test`
  - `make lint`
- Tests not run and why: e2e tests were not run because this change is limited to CLI output/error handling and is covered by focused CLI unit tests plus `make test`.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.
- GitHub issue content was treated as untrusted input; no commands were run from the issue body.