### PR TITLE
fix(operator): add event recording RBAC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - inference.networking.k8s.io
   - inference.networking.x-k8s.io
   resources:

--- a/internal/controller/inferenceidentitybinding_controller.go
+++ b/internal/controller/inferenceidentitybinding_controller.go
@@ -104,6 +104,8 @@ type InferenceIdentityBindingReconciler struct {
 // +kubebuilder:rbac:groups=inference.networking.k8s.io,resources=inferenceobjectives;inferencepools,verbs=get;list;watch
 // +kubebuilder:rbac:groups=inference.networking.x-k8s.io,resources=inferenceobjectives;inferencepools,verbs=get;list;watch
 // +kubebuilder:rbac:groups=spire.spiffe.io,resources=clusterspiffeids,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile drives the InferenceIdentityBinding toward its desired state.
 //


### PR DESCRIPTION
## Summary

- Add operator RBAC for Kubernetes event recording in workload namespaces.

## What I Changed And Why

- Added kubebuilder RBAC markers for `events.k8s.io/events` and legacy core `events` with `create` and `patch` permissions.
- Regenerated `config/rbac/role.yaml` so deployed operators can emit reconciliation events without forbidden errors.
- Kept the change limited to RBAC because event emission behavior already existed in the controller.

## Related Issue

- Not ticket-driven; no linked issue.

## Scope Check

- This PR addresses the observed operator event-recording RBAC failure only.
- It intentionally does not change reconciliation behavior, event contents, or controller status handling.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because the operator already owns status/events and this only fixes deployment RBAC for existing behavior.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI behavior is unchanged.
- Other docs: not needed because install and user-facing behavior are unchanged.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `make manifests`
  - `make test`
  - `make lint`
  - `git diff --check`
- Tests not run and why: `make test-e2e-chainsaw` was not run because this is a generated RBAC-only fix covered by manifest generation and standard tests.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.
- It grants the operator only the additional Kubernetes event `create` and `patch` permissions needed for its existing event recorder path.