### PR TITLE
fix(operator): make trust domain and ClusterSPIFFEID class configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ IMG ?= ghcr.io/sonda-red/kleym-operator:latest
 VERSION ?= dev
 DOCS_PORT ?= 1313
 HUGO ?= hugo
+TRUST_DOMAIN ?= kleym.sonda.red
+CLUSTERSPIFFEID_CLASS_NAME ?=
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -167,7 +169,7 @@ build: build-operator ## Compatibility alias for build-operator.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/kleym-operator
+	go run ./cmd/kleym-operator --trust-domain="$(TRUST_DOMAIN)" --clusterspiffeid-class-name="$(CLUSTERSPIFFEID_CLASS_NAME)"
 
 # If you wish to build the operator image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Run the controller locally:
 make run
 ```
 
+`make run` defaults to `TRUST_DOMAIN=kleym.sonda.red`. Override it when
+running against a SPIRE install with a different trust domain:
+
+```sh
+make run TRUST_DOMAIN=example.org CLUSTERSPIFFEID_CLASS_NAME=kleym
+```
+
 Install CRDs and deploy the controller:
 
 ```sh

--- a/cmd/kleym-operator/main.go
+++ b/cmd/kleym-operator/main.go
@@ -59,6 +59,8 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var trustDomain string
+	var clusterSPIFFEIDClassName string
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -74,6 +76,10 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics server")
+	flag.StringVar(&trustDomain, "trust-domain", "",
+		"The SPIRE Server trust domain used when rendering all SPIFFE IDs.")
+	flag.StringVar(&clusterSPIFFEIDClassName, "clusterspiffeid-class-name", "",
+		"The optional SPIRE Controller Manager ClusterSPIFFEID className for managed resources.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -81,6 +87,15 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	operatorConfig := controller.OperatorConfig{
+		TrustDomain:              trustDomain,
+		ClusterSPIFFEIDClassName: clusterSPIFFEIDClassName,
+	}
+	if err := operatorConfig.Validate(); err != nil {
+		setupLog.Error(err, "invalid operator configuration")
+		os.Exit(1)
+	}
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
@@ -154,6 +169,7 @@ func main() {
 	if err := (&controller.InferenceIdentityBindingReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
+		Config: operatorConfig,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "InferenceIdentityBinding")
 		os.Exit(1)

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -43,6 +43,7 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
+          - --trust-domain=kleym.sonda.red
         image: controller:latest
         name: operator
         ports: []

--- a/docs/cli/inspection-report.md
+++ b/docs/cli/inspection-report.md
@@ -36,7 +36,7 @@ kleym inspect binding <name> -n <namespace> -o json
 | --- | --- |
 | `bindingRef` | Binding identity, generation, mode, refs, and current conditions. |
 | `resolvedInput` | Resolved GAIE inputs, served GVKs, selector provenance, and container name. |
-| `desired` | Desired `ClusterSPIFFEID` name, SPIFFE ID, selectors, hint, and fallback value. |
+| `desired` | Desired `ClusterSPIFFEID` name, SPIFFE ID, class name, selectors, hint, and fallback value. |
 | `observed` | Managed `ClusterSPIFFEID` resources, status, drift, and eligible workloads when pod reads are available. |
 | `findings` | Typed inspection findings. |
 | `capabilities` | Completeness for each inspection area. |

--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -41,6 +41,15 @@ Inspect one binding:
 bin/kleym inspect binding <name> -n <namespace>
 ```
 
+If the operator was installed with non-default identity settings, pass the same
+values to inspection:
+
+```sh
+bin/kleym inspect binding <name> -n <namespace> \
+  --trust-domain=example.org \
+  --clusterspiffeid-class-name=kleym
+```
+
 Use JSON for automation:
 
 ```sh
@@ -57,6 +66,8 @@ bin/kleym inspect binding <name> -n <namespace> -o json
 | `--context` | Kubeconfig context name. |
 | `--kubeconfig` | Kubeconfig file path. |
 | `--timeout` | Inspection timeout. Must be greater than zero. |
+| `--trust-domain` | Trust domain used to recompute desired SPIFFE IDs. Defaults to `kleym.sonda.red`. |
+| `--clusterspiffeid-class-name` | Optional expected `ClusterSPIFFEID.spec.className`. Defaults to classless output. |
 
 ## Access
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -32,6 +32,13 @@ Run the controller against your current kubeconfig:
 make run
 ```
 
+`make run` supplies `--trust-domain=kleym.sonda.red` by default. Override the
+operator identity settings when your local SPIRE install uses different values:
+
+```sh
+make run TRUST_DOMAIN=example.org CLUSTERSPIFFEID_CLASS_NAME=kleym
+```
+
 Build the operator binary:
 
 ```sh

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -56,10 +56,10 @@ Current validation rules enforced by the CRD:
 
 ## Current Defaults
 
-The controller always renders deterministic SPIFFE IDs:
+The controller always renders deterministic SPIFFE IDs under its configured trust domain:
 
-- `PoolOnly`: `spiffe://kleym.sonda.red/ns/<namespace>/pool/<pool-name>`
-- `PerObjective`: `spiffe://kleym.sonda.red/ns/<namespace>/objective/<objective-name>`
+- `PoolOnly`: `spiffe://<trustDomain>/ns/<namespace>/pool/<pool-name>`
+- `PerObjective`: `spiffe://<trustDomain>/ns/<namespace>/objective/<objective-name>`
 
 When `mode` is omitted, the controller behaves as `PerObjective`.
 

--- a/docs/reference/resources.md
+++ b/docs/reference/resources.md
@@ -18,6 +18,7 @@ resources in `spire.spiffe.io`.
 | `spec.spiffeIDTemplate` | Fully rendered SPIFFE ID. |
 | `spec.podSelector` | Validated selector derived from the referenced pool. |
 | `spec.workloadSelectorTemplates` | Rendered namespace and service-account safety selectors, pool-derived selectors, and the optional per-objective container-name selector. |
+| `spec.className` | Rendered only when `kleym-operator` is configured with `--clusterspiffeid-class-name`. When omitted, SPIRE Controller Manager must watch classless resources. |
 | `spec.fallback` | `false` for all managed identities. |
 | `spec.hint` | Originating binding reference in the form `<namespace>/<binding-name>`. |
 | JWT-SVID-related fields | Not rendered today. Requires a user story and SPIRE Controller Manager/SPIRE version gate. |

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -30,9 +30,14 @@ Supported flags:
 --context
 --kubeconfig
 --timeout
+--trust-domain
+--clusterspiffeid-class-name
 ```
 
 Default namespace is `default`. Default output is `text`. `--timeout` must be greater than zero.
+`--trust-domain` defaults to `kleym.sonda.red` and must follow the same validation rules as
+`kleym-operator --trust-domain`. `--clusterspiffeid-class-name` defaults to empty, matching
+classless `ClusterSPIFFEID` output.
 
 ## Output Contract
 
@@ -75,9 +80,10 @@ Report fields and findings are documented in [Inspection Report][inspection-repo
 
 1. Resolve the binding, `poolRef`, and required or present `objectiveRef`; validate that an objective references the same pool.
 2. Recompute desired identity state with shared Kleym logic.
-3. Evaluate Kleym collision state from peer binding fingerprints when available; otherwise use the inspected binding's current `Conflict` condition and mark peer analysis partial or unknown.
-4. Locate Kleym-managed `ClusterSPIFFEID` resources, compare desired and observed state, and evaluate eligible workloads when pod reads are available.
-5. Emit the report and exit according to finding severity and inspection completeness.
+3. Use the inspection trust domain and optional `ClusterSPIFFEID` class setting when recomputing desired SPIFFE IDs and managed output.
+4. Evaluate Kleym collision state from peer binding fingerprints when available; otherwise use the inspected binding's current `Conflict` condition and mark peer analysis partial or unknown.
+5. Locate Kleym-managed `ClusterSPIFFEID` resources, compare desired and observed state, and evaluate eligible workloads when pod reads are available.
+6. Emit the report and exit according to finding severity and inspection completeness.
 
 `kleym` reports eligibility, not credential use. It reports deterministic Kleym collisions and visible drift; it does not fully simulate SPIRE selection behavior or analyze unrelated non-Kleym `ClusterSPIFFEID` overlap.
 

--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -15,6 +15,19 @@ Kleym does not own inference workloads, schedulers, routes, gateways, serving be
 
 Dependency facts live in [Dependencies][dependencies]. Supported GAIE inputs live in [GAIE Compatibility][gaie-compatibility].
 
+## Operator Configuration
+
+`kleym-operator` requires install-level identity configuration at startup:
+
+| Flag | Required | Behavior |
+| --- | --- | --- |
+| `--trust-domain=<value>` | yes | Sets the SPIRE Server trust domain used when rendering every SPIFFE ID. The value must not include `spiffe://`, must not contain `/`, and must not include leading or trailing whitespace. |
+| `--clusterspiffeid-class-name=<value>` | no | Sets `spec.className` on every managed `ClusterSPIFFEID`. When empty, Kleym omits `spec.className` and keeps classless output. |
+
+`trustDomain` and `ClusterSPIFFEID` class are deployment concerns, not per-binding inference identity intent. They are not fields on `InferenceIdentityBinding`.
+
+When `--clusterspiffeid-class-name` is empty, SPIRE Controller Manager must be configured to watch classless `ClusterSPIFFEID` resources, for example with its `watchClassless` behavior. When a class name is set, SPIRE Controller Manager must watch that class.
+
 ## API Contract
 
 `InferenceIdentityBinding` is namespaced. Pool and objective references stay in that namespace.
@@ -23,9 +36,9 @@ Dependency facts live in [Dependencies][dependencies]. Supported GAIE inputs liv
 2. `objectiveRef` references one [`InferenceObjective`][gaie-inferenceobjective]. It is required for `PerObjective`; the objective must reference the same pool as `poolRef`.
 3. `mode` is `PoolOnly` or `PerObjective`. These are the only identity boundaries. The default is `PerObjective`.
 4. `serviceAccountName` is required. Kleym renders safety selectors internally as `k8s:ns:<binding namespace>` and `k8s:sa:<serviceAccountName>`.
-5. SPIFFE IDs are always deterministic:
-   - `PoolOnly`: `spiffe://kleym.sonda.red/ns/<namespace>/pool/<pool-name>`
-   - `PerObjective`: `spiffe://kleym.sonda.red/ns/<namespace>/objective/<objective-name>`
+5. SPIFFE IDs are always deterministic under the configured trust domain:
+   - `PoolOnly`: `spiffe://<trustDomain>/ns/<namespace>/pool/<pool-name>`
+   - `PerObjective`: `spiffe://<trustDomain>/ns/<namespace>/objective/<objective-name>`
 6. `containerName` is required for `PerObjective` and must be empty for `PoolOnly`.
 7. Status records `computedSpiffeIDs`, `renderedSelectors`, and conditions. Conditions include `Ready`, `Conflict`, `InvalidRef`, `UnsafeSelector`, and `RenderFailure`.
 

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -15,9 +15,11 @@ var (
 
 var newBindingInspectionRunner = func(opts *Options) (inspection.BindingInspector, error) {
 	return inspection.NewKubernetesBindingInspector(inspection.Config{
-		Context:    opts.Context,
-		Kubeconfig: opts.Kubeconfig,
-		Timeout:    opts.Timeout,
+		Context:                  opts.Context,
+		Kubeconfig:               opts.Kubeconfig,
+		Timeout:                  opts.Timeout,
+		TrustDomain:              opts.TrustDomain,
+		ClusterSPIFFEIDClassName: opts.ClusterSPIFFEIDClassName,
 	})
 }
 

--- a/internal/cli/inspect_test.go
+++ b/internal/cli/inspect_test.go
@@ -45,6 +45,41 @@ func TestInspectBindingJSONUsesRunner(t *testing.T) {
 	}
 }
 
+func TestInspectBindingPassesOperatorConfigFlagsToRunner(t *testing.T) {
+	originalFactory := newBindingInspectionRunner
+	t.Cleanup(func() { newBindingInspectionRunner = originalFactory })
+
+	fakeReport := inspection.NewBindingInspectionReport()
+	var captured Options
+	newBindingInspectionRunner = func(opts *Options) (inspection.BindingInspector, error) {
+		captured = *opts
+		return fixedInspectionRunner{report: fakeReport}, nil
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"inspect",
+		"binding",
+		"binding-a",
+		"--trust-domain",
+		"example.org",
+		"--clusterspiffeid-class-name",
+		"kleym",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("inspect binding returned error: %v", err)
+	}
+	if captured.TrustDomain != "example.org" {
+		t.Fatalf("trustDomain = %q, want example.org", captured.TrustDomain)
+	}
+	if captured.ClusterSPIFFEIDClassName != "kleym" {
+		t.Fatalf("ClusterSPIFFEIDClassName = %q, want kleym", captured.ClusterSPIFFEIDClassName)
+	}
+}
+
 func TestInspectBindingDefaultTextUsesRunner(t *testing.T) {
 	originalFactory := newBindingInspectionRunner
 	t.Cleanup(func() { newBindingInspectionRunner = originalFactory })

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sonda-red/kleym/internal/identity"
+	"github.com/sonda-red/kleym/internal/inspection"
 	"github.com/sonda-red/kleym/internal/version"
 	"github.com/spf13/cobra"
 )
@@ -19,12 +21,14 @@ var validOutputFormats = []string{outputText, outputJSON}
 
 // Options holds top-level CLI flags for the kleym command tree.
 type Options struct {
-	Namespace  string
-	Output     string
-	Strict     bool
-	Context    string
-	Kubeconfig string
-	Timeout    time.Duration
+	Namespace                string
+	Output                   string
+	Strict                   bool
+	Context                  string
+	Kubeconfig               string
+	Timeout                  time.Duration
+	TrustDomain              string
+	ClusterSPIFFEIDClassName string
 }
 
 // NewRootCommand builds the kleym root command defined by the CLI spec.
@@ -49,6 +53,8 @@ func NewRootCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.Context, "context", "", "Name of the kubeconfig context to use")
 	cmd.PersistentFlags().StringVar(&opts.Kubeconfig, "kubeconfig", "", "Path to the kubeconfig file")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", 30*time.Second, "Inspection timeout")
+	cmd.PersistentFlags().StringVar(&opts.TrustDomain, "trust-domain", identity.DefaultTrustDomain, "SPIRE Server trust domain used when recomputing desired SPIFFE IDs")
+	cmd.PersistentFlags().StringVar(&opts.ClusterSPIFFEIDClassName, "clusterspiffeid-class-name", "", "Optional SPIRE Controller Manager ClusterSPIFFEID className expected on managed resources")
 
 	cmd.AddCommand(newInspectCommand(opts))
 	return cmd
@@ -60,6 +66,9 @@ func validateRunnableOptions(opts *Options) error {
 	}
 	if opts.Timeout <= 0 {
 		return withExitCode(exitUsage, fmt.Errorf("invalid --timeout %s: must be greater than 0", opts.Timeout))
+	}
+	if err := inspection.ValidateOperatorIdentityConfig(opts.TrustDomain, opts.ClusterSPIFFEIDClassName); err != nil {
+		return withExitCode(exitUsage, err)
 	}
 	return nil
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -52,7 +52,16 @@ func TestInspectBindingHelpIncludesMVPFlags(t *testing.T) {
 	}
 
 	help := stdout.String() + "\n" + stderr.String()
-	for _, want := range []string{"--namespace", "--output", "--strict", "--context", "--kubeconfig", "--timeout"} {
+	for _, want := range []string{
+		"--namespace",
+		"--output",
+		"--strict",
+		"--context",
+		"--kubeconfig",
+		"--timeout",
+		"--trust-domain",
+		"--clusterspiffeid-class-name",
+	} {
 		if !strings.Contains(help, want) {
 			t.Fatalf("help output missing %q\n%s", want, help)
 		}
@@ -135,6 +144,24 @@ func TestInvalidTimeoutRejected(t *testing.T) {
 	}
 	if got := codeForError(err); got != exitUsage {
 		t.Fatalf("expected invalid timeout to return exit code %d, got %d", exitUsage, got)
+	}
+}
+
+func TestInvalidTrustDomainRejected(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"inspect", "binding", "my-binding", "--trust-domain", "spiffe://example.org"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected invalid trust domain to fail")
+	}
+	if !strings.Contains(err.Error(), "trustDomain must not include spiffe://") {
+		t.Fatalf("expected invalid trustDomain error, got: %v", err)
+	}
+	if got := codeForError(err); got != exitUsage {
+		t.Fatalf("expected invalid trust domain to return exit code %d, got %d", exitUsage, got)
 	}
 }
 

--- a/internal/controller/inferenceidentitybinding_collision_test.go
+++ b/internal/controller/inferenceidentitybinding_collision_test.go
@@ -36,7 +36,7 @@ func TestReconcilePerObjectiveCollisionMarksAllAndBlocksClusterSPIFFEID(t *testi
 	}
 
 	fakeRecorder := newFakeEventRecorder(32)
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -75,7 +75,7 @@ func TestReconcilePerObjectiveCollisionResolutionClearsConflictAndResumes(t *tes
 	}
 
 	fakeRecorder := newFakeEventRecorder(64)
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -135,7 +135,7 @@ func TestReconcilePerObjectiveCollisionResolutionRefreshesPeersOnSingleReconcile
 		newPerObjectiveBinding("binding-b", "objective-b"),
 	}
 
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -186,7 +186,7 @@ func TestPoolOnlyBindingsAreNotSubjectToPerObjectiveCollisionRule(t *testing.T) 
 		newPoolOnlyBinding("binding-b", "objective-b"),
 	}
 
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -220,7 +220,7 @@ func TestChangingBindingToPoolOnlyResolvesPeerCollision(t *testing.T) {
 		newPerObjectiveBinding("binding-b", "objective-b"),
 	}
 
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -272,7 +272,7 @@ func TestPerObjectiveBindingsWithDifferentEffectiveSelectorsDoNotCollide(t *test
 		newPerObjectiveBindingWithServiceAccount("binding-b", "objective-b", "inference-sa-b"),
 	}
 
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).

--- a/internal/controller/inferenceidentitybinding_controller.go
+++ b/internal/controller/inferenceidentitybinding_controller.go
@@ -92,6 +92,7 @@ var (
 type InferenceIdentityBindingReconciler struct {
 	client.Client
 	Scheme                 *runtime.Scheme
+	Config                 OperatorConfig
 	Recorder               events.EventRecorder
 	MetricsRecorder        bindingOutcomeRecorder
 	availableObjectiveGVKs []schema.GroupVersionKind
@@ -288,7 +289,11 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(
 	}
 
 	primaryIdentity := desiredState.identities[0]
-	primaryClusterSPIFFEIDName := spirecm.DesiredClusterSPIFFEID(binding, primaryIdentity).GetName()
+	primaryClusterSPIFFEIDName := spirecm.DesiredClusterSPIFFEID(
+		binding,
+		primaryIdentity,
+		r.Config.ClusterSPIFFEIDClassName,
+	).GetName()
 	r.recordEventf(binding, corev1.EventTypeNormal, "Reconciled", "reconciled ClusterSPIFFEID %q", primaryClusterSPIFFEIDName)
 	logger.Info(
 		"reconciled successfully",
@@ -302,6 +307,10 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(
 // SetupWithManager sets up the controller with the Manager.
 func (r *InferenceIdentityBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	setupLogger := logf.Log.WithName("setup").WithName("inferenceidentitybinding")
+
+	if err := r.Config.Validate(); err != nil {
+		return err
+	}
 
 	r.Recorder = mgr.GetEventRecorder("inferenceidentitybinding-controller")
 	if r.MetricsRecorder == nil {
@@ -497,7 +506,11 @@ func (r *InferenceIdentityBindingReconciler) computeDesiredState(
 		"rendered identity from inference intent",
 		logKeyMode, identity.Mode,
 		logKeySpiffeID, identity.SpiffeID,
-		logKeyClusterSPIFFEID, spirecm.DesiredClusterSPIFFEID(binding, identity).GetName(),
+		logKeyClusterSPIFFEID, spirecm.DesiredClusterSPIFFEID(
+			binding,
+			identity,
+			r.Config.ClusterSPIFFEIDClassName,
+		).GetName(),
 		logKeySelectors, identity.Selectors,
 		logKeyPodSelector, identity.PodSelector,
 		logKeyObjective, identity.ObjectiveRef,

--- a/internal/controller/inferenceidentitybinding_controller_test.go
+++ b/internal/controller/inferenceidentitybinding_controller_test.go
@@ -41,7 +41,7 @@ var _ = Describe("InferenceIdentityBinding Controller", func() {
 		}
 		Expect(err).NotTo(HaveOccurred())
 
-		controllerReconciler := &InferenceIdentityBindingReconciler{
+		controllerReconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 			Client: k8sClient,
 			Scheme: k8sClient.Scheme(),
 		}
@@ -96,7 +96,7 @@ var _ = Describe("InferenceIdentityBinding Controller", func() {
 
 		It("should reconcile and surface unresolved references in status", func() {
 			By("Reconciling the created resource")
-			controllerReconciler := &InferenceIdentityBindingReconciler{
+			controllerReconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}
@@ -135,7 +135,7 @@ var _ = Describe("InferenceIdentityBinding Controller", func() {
 			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
 
 			By("reconciling the updated resource")
-			controllerReconciler := &InferenceIdentityBindingReconciler{
+			controllerReconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}
@@ -166,7 +166,7 @@ var _ = Describe("InferenceIdentityBinding Controller", func() {
 
 		It("should not return an error for a missing resource", func() {
 			By("Reconciling a resource that does not exist")
-			controllerReconciler := &InferenceIdentityBindingReconciler{
+			controllerReconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}
@@ -213,7 +213,7 @@ var _ = Describe("InferenceIdentityBinding Controller", func() {
 			})
 
 			By("reconciling the created resource")
-			controllerReconciler := &InferenceIdentityBindingReconciler{
+			controllerReconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}
@@ -278,7 +278,7 @@ var _ = Describe("InferenceIdentityBinding Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("setting up the controller with the manager")
-			controllerReconciler := &InferenceIdentityBindingReconciler{
+			controllerReconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 				Client: mgr.GetClient(),
 				Scheme: mgr.GetScheme(),
 			}

--- a/internal/controller/inferenceidentitybinding_delete_test.go
+++ b/internal/controller/inferenceidentitybinding_delete_test.go
@@ -30,7 +30,7 @@ func TestReconcileDeleteWaitsForManagedClusterSPIFFEIDsToDisappear(t *testing.T)
 	managed := newManagedClusterSPIFFEIDForBinding(binding, "binding-delete-child")
 	managed.SetFinalizers([]string{"test.finalizer/hold"})
 
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithObjects(binding, managed).
@@ -115,7 +115,7 @@ func TestReconcileCorrectsClusterSPIFFEIDDriftOnResync(t *testing.T) {
 
 	binding := newPerObjectiveBinding("binding-drift", "objective-a")
 
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -142,7 +142,7 @@ func TestReconcileCorrectsClusterSPIFFEIDDriftOnResync(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to render desired identity: %v", err)
 	}
-	desired := spirecm.DesiredClusterSPIFFEID(currentBinding, identity)
+	desired := spirecm.DesiredClusterSPIFFEID(currentBinding, identity, "")
 
 	current := &unstructured.Unstructured{}
 	current.SetGroupVersionKind(clusterSPIFFEIDGVK)

--- a/internal/controller/inferenceidentitybinding_envtest_test.go
+++ b/internal/controller/inferenceidentitybinding_envtest_test.go
@@ -37,7 +37,7 @@ var _ = Describe("InferenceIdentityBinding Envtest Coverage", func() {
 	}
 
 	cleanupBinding := func(key types.NamespacedName) {
-		reconciler := &InferenceIdentityBindingReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: k8sClient, Scheme: k8sClient.Scheme()}
 
 		Eventually(func(g Gomega) {
 			binding := &kleymv1alpha1.InferenceIdentityBinding{}
@@ -116,7 +116,7 @@ var _ = Describe("InferenceIdentityBinding Envtest Coverage", func() {
 			cleanupBinding(types.NamespacedName{Namespace: testNamespace, Name: bindingName})
 		})
 
-		reconciler := &InferenceIdentityBindingReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: k8sClient, Scheme: k8sClient.Scheme()}
 		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: bindingName}})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -156,7 +156,7 @@ var _ = Describe("InferenceIdentityBinding Envtest Coverage", func() {
 			cleanupBinding(types.NamespacedName{Namespace: testNamespace, Name: bindingName})
 		})
 
-		reconciler := &InferenceIdentityBindingReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: k8sClient, Scheme: k8sClient.Scheme()}
 		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: bindingName}})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -197,7 +197,7 @@ var _ = Describe("InferenceIdentityBinding Envtest Coverage", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		reconciler := &InferenceIdentityBindingReconciler{
+		reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),
 		}

--- a/internal/controller/inferenceidentitybinding_logging_test.go
+++ b/internal/controller/inferenceidentitybinding_logging_test.go
@@ -26,7 +26,7 @@ func TestReconcileLogsStructuredSuccessPath(t *testing.T) {
 
 	scheme := newCollisionTestScheme(t)
 	binding := newPoolOnlyBinding("binding-log-success", "objective-a")
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -78,7 +78,7 @@ func TestReconcileLogsFailureStatus(t *testing.T) {
 
 	scheme := newCollisionTestScheme(t)
 	binding := newPerObjectiveBinding("binding-log-failure", "missing-objective")
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -131,14 +131,14 @@ func TestReconcileClusterSPIFFEIDsLogsApplyDecisions(t *testing.T) {
 		PoolRef:      "pool-a",
 	}
 
-	drifted := spirecm.DesiredClusterSPIFFEID(binding, identity)
+	drifted := spirecm.DesiredClusterSPIFFEID(binding, identity, "")
 	expectedName := drifted.GetName()
 	drifted.Object["spec"] = map[string]any{"spiffeIDTemplate": "spiffe://wrong"}
 
-	stale := spirecm.DesiredClusterSPIFFEID(binding, identity)
+	stale := spirecm.DesiredClusterSPIFFEID(binding, identity, "")
 	stale.SetName("stale-clusterspiffeid")
 
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithObjects(binding, drifted, stale).

--- a/internal/controller/inferenceidentitybinding_metrics_test.go
+++ b/internal/controller/inferenceidentitybinding_metrics_test.go
@@ -119,7 +119,7 @@ func TestReconcileRecordsSuccessfulTerminalOutcomeAfterStatusPatch(t *testing.T)
 		key:    types.NamespacedName{Namespace: testNamespace, Name: binding.Name},
 	}
 
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client:          k8sClient,
 		Scheme:          scheme,
 		MetricsRecorder: recorder,
@@ -156,7 +156,7 @@ func TestReconcileRecordsFailureTerminalOutcomeAfterStatusPatch(t *testing.T) {
 		key:    types.NamespacedName{Namespace: testNamespace, Name: binding.Name},
 	}
 
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client:          k8sClient,
 		Scheme:          scheme,
 		MetricsRecorder: recorder,

--- a/internal/controller/inferenceidentitybinding_mode_status_test.go
+++ b/internal/controller/inferenceidentitybinding_mode_status_test.go
@@ -21,7 +21,7 @@ func TestModeFlipKeepsComputedSpiffeIDsInSyncWithManagedClusterSPIFFEIDs(t *test
 	scheme := newCollisionTestScheme(t)
 
 	binding := newPerObjectiveBinding("binding-mode-flip", "objective-a")
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).

--- a/internal/controller/inferenceidentitybinding_render.go
+++ b/internal/controller/inferenceidentitybinding_render.go
@@ -44,6 +44,7 @@ func (r *InferenceIdentityBindingReconciler) renderIdentity(
 	}
 	return identity.PlanIdentity(identity.PlanInput{
 		Binding:              binding,
+		TrustDomain:          r.Config.TrustDomain,
 		ObjectiveName:        objectiveName,
 		PoolName:             pool.GetName(),
 		PodSelector:          podSelector,

--- a/internal/controller/inferenceidentitybinding_render_test.go
+++ b/internal/controller/inferenceidentitybinding_render_test.go
@@ -13,7 +13,7 @@ import (
 func TestRenderIdentityMapsInvalidPoolSelectorToUnsafeSelector(t *testing.T) {
 	t.Parallel()
 
-	reconciler := &InferenceIdentityBindingReconciler{}
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig()}
 	binding := testRenderBinding("binding-invalid-selector", "pool-invalid-selector")
 	pool := testRenderPool("pool-invalid-selector", map[string]any{
 		"app": []any{"model-server"},
@@ -39,7 +39,7 @@ func TestRenderIdentityMapsInvalidPoolSelectorToUnsafeSelector(t *testing.T) {
 func TestRenderIdentityPassesValidGAIESelectorIntoIdentityPlan(t *testing.T) {
 	t.Parallel()
 
-	reconciler := &InferenceIdentityBindingReconciler{}
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig()}
 	binding := testRenderBinding("binding-valid-selector", "pool-valid-selector")
 	pool := testRenderPool("pool-valid-selector", map[string]any{
 		"app":                                "model-server",

--- a/internal/controller/inferenceidentitybinding_resolver_test.go
+++ b/internal/controller/inferenceidentitybinding_resolver_test.go
@@ -21,7 +21,7 @@ func TestReconcileSetsInvalidRefWhenPoolCannotBeResolved(t *testing.T) {
 	scheme := newCollisionTestScheme(t)
 
 	binding := newPerObjectiveBinding("binding-missing-pool", "objective-missing-pool")
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -51,7 +51,7 @@ func TestReconcilePoolOnlyDoesNotRequireObjective(t *testing.T) {
 	scheme := newCollisionTestScheme(t)
 
 	binding := newPoolOnlyBinding("binding-pool-only", "")
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -71,6 +71,56 @@ func TestReconcilePoolOnlyDoesNotRequireObjective(t *testing.T) {
 	assertClusterSPIFFEIDCount(t, ctx, reconciler.Client, 1)
 }
 
+func TestReconcileUsesOperatorConfigForRenderedOutput(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newCollisionTestScheme(t)
+
+	binding := newPoolOnlyBinding("binding-operator-config", "")
+	reconciler := &InferenceIdentityBindingReconciler{Config: OperatorConfig{
+		TrustDomain:              "example.org",
+		ClusterSPIFFEIDClassName: "kleym",
+	},
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+			WithObjects(newTestPool(), binding).
+			Build(),
+		Scheme: scheme,
+	}
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: binding.Name},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(clusterSPIFFEIDGVK.GroupVersion().WithKind(clusterSPIFFEIDGVK.Kind + "List"))
+	if err := reconciler.List(ctx, list); err != nil {
+		t.Fatalf("failed to list ClusterSPIFFEIDs: %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("ClusterSPIFFEID count = %d, want 1", len(list.Items))
+	}
+	spiffeID, _, err := unstructured.NestedString(list.Items[0].Object, "spec", "spiffeIDTemplate")
+	if err != nil {
+		t.Fatalf("failed to read spec.spiffeIDTemplate: %v", err)
+	}
+	if spiffeID != "spiffe://example.org/ns/default/pool/pool-a" {
+		t.Fatalf("spiffeIDTemplate = %q, want spiffe://example.org/ns/default/pool/pool-a", spiffeID)
+	}
+	className, _, err := unstructured.NestedString(list.Items[0].Object, "spec", "className")
+	if err != nil {
+		t.Fatalf("failed to read spec.className: %v", err)
+	}
+	if className != "kleym" {
+		t.Fatalf("className = %q, want kleym", className)
+	}
+}
+
 func TestReconcilePerObjectiveRequiresObjectiveRef(t *testing.T) {
 	t.Parallel()
 
@@ -80,7 +130,7 @@ func TestReconcilePerObjectiveRequiresObjectiveRef(t *testing.T) {
 	binding := newPoolOnlyBinding("binding-missing-objective-ref", "")
 	binding.Spec.Mode = kleymv1alpha1.InferenceIdentityBindingModePerObjective
 	binding.Spec.ContainerName = "main"
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -108,7 +158,7 @@ func TestReconcilePerObjectiveFailsWhenObjectiveRefMissing(t *testing.T) {
 	scheme := newCollisionTestScheme(t)
 
 	binding := newPerObjectiveBinding("binding-missing-objective", "missing-objective")
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -143,7 +193,7 @@ func TestReconcileSetsInvalidRefWhenObjectivePointsAtDifferentPool(t *testing.T)
 	}
 
 	binding := newPerObjectiveBinding("binding-objective-pool-mismatch", objective.GetName())
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -184,7 +234,7 @@ func TestReconcileSetsInvalidRefWhenObjectivePoolRefIsInvalid(t *testing.T) {
 	objective.SetName("objective-invalid-pool-ref")
 
 	binding := newPerObjectiveBinding("binding-invalid-pool-ref", objective.GetName())
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -229,7 +279,7 @@ func TestReconcileSetsInvalidRefWhenObjectivePoolRefGroupIsUnsupported(t *testin
 	}
 
 	binding := newPerObjectiveBinding("binding-unsupported-pool-group", objective.GetName())
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -280,7 +330,7 @@ func TestReconcileUsesDiscoveredObjectiveGVKsForResolution(t *testing.T) {
 	binding := newPerObjectiveBinding("binding-filtered-objective", "objective-shared")
 	binding.Spec.PoolRef = kleymv1alpha1.InferencePoolTargetRef{Name: "pool-x"}
 
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).

--- a/internal/controller/inferenceidentitybinding_setup_partial_crd_test.go
+++ b/internal/controller/inferenceidentitybinding_setup_partial_crd_test.go
@@ -80,7 +80,7 @@ func TestSetupWithManagerStartsAndReconcilesWithXObjectiveOnlyCRD(t *testing.T) 
 		t.Fatalf("create manager: %v", err)
 	}
 
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}
@@ -214,7 +214,7 @@ func TestSetupWithManagerFailsWithoutAnySupportedGAIEGVKs(t *testing.T) {
 		t.Fatalf("create manager: %v", err)
 	}
 
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}

--- a/internal/controller/inferenceidentitybinding_spiffe.go
+++ b/internal/controller/inferenceidentitybinding_spiffe.go
@@ -47,7 +47,7 @@ func (r *InferenceIdentityBindingReconciler) reconcileClusterSPIFFEIDs(
 
 	desiredNames := make(map[string]struct{}, len(identities))
 	for _, identity := range identities {
-		desired := spirecm.DesiredClusterSPIFFEID(binding, identity)
+		desired := spirecm.DesiredClusterSPIFFEID(binding, identity, r.Config.ClusterSPIFFEIDClassName)
 		desiredName := desired.GetName()
 		desiredNames[desiredName] = struct{}{}
 

--- a/internal/controller/inferenceidentitybinding_watch_test.go
+++ b/internal/controller/inferenceidentitybinding_watch_test.go
@@ -20,7 +20,7 @@ func TestMapObjectiveToBindingsTargetsOnlyMatchingBindings(t *testing.T) {
 
 	ctx := context.Background()
 	scheme := newCollisionTestScheme(t)
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithIndex(&kleymv1alpha1.InferenceIdentityBinding{}, fieldIndexObjectiveRefName, bindingObjectiveRefNameIndexValue).
@@ -51,7 +51,7 @@ func TestMapPoolToBindingsTargetsOnlyBindingsForReferencingObjectives(t *testing
 	bindingB := newPerObjectiveBinding("binding-b", "objective-b")
 	bindingB.Spec.PoolRef.Name = "pool-b"
 
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithIndex(&kleymv1alpha1.InferenceIdentityBinding{}, fieldIndexPoolRefName, bindingPoolRefNameIndexValue).
@@ -93,7 +93,7 @@ func TestMapPoolToBindingsRespectsPoolRefGroup(t *testing.T) {
 		Group: "inference.networking.x-k8s.io",
 	}
 
-	reconciler := &InferenceIdentityBindingReconciler{
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithIndex(&kleymv1alpha1.InferenceIdentityBinding{}, fieldIndexPoolRefName, bindingPoolRefNameIndexValue).

--- a/internal/controller/operator_config.go
+++ b/internal/controller/operator_config.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026 Kalin Daskalov.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controller
+
+import (
+	"fmt"
+	"strings"
+)
+
+const trustDomainRequiredMessage = "trustDomain must be configured before Kleym can render SPIFFE IDs"
+
+// OperatorConfig carries install-level settings that affect all reconciled identities.
+type OperatorConfig struct {
+	TrustDomain              string
+	ClusterSPIFFEIDClassName string
+}
+
+// Validate rejects ambiguous install-level identity configuration before reconciliation starts.
+func (c OperatorConfig) Validate() error {
+	if strings.TrimSpace(c.TrustDomain) == "" {
+		return fmt.Errorf("%s", trustDomainRequiredMessage)
+	}
+	if c.TrustDomain != strings.TrimSpace(c.TrustDomain) {
+		return fmt.Errorf("trustDomain must not include leading or trailing whitespace")
+	}
+	if strings.HasPrefix(c.TrustDomain, "spiffe://") {
+		return fmt.Errorf("trustDomain must not include spiffe://")
+	}
+	if strings.Contains(c.TrustDomain, "/") {
+		return fmt.Errorf("trustDomain must not contain /")
+	}
+	if c.ClusterSPIFFEIDClassName != strings.TrimSpace(c.ClusterSPIFFEIDClassName) {
+		return fmt.Errorf("clusterspiffeidClassName must not include leading or trailing whitespace")
+	}
+	return nil
+}

--- a/internal/controller/operator_config_test.go
+++ b/internal/controller/operator_config_test.go
@@ -1,0 +1,65 @@
+package controller
+
+import "testing"
+
+func TestOperatorConfigValidateRequiresTrustDomain(t *testing.T) {
+	t.Parallel()
+
+	err := (OperatorConfig{}).Validate()
+	if err == nil {
+		t.Fatalf("expected missing trustDomain error, got nil")
+	}
+	if err.Error() != trustDomainRequiredMessage {
+		t.Fatalf("error = %q, want %q", err.Error(), trustDomainRequiredMessage)
+	}
+}
+
+func TestOperatorConfigValidateRejectsAmbiguousValues(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]OperatorConfig{
+		"trust-domain-leading-whitespace": {
+			TrustDomain: " example.org",
+		},
+		"trust-domain-scheme": {
+			TrustDomain: "spiffe://example.org",
+		},
+		"trust-domain-path": {
+			TrustDomain: "example.org/ns",
+		},
+		"class-name-whitespace": {
+			TrustDomain:              "example.org",
+			ClusterSPIFFEIDClassName: " kleym",
+		},
+	}
+
+	for name, config := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := config.Validate(); err == nil {
+				t.Fatalf("expected validation error, got nil")
+			}
+		})
+	}
+}
+
+func TestOperatorConfigValidateAcceptsOptionalClassName(t *testing.T) {
+	t.Parallel()
+
+	for name, config := range map[string]OperatorConfig{
+		"classless": {TrustDomain: "example.org"},
+		"classed": {
+			TrustDomain:              "example.org",
+			ClusterSPIFFEIDClassName: "kleym",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := config.Validate(); err != nil {
+				t.Fatalf("Validate returned error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -57,6 +57,10 @@ func TestControllers(t *testing.T) {
 	RunSpecs(t, "Controller Suite")
 }
 
+func testOperatorConfig() OperatorConfig {
+	return OperatorConfig{TrustDomain: "kleym.sonda.red"}
+}
+
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 

--- a/internal/identity/render.go
+++ b/internal/identity/render.go
@@ -44,6 +44,13 @@ func PlanIdentity(input PlanInput) (Plan, error) {
 			"objectiveRef is required when mode is PerObjective",
 		)
 	}
+	if strings.TrimSpace(input.TrustDomain) == "" {
+		return Plan{}, newStateError(
+			ConditionTypeRenderFailure,
+			"MissingTrustDomain",
+			"trustDomain must be configured before Kleym can render SPIFFE IDs",
+		)
+	}
 
 	templateData := renderTemplateData{
 		Namespace:     binding.Namespace,
@@ -90,7 +97,7 @@ func PlanIdentity(input PlanInput) (Plan, error) {
 		)
 	}
 
-	spiffeID := renderSPIFFEID(mode, templateData)
+	spiffeID := renderSPIFFEID(mode, input.TrustDomain, templateData)
 	if !strings.HasPrefix(spiffeID, "spiffe://") {
 		return Plan{}, newStateError(
 			ConditionTypeRenderFailure,
@@ -137,13 +144,14 @@ func SelectorForContainerName(containerName string) (string, error) {
 // renderSPIFFEID computes the fixed SPIFFE ID forms defined by docs/spec/operator.md.
 func renderSPIFFEID(
 	mode kleymv1alpha1.InferenceIdentityBindingMode,
+	trustDomain string,
 	data renderTemplateData,
 ) string {
 	switch mode {
 	case kleymv1alpha1.InferenceIdentityBindingModePoolOnly:
-		return fmt.Sprintf("spiffe://%s/ns/%s/pool/%s", defaultTrustDomain, data.Namespace, data.PoolName)
+		return fmt.Sprintf("spiffe://%s/ns/%s/pool/%s", trustDomain, data.Namespace, data.PoolName)
 	case kleymv1alpha1.InferenceIdentityBindingModePerObjective:
-		return fmt.Sprintf("spiffe://%s/ns/%s/objective/%s", defaultTrustDomain, data.Namespace, data.ObjectiveName)
+		return fmt.Sprintf("spiffe://%s/ns/%s/objective/%s", trustDomain, data.Namespace, data.ObjectiveName)
 	default:
 		return ""
 	}

--- a/internal/identity/render_test.go
+++ b/internal/identity/render_test.go
@@ -133,9 +133,45 @@ func TestRenderIdentityUsesDeterministicSPIFFEID(t *testing.T) {
 		t.Fatalf("PlanIdentity returned error: %v", err)
 	}
 
-	expectedSPIFFEID := "spiffe://kleym.sonda.red/ns/default/objective/objective-a"
+	expectedSPIFFEID := "spiffe://example.org/ns/default/objective/objective-a"
 	if identity.SpiffeID != expectedSPIFFEID {
 		t.Fatalf("spiffeID = %q, want %q", identity.SpiffeID, expectedSPIFFEID)
+	}
+}
+
+func TestRenderIdentityUsesConfiguredTrustDomainForPoolOnly(t *testing.T) {
+	t.Parallel()
+
+	binding := testBinding(kleymv1alpha1.InferenceIdentityBindingModePoolOnly)
+
+	identity, err := PlanIdentity(testPlanInput(binding, "objective-a", "pool-a"))
+	if err != nil {
+		t.Fatalf("PlanIdentity returned error: %v", err)
+	}
+
+	expectedSPIFFEID := "spiffe://example.org/ns/default/pool/pool-a"
+	if identity.SpiffeID != expectedSPIFFEID {
+		t.Fatalf("spiffeID = %q, want %q", identity.SpiffeID, expectedSPIFFEID)
+	}
+}
+
+func TestRenderIdentityRejectsMissingTrustDomain(t *testing.T) {
+	t.Parallel()
+
+	binding := testBinding(kleymv1alpha1.InferenceIdentityBindingModePoolOnly)
+	input := testPlanInput(binding, "objective-a", "pool-a")
+	input.TrustDomain = ""
+
+	_, err := PlanIdentity(input)
+	if err == nil {
+		t.Fatalf("expected missing trust domain error, got nil")
+	}
+	var stateErr *StateError
+	if !errors.As(err, &stateErr) {
+		t.Fatalf("expected StateError, got %T", err)
+	}
+	if stateErr.ConditionType != ConditionTypeRenderFailure || stateErr.Reason != "MissingTrustDomain" {
+		t.Fatalf("condition/reason = %q/%q, want %q/MissingTrustDomain", stateErr.ConditionType, stateErr.Reason, ConditionTypeRenderFailure)
 	}
 }
 
@@ -199,6 +235,7 @@ func testPlanInput(
 ) PlanInput {
 	return PlanInput{
 		Binding:              binding,
+		TrustDomain:          "example.org",
 		ObjectiveName:        objectiveName,
 		PoolName:             poolName,
 		PodSelector:          map[string]any{"matchLabels": map[string]any{"app": "model-server"}},

--- a/internal/identity/types.go
+++ b/internal/identity/types.go
@@ -22,7 +22,9 @@ import (
 )
 
 const (
-	defaultTrustDomain = "kleym.sonda.red"
+	// DefaultTrustDomain preserves the original single-install rendering behavior for callers
+	// that do not have operator deployment configuration available.
+	DefaultTrustDomain = "kleym.sonda.red"
 
 	// ConditionTypeUnsafeSelector matches the controller status condition for unsafe selector rendering.
 	ConditionTypeUnsafeSelector = "UnsafeSelector"
@@ -52,6 +54,7 @@ func newStateError(conditionType, reason, message string) *StateError {
 // PlanInput carries already-resolved identity planning inputs.
 type PlanInput struct {
 	Binding              *kleymv1alpha1.InferenceIdentityBinding
+	TrustDomain          string
 	ObjectiveName        string
 	PoolName             string
 	PodSelector          map[string]any

--- a/internal/inspection/inspection.go
+++ b/internal/inspection/inspection.go
@@ -57,9 +57,11 @@ var (
 
 // Config describes Kubernetes access settings for live binding inspection.
 type Config struct {
-	Context    string
-	Kubeconfig string
-	Timeout    time.Duration
+	Context                  string
+	Kubeconfig               string
+	Timeout                  time.Duration
+	TrustDomain              string
+	ClusterSPIFFEIDClassName string
 }
 
 // BindingInspector inspects one binding and returns the stable report model.
@@ -68,13 +70,20 @@ type BindingInspector interface {
 }
 
 type bindingInspector struct {
-	client client.Client
-	mapper meta.RESTMapper
-	now    func() time.Time
+	client                   client.Client
+	mapper                   meta.RESTMapper
+	now                      func() time.Time
+	trustDomain              string
+	clusterSPIFFEIDClassName string
 }
 
 // NewKubernetesBindingInspector returns a read-only Kubernetes-backed binding inspector.
 func NewKubernetesBindingInspector(config Config) (BindingInspector, error) {
+	identityConfig, err := normalizedInspectionIdentityConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
 	configOverrides := &clientcmd.ConfigOverrides{CurrentContext: config.Context}
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if config.Kubeconfig != "" {
@@ -102,10 +111,52 @@ func NewKubernetesBindingInspector(config Config) (BindingInspector, error) {
 	}
 
 	return &bindingInspector{
-		client: kubeClient,
-		mapper: mapper,
-		now:    time.Now,
+		client:                   kubeClient,
+		mapper:                   mapper,
+		now:                      time.Now,
+		trustDomain:              identityConfig.trustDomain,
+		clusterSPIFFEIDClassName: identityConfig.clusterSPIFFEIDClassName,
 	}, nil
+}
+
+type inspectionIdentityConfig struct {
+	trustDomain              string
+	clusterSPIFFEIDClassName string
+}
+
+func normalizedInspectionIdentityConfig(config Config) (inspectionIdentityConfig, error) {
+	trustDomain := config.TrustDomain
+	if trustDomain == "" {
+		trustDomain = identity.DefaultTrustDomain
+	}
+	identityConfig := inspectionIdentityConfig{
+		trustDomain:              trustDomain,
+		clusterSPIFFEIDClassName: config.ClusterSPIFFEIDClassName,
+	}
+	if err := ValidateOperatorIdentityConfig(identityConfig.trustDomain, identityConfig.clusterSPIFFEIDClassName); err != nil {
+		return inspectionIdentityConfig{}, err
+	}
+	return identityConfig, nil
+}
+
+// ValidateOperatorIdentityConfig rejects inspection settings that the operator would not start with.
+func ValidateOperatorIdentityConfig(trustDomain string, clusterSPIFFEIDClassName string) error {
+	if strings.TrimSpace(trustDomain) == "" {
+		return fmt.Errorf("trustDomain must be configured before Kleym can render SPIFFE IDs")
+	}
+	if trustDomain != strings.TrimSpace(trustDomain) {
+		return fmt.Errorf("trustDomain must not include leading or trailing whitespace")
+	}
+	if strings.HasPrefix(trustDomain, "spiffe://") {
+		return fmt.Errorf("trustDomain must not include spiffe://")
+	}
+	if strings.Contains(trustDomain, "/") {
+		return fmt.Errorf("trustDomain must not contain /")
+	}
+	if clusterSPIFFEIDClassName != strings.TrimSpace(clusterSPIFFEIDClassName) {
+		return fmt.Errorf("clusterspiffeidClassName must not include leading or trailing whitespace")
+	}
+	return nil
 }
 
 func newBindingInspectionScheme() *runtime.Scheme {
@@ -281,7 +332,7 @@ func (i *bindingInspector) inspectDesiredState(
 	}
 	rendered, err := identity.PlanIdentity(identity.PlanInput{
 		Binding:              binding,
-		TrustDomain:          identity.DefaultTrustDomain,
+		TrustDomain:          i.trustDomain,
 		ObjectiveName:        objectiveName,
 		PoolName:             pool.GetName(),
 		PodSelector:          poolSelector,
@@ -304,6 +355,7 @@ func (i *bindingInspector) inspectDesiredState(
 		WorkloadSelectors:   append([]string(nil), rendered.Selectors...),
 		SelectorProvenance:  &provenance,
 		Hint:                spirecm.BuildClusterSPIFFEIDHint(binding),
+		ClassName:           i.clusterSPIFFEIDClassName,
 		Fallback:            boolPtr(spirecm.RenderFallback()),
 	}
 	report.Capabilities.GAIEResources = BindingInspectionCapabilityFull
@@ -370,7 +422,7 @@ func (i *bindingInspector) inspectObservedState(
 		return
 	}
 
-	desired := spirecm.DesiredClusterSPIFFEID(binding, rendered, "")
+	desired := spirecm.DesiredClusterSPIFFEID(binding, rendered, i.clusterSPIFFEIDClassName)
 	if len(objects) == 0 {
 		report.Observed.Drift = append(report.Observed.Drift, BindingInspectionDriftEntry{
 			Field:    "metadata.name",
@@ -882,6 +934,7 @@ func managedClusterSPIFFEIDReport(object *unstructured.Unstructured) BindingInsp
 	spiffeID, _ := spec["spiffeIDTemplate"].(string)
 	podSelector, _ := spec["podSelector"].(map[string]any)
 	hint, _ := spec["hint"].(string)
+	className, _ := spec["className"].(string)
 	fallback, hasFallback := spec["fallback"].(bool)
 
 	report := BindingInspectionManagedClusterSPIFFEID{
@@ -890,6 +943,7 @@ func managedClusterSPIFFEIDReport(object *unstructured.Unstructured) BindingInsp
 		PodSelector:       podSelector,
 		WorkloadSelectors: stringSliceFromAny(spec["workloadSelectorTemplates"]),
 		Hint:              hint,
+		ClassName:         className,
 		Conditions:        clusterSPIFFEIDConditions(object),
 	}
 	if hasFallback {

--- a/internal/inspection/inspection.go
+++ b/internal/inspection/inspection.go
@@ -281,6 +281,7 @@ func (i *bindingInspector) inspectDesiredState(
 	}
 	rendered, err := identity.PlanIdentity(identity.PlanInput{
 		Binding:              binding,
+		TrustDomain:          identity.DefaultTrustDomain,
 		ObjectiveName:        objectiveName,
 		PoolName:             pool.GetName(),
 		PodSelector:          poolSelector,
@@ -369,7 +370,7 @@ func (i *bindingInspector) inspectObservedState(
 		return
 	}
 
-	desired := spirecm.DesiredClusterSPIFFEID(binding, rendered)
+	desired := spirecm.DesiredClusterSPIFFEID(binding, rendered, "")
 	if len(objects) == 0 {
 		report.Observed.Drift = append(report.Observed.Drift, BindingInspectionDriftEntry{
 			Field:    "metadata.name",

--- a/internal/inspection/inspection_test.go
+++ b/internal/inspection/inspection_test.go
@@ -30,7 +30,7 @@ func TestInspectBindingSuccessReport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("render test identity: %v", err)
 	}
-	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered)
+	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered, "")
 	pod := testInspectionPod("model-server-a", "model-server")
 
 	inspector := newTestBindingInspector(t, nil, binding, pool, objective, managed, pod)
@@ -78,7 +78,7 @@ func TestInspectBindingPoolOnlyEligibleWorkload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("render test identity: %v", err)
 	}
-	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered)
+	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered, "")
 	pod := testInspectionPod("model-server-a", "model-server")
 
 	inspector := newTestBindingInspector(t, nil, binding, pool, managed, pod)
@@ -157,7 +157,7 @@ func TestInspectBindingObservedDriftFinding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("render test identity: %v", err)
 	}
-	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered)
+	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered, "")
 	if err := unstructured.SetNestedField(managed.Object, "spiffe://drifted.example.test/ns/tenant-a/objective/objective-a", "spec", "spiffeIDTemplate"); err != nil {
 		t.Fatalf("set drifted spiffeIDTemplate: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestInspectBindingZeroEligibleWorkloadsFinding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("render test identity: %v", err)
 	}
-	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered)
+	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered, "")
 	inspector := newTestBindingInspector(t, nil, binding, pool, objective, managed)
 
 	report, err := inspector.InspectBinding(context.Background(), "tenant-a", "binding-a")
@@ -246,7 +246,7 @@ func TestInspectBindingRBACLimitedPods(t *testing.T) {
 	if err != nil {
 		t.Fatalf("render test identity: %v", err)
 	}
-	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered)
+	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered, "")
 	forbidden := apierrors.NewForbidden(
 		schema.GroupResource{Resource: podResourceName},
 		"",
@@ -542,6 +542,7 @@ func inspectionPlan(
 	}
 	return identity.PlanIdentity(identity.PlanInput{
 		Binding:              binding,
+		TrustDomain:          identity.DefaultTrustDomain,
 		ObjectiveName:        objectiveName,
 		PoolName:             pool.GetName(),
 		PodSelector:          poolSelector,

--- a/internal/inspection/inspection_test.go
+++ b/internal/inspection/inspection_test.go
@@ -105,6 +105,44 @@ func TestInspectBindingPoolOnlyEligibleWorkload(t *testing.T) {
 	}
 }
 
+func TestInspectBindingUsesConfiguredOperatorOutput(t *testing.T) {
+	binding := testInspectionBinding()
+	pool := testInspectionPool("pool-a")
+	objective := testInspectionObjective("objective-a", "pool-a")
+	rendered, err := inspectionPlanWithTrustDomain(binding, objective, pool, "example.org")
+	if err != nil {
+		t.Fatalf("render test identity: %v", err)
+	}
+	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered, "kleym")
+	pod := testInspectionPod("model-server-a", "model-server")
+
+	inspector := newTestBindingInspectorWithIdentityConfig(t, inspectionIdentityConfig{
+		trustDomain:              "example.org",
+		clusterSPIFFEIDClassName: "kleym",
+	}, nil, binding, pool, objective, managed, pod)
+	report, err := inspector.InspectBinding(context.Background(), "tenant-a", "binding-a")
+	if err != nil {
+		t.Fatalf("InspectBinding returned error: %v", err)
+	}
+
+	if report.Desired.SPIFFEID != "spiffe://example.org/ns/tenant-a/objective/objective-a" {
+		t.Fatalf("desired spiffeID = %q, want configured trust domain", report.Desired.SPIFFEID)
+	}
+	if report.Desired.ClassName != "kleym" {
+		t.Fatalf("desired className = %q, want kleym", report.Desired.ClassName)
+	}
+	if len(report.Observed.ManagedClusterSPIFFEIDs) != 1 ||
+		report.Observed.ManagedClusterSPIFFEIDs[0].ClassName != "kleym" {
+		t.Fatalf("managed ClusterSPIFFEIDs = %#v, want className kleym", report.Observed.ManagedClusterSPIFFEIDs)
+	}
+	if len(report.Observed.Drift) != 0 {
+		t.Fatalf("expected no drift, got %#v", report.Observed.Drift)
+	}
+	if len(report.Findings) != 0 {
+		t.Fatalf("expected no findings, got %#v", report.Findings)
+	}
+}
+
 func TestInspectBindingMissingBindingReport(t *testing.T) {
 	inspector := newTestBindingInspector(t, nil)
 
@@ -310,6 +348,20 @@ func newTestBindingInspector(t *testing.T, listErr error, objects ...client.Obje
 	return newTestBindingInspectorWithListErrors(t, listErr, nil, objects...)
 }
 
+func newTestBindingInspectorWithIdentityConfig(
+	t *testing.T,
+	identityConfig inspectionIdentityConfig,
+	listErr error,
+	objects ...client.Object,
+) *bindingInspector {
+	t.Helper()
+
+	inspector := newTestBindingInspectorWithListErrors(t, listErr, nil, objects...)
+	inspector.trustDomain = identityConfig.trustDomain
+	inspector.clusterSPIFFEIDClassName = identityConfig.clusterSPIFFEIDClassName
+	return inspector
+}
+
 func newTestBindingInspectorWithPodListErr(t *testing.T, podListErr error, objects ...client.Object) *bindingInspector {
 	return newTestBindingInspectorWithListErrors(t, nil, podListErr, objects...)
 }
@@ -336,6 +388,11 @@ func newTestBindingInspectorWithListErrors(
 		}
 	}
 
+	identityConfig, err := normalizedInspectionIdentityConfig(Config{})
+	if err != nil {
+		t.Fatalf("default identity config: %v", err)
+	}
+
 	return &bindingInspector{
 		client: kubeClient,
 		mapper: newInspectionTestRESTMapper(
@@ -345,6 +402,8 @@ func newTestBindingInspectorWithListErrors(
 		now: func() time.Time {
 			return time.Date(2026, 5, 18, 10, 11, 12, 0, time.UTC)
 		},
+		trustDomain:              identityConfig.trustDomain,
+		clusterSPIFFEIDClassName: identityConfig.clusterSPIFFEIDClassName,
 	}
 }
 
@@ -532,6 +591,15 @@ func inspectionPlan(
 	objective *unstructured.Unstructured,
 	pool *unstructured.Unstructured,
 ) (identity.Plan, error) {
+	return inspectionPlanWithTrustDomain(binding, objective, pool, identity.DefaultTrustDomain)
+}
+
+func inspectionPlanWithTrustDomain(
+	binding *kleymv1alpha1.InferenceIdentityBinding,
+	objective *unstructured.Unstructured,
+	pool *unstructured.Unstructured,
+	trustDomain string,
+) (identity.Plan, error) {
 	poolSelector, poolDerivedSelectors, err := gaie.DeriveSelectorsFromPool(pool)
 	if err != nil {
 		return identity.Plan{}, err
@@ -542,7 +610,7 @@ func inspectionPlan(
 	}
 	return identity.PlanIdentity(identity.PlanInput{
 		Binding:              binding,
-		TrustDomain:          identity.DefaultTrustDomain,
+		TrustDomain:          trustDomain,
 		ObjectiveName:        objectiveName,
 		PoolName:             pool.GetName(),
 		PodSelector:          poolSelector,

--- a/internal/inspection/report.go
+++ b/internal/inspection/report.go
@@ -105,6 +105,7 @@ type BindingInspectionDesiredState struct {
 	WorkloadSelectors   []string                             `json:"workloadSelectors,omitempty"`
 	SelectorProvenance  *BindingInspectionSelectorProvenance `json:"selectorProvenance,omitempty"`
 	Hint                string                               `json:"hint,omitempty"`
+	ClassName           string                               `json:"className,omitempty"`
 	Fallback            *bool                                `json:"fallback,omitempty"`
 }
 
@@ -122,6 +123,7 @@ type BindingInspectionManagedClusterSPIFFEID struct {
 	PodSelector       map[string]any     `json:"podSelector,omitempty"`
 	WorkloadSelectors []string           `json:"workloadSelectors,omitempty"`
 	Hint              string             `json:"hint,omitempty"`
+	ClassName         string             `json:"className,omitempty"`
 	Fallback          *bool              `json:"fallback,omitempty"`
 	Conditions        []metav1.Condition `json:"conditions,omitempty"`
 }
@@ -223,6 +225,7 @@ func writeBindingInspectionReportText(w io.Writer, report BindingInspectionRepor
 	appendTextLine(&builder, "Identity:")
 	appendTextLine(&builder, "  ClusterSPIFFEID: %s", textString(report.Desired.ClusterSPIFFEIDName))
 	appendTextLine(&builder, "  SPIFFE ID: %s", textString(report.Desired.SPIFFEID))
+	appendTextLine(&builder, "  ClassName: %s", textString(report.Desired.ClassName))
 	appendTextLine(&builder, "  Hint: %s", textString(report.Desired.Hint))
 	appendTextLine(&builder, "  Fallback: %s", textBool(report.Desired.Fallback))
 

--- a/internal/inspection/report_test.go
+++ b/internal/inspection/report_test.go
@@ -137,8 +137,9 @@ func TestBindingInspectionReportJSONRepresentativeShape(t *testing.T) {
 				ContainerSelector:    "k8s:container-name:model-server",
 				SafetySelectors:      []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
 			},
-			Hint:     "tenant-a/binding-a",
-			Fallback: &fallbackFalse,
+			Hint:      "tenant-a/binding-a",
+			ClassName: "kleym",
+			Fallback:  &fallbackFalse,
 		},
 		Observed: BindingInspectionObservedState{
 			ManagedClusterSPIFFEIDs: []BindingInspectionManagedClusterSPIFFEID{{
@@ -149,6 +150,7 @@ func TestBindingInspectionReportJSONRepresentativeShape(t *testing.T) {
 				},
 				WorkloadSelectors: []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
 				Hint:              "tenant-a/binding-a",
+				ClassName:         "kleym",
 				Fallback:          &fallbackFalse,
 			}},
 			Drift: []BindingInspectionDriftEntry{{
@@ -193,7 +195,7 @@ func TestBindingInspectionReportJSONRepresentativeShape(t *testing.T) {
 
 	assertObjectKeys(t, got["bindingRef"], "conditions", "generation", "mode", "name", "namespace", "objectiveRef", "poolRef")
 	assertObjectKeys(t, got["resolvedInput"], "containerName", "objectiveRef", "poolRef", "poolSelector", "selectorProvenance", "servedGVKs")
-	assertObjectKeys(t, got["desired"], "clusterSPIFFEIDName", "fallback", "hint", "podSelector", "selectorProvenance", "spiffeID", "workloadSelectors")
+	assertObjectKeys(t, got["desired"], "className", "clusterSPIFFEIDName", "fallback", "hint", "podSelector", "selectorProvenance", "spiffeID", "workloadSelectors")
 	assertObjectKeys(t, got["observed"], "drift", "eligibleWorkloads", "managedClusterSPIFFEIDs")
 	assertObjectKeys(t, got["capabilities"], "binding", "clusterspiffeids", "gaieResources", "peerBindings", "pods")
 

--- a/internal/spirecm/clusterspiffeid.go
+++ b/internal/spirecm/clusterspiffeid.go
@@ -71,6 +71,7 @@ func ClusterSPIFFEIDGVK() schema.GroupVersionKind {
 func DesiredClusterSPIFFEID(
 	binding *kleymv1alpha1.InferenceIdentityBinding,
 	plan identity.Plan,
+	className string,
 ) *unstructured.Unstructured {
 	object := &unstructured.Unstructured{}
 	object.SetGroupVersionKind(ClusterSPIFFEIDGVK())
@@ -82,13 +83,17 @@ func DesiredClusterSPIFFEID(
 		selectorTemplates = append(selectorTemplates, selector)
 	}
 
-	object.Object["spec"] = map[string]any{
+	spec := map[string]any{
 		"spiffeIDTemplate":          plan.SpiffeID,
 		"podSelector":               plan.PodSelector,
 		"workloadSelectorTemplates": selectorTemplates,
 		"fallback":                  RenderFallback(),
 		"hint":                      BuildClusterSPIFFEIDHint(binding),
 	}
+	if className != "" {
+		spec["className"] = className
+	}
+	object.Object["spec"] = spec
 
 	return object
 }
@@ -201,6 +206,7 @@ func DriftEntries(desired *unstructured.Unstructured, observed *unstructured.Uns
 		"workloadSelectorTemplates",
 		"hint",
 		"fallback",
+		"className",
 	} {
 		if reflect.DeepEqual(desiredSpec[field], observedSpec[field]) {
 			continue

--- a/internal/spirecm/clusterspiffeid_test.go
+++ b/internal/spirecm/clusterspiffeid_test.go
@@ -22,7 +22,7 @@ func TestDesiredClusterSPIFFEIDIncludesHintAndFallback(t *testing.T) {
 		Selectors:   []string{"k8s:ns:default", "k8s:sa:inference-sa", "k8s:pod-label:app:model-server"},
 	}
 
-	desired := DesiredClusterSPIFFEID(binding, plan)
+	desired := DesiredClusterSPIFFEID(binding, plan, "")
 	spec, found, err := unstructured.NestedMap(desired.Object, "spec")
 	if err != nil {
 		t.Fatalf("failed to inspect desired ClusterSPIFFEID spec: %v", err)
@@ -35,5 +35,37 @@ func TestDesiredClusterSPIFFEIDIncludesHintAndFallback(t *testing.T) {
 	}
 	if spec["fallback"] != false {
 		t.Fatalf("fallback = %v, want false", spec["fallback"])
+	}
+}
+
+func TestDesiredClusterSPIFFEIDClassName(t *testing.T) {
+	t.Parallel()
+
+	binding := &kleymv1alpha1.InferenceIdentityBinding{}
+	binding.Name = "binding-a"
+	binding.Namespace = "default"
+	plan := identity.Plan{
+		Mode:        kleymv1alpha1.InferenceIdentityBindingModePoolOnly,
+		SpiffeID:    "spiffe://example.org/ns/default/pool/pool-a",
+		PodSelector: map[string]any{"matchLabels": map[string]any{"app": "model-server"}},
+		Selectors:   []string{"k8s:ns:default", "k8s:sa:inference-sa", "k8s:pod-label:app:model-server"},
+	}
+
+	classless := DesiredClusterSPIFFEID(binding, plan, "")
+	classlessSpec, _, err := unstructured.NestedMap(classless.Object, "spec")
+	if err != nil {
+		t.Fatalf("failed to inspect classless ClusterSPIFFEID spec: %v", err)
+	}
+	if _, ok := classlessSpec["className"]; ok {
+		t.Fatalf("classless spec rendered className: %#v", classlessSpec["className"])
+	}
+
+	classed := DesiredClusterSPIFFEID(binding, plan, "kleym")
+	classedSpec, _, err := unstructured.NestedMap(classed.Object, "spec")
+	if err != nil {
+		t.Fatalf("failed to inspect classed ClusterSPIFFEID spec: %v", err)
+	}
+	if classedSpec["className"] != "kleym" {
+		t.Fatalf("className = %q, want kleym", classedSpec["className"])
 	}
 }


### PR DESCRIPTION
## Summary

- Add install-level operator configuration for SPIFFE trust domain and optional ClusterSPIFFEID class name.
- Wire the configured trust domain through identity planning and ClusterSPIFFEID rendering.
- Update operator docs/reference material and tests for configured trust domains and classed/classless ClusterSPIFFEID output.

## What I Changed And Why

- Added `--trust-domain` and `--clusterspiffeid-class-name` flags to `kleym-operator` so deployment-level SPIRE settings are controlled at operator startup instead of per binding.
- Added controller operator config validation that fails startup when the trust domain is missing or malformed, and allows an empty class name to preserve classless ClusterSPIFFEID behavior.
- Replaced the hardcoded SPIFFE trust domain in identity rendering with configured input, and passed the optional class name into SPIRE Controller Manager resource rendering.
- Updated controller, identity, inspection, and SPIRE CM tests to cover the configured rendering paths while preserving existing reconciliation behavior.

## Related Issue

- Fixes #202

## Scope Check

- This PR keeps `trustDomain` and `ClusterSPIFFEID` class name as operator deployment concerns and does not add fields to `InferenceIdentityBinding`.
- It does not introduce multi-class support, a generic registration backend abstraction, or CRD/API shape changes.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): updated with operator config, trust domain behavior, and SPIRE Controller Manager class/watchClassless interaction.
- CLI Spec (`docs/spec/cli.md`): not needed because the CLI behavior is unchanged.
- Other docs: updated generated/reference docs for operator args and rendered resource behavior.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none identified.

## Verification

- Commands run: `go test ./internal/identity ./internal/spirecm ./internal/controller ./cmd/kleym-operator`
- Tests not run and why: broader repository checks were not run because the issue's expected validation targets the touched Go packages.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or repository secret handling.
- It does touch identity trust-boundary configuration by making the SPIFFE trust domain explicit and fail-fast validated; untrusted GitHub issue content was not used to execute commands or broaden scope.