### PR TITLE
fix(cli): use binding status operator config

### DIFF
--- a/api/v1alpha1/inferenceidentitybinding_types.go
+++ b/api/v1alpha1/inferenceidentitybinding_types.go
@@ -155,6 +155,15 @@ type InferenceIdentityBindingStatus struct {
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
+	// trustDomain is the operator trust domain used when rendering the latest status.
+	// +optional
+	TrustDomain string `json:"trustDomain,omitempty"`
+
+	// clusterSPIFFEIDClassName is the operator ClusterSPIFFEID class name used
+	// when rendering the latest status. Empty means classless ClusterSPIFFEID output.
+	// +optional
+	ClusterSPIFFEIDClassName string `json:"clusterSPIFFEIDClassName,omitempty"`
+
 	// computedSpiffeIDs lists the SPIFFE IDs produced from the binding references.
 	// +optional
 	ComputedSpiffeIDs []ComputedSpiffeIDStatus `json:"computedSpiffeIDs,omitempty"`

--- a/config/crd/bases/kleym.sonda.red_inferenceidentitybindings.yaml
+++ b/config/crd/bases/kleym.sonda.red_inferenceidentitybindings.yaml
@@ -114,6 +114,11 @@ spec:
           status:
             description: status defines the observed state of InferenceIdentityBinding.
             properties:
+              clusterSPIFFEIDClassName:
+                description: |-
+                  clusterSPIFFEIDClassName is the operator ClusterSPIFFEID class name used
+                  when rendering the latest status. Empty means classless ClusterSPIFFEID output.
+                type: string
               computedSpiffeIDs:
                 description: computedSpiffeIDs lists the SPIFFE IDs produced from
                   the binding references.
@@ -225,6 +230,10 @@ spec:
                   - spiffeID
                   type: object
                 type: array
+              trustDomain:
+                description: trustDomain is the operator trust domain used when rendering
+                  the latest status.
+                type: string
             type: object
         required:
         - spec

--- a/docs/cli/findings.md
+++ b/docs/cli/findings.md
@@ -35,5 +35,6 @@ reasons where possible. See [Conditions](/reference/conditions/).
 | `kleym-collision` | `error` | Kleym detected a deterministic identity collision. |
 | `zero-eligible-workloads` | `info` | Scale-to-zero can be valid. |
 | `observed-drift` | `warning` or `error` | Managed output differs from desired output. |
+| `identity-config-undiscovered` | `warning` | Binding status does not include operator config, so inspection used CLI flags, defaults, or both. |
 | `rbac-limited` | `warning` | Inspection continued with reduced visibility. |
 | `unsupported-selector` | `warning` | Pod inspection cannot fully evaluate a rendered selector type. |

--- a/docs/cli/inspection-report.md
+++ b/docs/cli/inspection-report.md
@@ -21,6 +21,7 @@ kleym inspect binding <name> -n <namespace> -o json
   "schemaVersion": "v1alpha1",
   "kind": "BindingInspectionReport",
   "generatedAt": "",
+  "identityConfig": {},
   "bindingRef": {},
   "resolvedInput": {},
   "desired": {},
@@ -34,6 +35,7 @@ kleym inspect binding <name> -n <namespace> -o json
 
 | Field | Meaning |
 | --- | --- |
+| `identityConfig` | Trust domain and `ClusterSPIFFEID` class name used to render desired output, plus per-field source (`flag`, `bindingStatus`, or `default`). |
 | `bindingRef` | Binding identity, generation, mode, refs, and current conditions. |
 | `resolvedInput` | Resolved GAIE inputs, served GVKs, selector provenance, and container name. |
 | `desired` | Desired `ClusterSPIFFEID` name, SPIFFE ID, class name, selectors, hint, and fallback value. |

--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -41,8 +41,9 @@ Inspect one binding:
 bin/kleym inspect binding <name> -n <namespace>
 ```
 
-If the operator was installed with non-default identity settings, pass the same
-values to inspection:
+Inspection normally reads operator config from `InferenceIdentityBinding.status.trustDomain`
+and `status.clusterSPIFFEIDClassName`. Pass flags only when you need to override
+that discovered config or inspect an older binding whose status does not record it:
 
 ```sh
 bin/kleym inspect binding <name> -n <namespace> \
@@ -66,8 +67,8 @@ bin/kleym inspect binding <name> -n <namespace> -o json
 | `--context` | Kubeconfig context name. |
 | `--kubeconfig` | Kubeconfig file path. |
 | `--timeout` | Inspection timeout. Must be greater than zero. |
-| `--trust-domain` | Trust domain used to recompute desired SPIFFE IDs. Defaults to `kleym.sonda.red`. |
-| `--clusterspiffeid-class-name` | Optional expected `ClusterSPIFFEID.spec.className`. Defaults to classless output. |
+| `--trust-domain` | Override trust domain used to recompute desired SPIFFE IDs. If operator config is unavailable and this flag is omitted, inspection falls back to `kleym.sonda.red`. |
+| `--clusterspiffeid-class-name` | Override expected `ClusterSPIFFEID.spec.className`. If operator config is unavailable and this flag is omitted, inspection falls back to classless output. |
 
 ## Access
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -51,6 +51,8 @@ Current validation rules enforced by the CRD:
 | Field | Meaning |
 | --- | --- |
 | `conditions` | Latest controller observations. |
+| `trustDomain` | Operator trust domain used for the latest status update. |
+| `clusterSPIFFEIDClassName` | Optional operator `ClusterSPIFFEID` class name used for the latest status update. Empty means classless output. |
 | `computedSpiffeIDs` | Computed SPIFFE IDs with the mode that produced them. |
 | `renderedSelectors` | Final selector set used for each rendered identity. |
 

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -35,9 +35,9 @@ Supported flags:
 ```
 
 Default namespace is `default`. Default output is `text`. `--timeout` must be greater than zero.
-`--trust-domain` defaults to `kleym.sonda.red` and must follow the same validation rules as
-`kleym-operator --trust-domain`. `--clusterspiffeid-class-name` defaults to empty, matching
-classless `ClusterSPIFFEID` output.
+`--trust-domain` must follow the same validation rules as `kleym-operator --trust-domain`.
+`--clusterspiffeid-class-name` defaults to empty when used as a fallback or explicit override,
+matching classless `ClusterSPIFFEID` output.
 
 ## Output Contract
 
@@ -51,12 +51,13 @@ kleym inspect binding <name> -n <namespace> -o json
 
 Text output leads with a summary and must not introduce inspection semantics absent from the canonical report data.
 
-`kleym inspect binding` emits a `BindingInspectionReport` with four core sections:
+`kleym inspect binding` emits a `BindingInspectionReport` with five core sections:
 
-1. `desired`: what Kleym would render from the inspected binding and resolved inputs.
-2. `observed`: Kleym-managed `ClusterSPIFFEID` resources, drift, status, and eligible workloads when pod reads are available.
-3. `findings`: typed issues or notable states discovered during inspection.
-4. `capabilities`: whether each inspection area was complete, partial, skipped, or unknown.
+1. `identityConfig`: trust domain and class-name values used for desired rendering, plus their sources.
+2. `desired`: what Kleym would render from the inspected binding and resolved inputs.
+3. `observed`: Kleym-managed `ClusterSPIFFEID` resources, drift, status, and eligible workloads when pod reads are available.
+4. `findings`: typed issues or notable states discovered during inspection.
+5. `capabilities`: whether each inspection area was complete, partial, skipped, or unknown.
 
 Top-level JSON shape:
 
@@ -65,6 +66,7 @@ Top-level JSON shape:
   "schemaVersion": "v1alpha1",
   "kind": "BindingInspectionReport",
   "generatedAt": "",
+  "identityConfig": {},
   "bindingRef": {},
   "resolvedInput": {},
   "desired": {},
@@ -79,11 +81,15 @@ Report fields and findings are documented in [Inspection Report][inspection-repo
 ## Inspect Binding Behavior
 
 1. Resolve the binding, `poolRef`, and required or present `objectiveRef`; validate that an objective references the same pool.
-2. Recompute desired identity state with shared Kleym logic.
-3. Use the inspection trust domain and optional `ClusterSPIFFEID` class setting when recomputing desired SPIFFE IDs and managed output.
-4. Evaluate Kleym collision state from peer binding fingerprints when available; otherwise use the inspected binding's current `Conflict` condition and mark peer analysis partial or unknown.
-5. Locate Kleym-managed `ClusterSPIFFEID` resources, compare desired and observed state, and evaluate eligible workloads when pod reads are available.
-6. Emit the report and exit according to finding severity and inspection completeness.
+2. Choose identity config for recomputing desired output with this precedence for each field:
+   explicit CLI flag, `InferenceIdentityBinding.status.trustDomain` and `status.clusterSPIFFEIDClassName`, then CLI default.
+   The default trust domain fallback is `kleym.sonda.red`; the default class-name fallback is empty.
+3. Record the chosen trust domain, class name, and per-field source in `report.identityConfig`.
+   If binding status does not contain operator config, add a warning finding that inspection is using CLI defaults, flags, or a mix of both.
+4. Recompute desired identity state with shared Kleym logic.
+5. Evaluate Kleym collision state from peer binding fingerprints when available; otherwise use the inspected binding's current `Conflict` condition and mark peer analysis partial or unknown.
+6. Locate Kleym-managed `ClusterSPIFFEID` resources, compare desired and observed state, and evaluate eligible workloads when pod reads are available.
+7. Emit the report and exit according to finding severity and inspection completeness.
 
 `kleym` reports eligibility, not credential use. It reports deterministic Kleym collisions and visible drift; it does not fully simulate SPIRE selection behavior or analyze unrelated non-Kleym `ClusterSPIFFEID` overlap.
 

--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -24,7 +24,7 @@ Dependency facts live in [Dependencies][dependencies]. Supported GAIE inputs liv
 | `--trust-domain=<value>` | yes | Sets the SPIRE Server trust domain used when rendering every SPIFFE ID. The value must not include `spiffe://`, must not contain `/`, and must not include leading or trailing whitespace. |
 | `--clusterspiffeid-class-name=<value>` | no | Sets `spec.className` on every managed `ClusterSPIFFEID`. When empty, Kleym omits `spec.className` and keeps classless output. |
 
-`trustDomain` and `ClusterSPIFFEID` class are deployment concerns, not per-binding inference identity intent. They are not fields on `InferenceIdentityBinding`.
+`trustDomain` and `ClusterSPIFFEID` class are deployment concerns, not per-binding inference identity intent. They are not fields in `InferenceIdentityBinding.spec`.
 
 When `--clusterspiffeid-class-name` is empty, SPIRE Controller Manager must be configured to watch classless `ClusterSPIFFEID` resources, for example with its `watchClassless` behavior. When a class name is set, SPIRE Controller Manager must watch that class.
 
@@ -40,7 +40,8 @@ When `--clusterspiffeid-class-name` is empty, SPIRE Controller Manager must be c
    - `PoolOnly`: `spiffe://<trustDomain>/ns/<namespace>/pool/<pool-name>`
    - `PerObjective`: `spiffe://<trustDomain>/ns/<namespace>/objective/<objective-name>`
 6. `containerName` is required for `PerObjective` and must be empty for `PoolOnly`.
-7. Status records `computedSpiffeIDs`, `renderedSelectors`, and conditions. Conditions include `Ready`, `Conflict`, `InvalidRef`, `UnsafeSelector`, and `RenderFailure`.
+7. Status records `trustDomain`, `clusterSPIFFEIDClassName`, `computedSpiffeIDs`, `renderedSelectors`, and conditions. Conditions include `Ready`, `Conflict`, `InvalidRef`, `UnsafeSelector`, and `RenderFailure`.
+8. `trustDomain` and `clusterSPIFFEIDClassName` record the operator config values used for the latest status update. They are observation data for read-only inspection compatibility; they do not make trust domain or class name per-binding spec intent.
 
 Field details live in [API Reference][api-reference]. Condition details live in [Conditions Reference][conditions-reference].
 

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -15,11 +15,13 @@ var (
 
 var newBindingInspectionRunner = func(opts *Options) (inspection.BindingInspector, error) {
 	return inspection.NewKubernetesBindingInspector(inspection.Config{
-		Context:                  opts.Context,
-		Kubeconfig:               opts.Kubeconfig,
-		Timeout:                  opts.Timeout,
-		TrustDomain:              opts.TrustDomain,
-		ClusterSPIFFEIDClassName: opts.ClusterSPIFFEIDClassName,
+		Context:                          opts.Context,
+		Kubeconfig:                       opts.Kubeconfig,
+		Timeout:                          opts.Timeout,
+		TrustDomain:                      opts.TrustDomain,
+		TrustDomainOverride:              opts.TrustDomainOverride,
+		ClusterSPIFFEIDClassName:         opts.ClusterSPIFFEIDClassName,
+		ClusterSPIFFEIDClassNameOverride: opts.ClusterSPIFFEIDClassNameOverride,
 	})
 }
 
@@ -36,7 +38,8 @@ func newInspectCommand(opts *Options) *cobra.Command {
 		Args: func(cmd *cobra.Command, args []string) error {
 			return withExitCode(exitUsage, cobra.ExactArgs(1)(cmd, args))
 		},
-		PreRunE: func(_ *cobra.Command, _ []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			captureIdentityConfigFlagSources(cmd, opts)
 			return validateRunnableOptions(opts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/inspect_test.go
+++ b/internal/cli/inspect_test.go
@@ -75,8 +75,41 @@ func TestInspectBindingPassesOperatorConfigFlagsToRunner(t *testing.T) {
 	if captured.TrustDomain != "example.org" {
 		t.Fatalf("trustDomain = %q, want example.org", captured.TrustDomain)
 	}
+	if !captured.TrustDomainOverride {
+		t.Fatalf("TrustDomainOverride = false, want true")
+	}
 	if captured.ClusterSPIFFEIDClassName != "kleym" {
 		t.Fatalf("ClusterSPIFFEIDClassName = %q, want kleym", captured.ClusterSPIFFEIDClassName)
+	}
+	if !captured.ClusterSPIFFEIDClassNameOverride {
+		t.Fatalf("ClusterSPIFFEIDClassNameOverride = false, want true")
+	}
+}
+
+func TestInspectBindingDefaultOperatorConfigFlagsAreNotOverrides(t *testing.T) {
+	originalFactory := newBindingInspectionRunner
+	t.Cleanup(func() { newBindingInspectionRunner = originalFactory })
+
+	fakeReport := inspection.NewBindingInspectionReport()
+	var captured Options
+	newBindingInspectionRunner = func(opts *Options) (inspection.BindingInspector, error) {
+		captured = *opts
+		return fixedInspectionRunner{report: fakeReport}, nil
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"inspect", "binding", "binding-a"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("inspect binding returned error: %v", err)
+	}
+	if captured.TrustDomainOverride {
+		t.Fatalf("TrustDomainOverride = true, want false")
+	}
+	if captured.ClusterSPIFFEIDClassNameOverride {
+		t.Fatalf("ClusterSPIFFEIDClassNameOverride = true, want false")
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -21,14 +21,16 @@ var validOutputFormats = []string{outputText, outputJSON}
 
 // Options holds top-level CLI flags for the kleym command tree.
 type Options struct {
-	Namespace                string
-	Output                   string
-	Strict                   bool
-	Context                  string
-	Kubeconfig               string
-	Timeout                  time.Duration
-	TrustDomain              string
-	ClusterSPIFFEIDClassName string
+	Namespace                        string
+	Output                           string
+	Strict                           bool
+	Context                          string
+	Kubeconfig                       string
+	Timeout                          time.Duration
+	TrustDomain                      string
+	TrustDomainOverride              bool
+	ClusterSPIFFEIDClassName         string
+	ClusterSPIFFEIDClassNameOverride bool
 }
 
 // NewRootCommand builds the kleym root command defined by the CLI spec.
@@ -58,6 +60,17 @@ func NewRootCommand() *cobra.Command {
 
 	cmd.AddCommand(newInspectCommand(opts))
 	return cmd
+}
+
+// captureIdentityConfigFlagSources records whether identity config flags were
+// explicitly set so inspection can prefer binding status by default.
+func captureIdentityConfigFlagSources(cmd *cobra.Command, opts *Options) {
+	if flag := cmd.Flag("trust-domain"); flag != nil {
+		opts.TrustDomainOverride = flag.Changed
+	}
+	if flag := cmd.Flag("clusterspiffeid-class-name"); flag != nil {
+		opts.ClusterSPIFFEIDClassNameOverride = flag.Changed
+	}
 }
 
 func validateRunnableOptions(opts *Options) error {

--- a/internal/controller/inferenceidentitybinding_collision_test.go
+++ b/internal/controller/inferenceidentitybinding_collision_test.go
@@ -36,7 +36,10 @@ func TestReconcilePerObjectiveCollisionMarksAllAndBlocksClusterSPIFFEID(t *testi
 	}
 
 	fakeRecorder := newFakeEventRecorder(32)
-	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
+	reconciler := &InferenceIdentityBindingReconciler{Config: OperatorConfig{
+		TrustDomain:              "example.org",
+		ClusterSPIFFEIDClassName: "kleym",
+	},
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
@@ -57,6 +60,7 @@ func TestReconcilePerObjectiveCollisionMarksAllAndBlocksClusterSPIFFEID(t *testi
 	assertConditionStatus(t, ctx, reconciler.Client, "binding-b", conditionTypeConflict, metav1.ConditionTrue, "IdentityCollision")
 	assertConditionStatus(t, ctx, reconciler.Client, "binding-a", conditionTypeReady, metav1.ConditionFalse, "IdentityCollision")
 	assertConditionStatus(t, ctx, reconciler.Client, "binding-b", conditionTypeReady, metav1.ConditionFalse, "IdentityCollision")
+	assertStatusOperatorConfig(t, ctx, reconciler.Client, "binding-b", "example.org", "kleym")
 	assertClusterSPIFFEIDCount(t, ctx, reconciler.Client, 0)
 	assertEventContains(t, fakeRecorder.Events, "IdentityCollision")
 }
@@ -419,6 +423,40 @@ func assertConditionStatus(
 	}
 	if expectedReason != "" && condition.Reason != expectedReason {
 		t.Fatalf("condition %q on %s/%s reason = %q, want %q", conditionType, testNamespace, name, condition.Reason, expectedReason)
+	}
+}
+
+func assertStatusOperatorConfig(
+	t *testing.T,
+	ctx context.Context,
+	cli client.Client,
+	name string,
+	trustDomain string,
+	clusterSPIFFEIDClassName string,
+) {
+	t.Helper()
+
+	binding := &kleymv1alpha1.InferenceIdentityBinding{}
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: name}, binding); err != nil {
+		t.Fatalf("failed to fetch %s/%s: %v", testNamespace, name, err)
+	}
+	if binding.Status.TrustDomain != trustDomain {
+		t.Fatalf(
+			"status.trustDomain on %s/%s = %q, want %q",
+			testNamespace,
+			name,
+			binding.Status.TrustDomain,
+			trustDomain,
+		)
+	}
+	if binding.Status.ClusterSPIFFEIDClassName != clusterSPIFFEIDClassName {
+		t.Fatalf(
+			"status.clusterSPIFFEIDClassName on %s/%s = %q, want %q",
+			testNamespace,
+			name,
+			binding.Status.ClusterSPIFFEIDClassName,
+			clusterSPIFFEIDClassName,
+		)
 	}
 }
 

--- a/internal/controller/inferenceidentitybinding_controller.go
+++ b/internal/controller/inferenceidentitybinding_controller.go
@@ -181,6 +181,7 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(
 	// Phase 4: Compute desired state — resolve objective → pool → identity → collisions.
 	statusBase := binding.DeepCopy()
 	initializeConditions(&binding.Status, binding.Generation)
+	applyOperatorConfig(&binding.Status, r.Config)
 	wasColliding := conditionIsTrue(statusBase.Status.Conditions, conditionTypeConflict)
 
 	desiredState, err := r.computeDesiredState(ctx, binding, wasColliding)
@@ -590,6 +591,7 @@ func (r *InferenceIdentityBindingReconciler) applyCollisionState(
 
 		if err := r.patchStatus(ctx, state.binding, func(status *kleymv1alpha1.InferenceIdentityBindingStatus) {
 			initializeConditions(status, state.binding.Generation)
+			applyOperatorConfig(status, r.Config)
 			applyCollisionStatus(status, state.binding.Generation, state.hasCollision, state.message)
 		}); err != nil {
 			return collisionApplyResult{}, err

--- a/internal/controller/inferenceidentitybinding_resolver_test.go
+++ b/internal/controller/inferenceidentitybinding_resolver_test.go
@@ -119,6 +119,17 @@ func TestReconcileUsesOperatorConfigForRenderedOutput(t *testing.T) {
 	if className != "kleym" {
 		t.Fatalf("className = %q, want kleym", className)
 	}
+
+	current := &kleymv1alpha1.InferenceIdentityBinding{}
+	if err := reconciler.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: binding.Name}, current); err != nil {
+		t.Fatalf("failed to read binding status: %v", err)
+	}
+	if current.Status.TrustDomain != "example.org" {
+		t.Fatalf("status.trustDomain = %q, want example.org", current.Status.TrustDomain)
+	}
+	if current.Status.ClusterSPIFFEIDClassName != "kleym" {
+		t.Fatalf("status.clusterSPIFFEIDClassName = %q, want kleym", current.Status.ClusterSPIFFEIDClassName)
+	}
 }
 
 func TestReconcilePerObjectiveRequiresObjectiveRef(t *testing.T) {

--- a/internal/controller/inferenceidentitybinding_status.go
+++ b/internal/controller/inferenceidentitybinding_status.go
@@ -62,6 +62,15 @@ func initializeConditions(
 	}
 }
 
+// applyOperatorConfig records the operator render settings used for this status update.
+func applyOperatorConfig(
+	status *kleymv1alpha1.InferenceIdentityBindingStatus,
+	config OperatorConfig,
+) {
+	status.TrustDomain = config.TrustDomain
+	status.ClusterSPIFFEIDClassName = config.ClusterSPIFFEIDClassName
+}
+
 func applySuccessStatus(
 	status *kleymv1alpha1.InferenceIdentityBindingStatus,
 	generation int64,

--- a/internal/inspection/inspection.go
+++ b/internal/inspection/inspection.go
@@ -29,23 +29,31 @@ import (
 )
 
 const (
-	findingBindingNotFound      = "binding-not-found"
-	findingInvalidRef           = "invalid-ref"
-	findingDependencyMissing    = "dependency-missing"
-	findingUnsafeSelector       = "unsafe-selector"
-	findingRenderFailure        = "render-failure"
-	findingKleymCollision       = "kleym-collision"
-	findingZeroEligibleWorkload = "zero-eligible-workloads"
-	findingUnsupportedSelector  = "unsupported-selector"
-	findingObservedDrift        = "observed-drift"
-	findingRBACLimited          = "rbac-limited"
-	reasonZeroEligibleWorkload  = "ZeroEligibleWorkloads"
-	reasonUnsupportedSelector   = "UnsupportedSelector"
-	reasonObservedDrift         = "ObservedDrift"
-	reasonRBACLimited           = "Forbidden"
-	conditionTypeConflict       = "Conflict"
-	clusterSPIFFEIDResourceName = "clusterspiffeids"
-	podResourceName             = "pods"
+	findingBindingNotFound       = "binding-not-found"
+	findingInvalidRef            = "invalid-ref"
+	findingDependencyMissing     = "dependency-missing"
+	findingUnsafeSelector        = "unsafe-selector"
+	findingRenderFailure         = "render-failure"
+	findingKleymCollision        = "kleym-collision"
+	findingZeroEligibleWorkload  = "zero-eligible-workloads"
+	findingUnsupportedSelector   = "unsupported-selector"
+	findingObservedDrift         = "observed-drift"
+	findingRBACLimited           = "rbac-limited"
+	findingIdentityConfigMissing = "identity-config-undiscovered"
+	reasonZeroEligibleWorkload   = "ZeroEligibleWorkloads"
+	reasonUnsupportedSelector    = "UnsupportedSelector"
+	reasonObservedDrift          = "ObservedDrift"
+	reasonRBACLimited            = "Forbidden"
+	reasonIdentityConfigMissing  = "IdentityConfigUndiscovered"
+	conditionTypeConflict        = "Conflict"
+	clusterSPIFFEIDResourceName  = "clusterspiffeids"
+	podResourceName              = "pods"
+)
+
+const (
+	identityConfigSourceBindingStatus = "bindingStatus"
+	identityConfigSourceDefault       = "default"
+	identityConfigSourceFlag          = "flag"
 )
 
 var (
@@ -57,11 +65,13 @@ var (
 
 // Config describes Kubernetes access settings for live binding inspection.
 type Config struct {
-	Context                  string
-	Kubeconfig               string
-	Timeout                  time.Duration
-	TrustDomain              string
-	ClusterSPIFFEIDClassName string
+	Context                          string
+	Kubeconfig                       string
+	Timeout                          time.Duration
+	TrustDomain                      string
+	TrustDomainOverride              bool
+	ClusterSPIFFEIDClassName         string
+	ClusterSPIFFEIDClassNameOverride bool
 }
 
 // BindingInspector inspects one binding and returns the stable report model.
@@ -70,11 +80,10 @@ type BindingInspector interface {
 }
 
 type bindingInspector struct {
-	client                   client.Client
-	mapper                   meta.RESTMapper
-	now                      func() time.Time
-	trustDomain              string
-	clusterSPIFFEIDClassName string
+	client         client.Client
+	mapper         meta.RESTMapper
+	now            func() time.Time
+	identityConfig inspectionIdentityConfig
 }
 
 // NewKubernetesBindingInspector returns a read-only Kubernetes-backed binding inspector.
@@ -111,17 +120,26 @@ func NewKubernetesBindingInspector(config Config) (BindingInspector, error) {
 	}
 
 	return &bindingInspector{
-		client:                   kubeClient,
-		mapper:                   mapper,
-		now:                      time.Now,
-		trustDomain:              identityConfig.trustDomain,
-		clusterSPIFFEIDClassName: identityConfig.clusterSPIFFEIDClassName,
+		client:         kubeClient,
+		mapper:         mapper,
+		now:            time.Now,
+		identityConfig: identityConfig,
 	}, nil
 }
 
 type inspectionIdentityConfig struct {
-	trustDomain              string
-	clusterSPIFFEIDClassName string
+	trustDomain                      string
+	trustDomainOverride              bool
+	clusterSPIFFEIDClassName         string
+	clusterSPIFFEIDClassNameOverride bool
+}
+
+type resolvedIdentityConfig struct {
+	trustDomain                    string
+	trustDomainSource              string
+	clusterSPIFFEIDClassName       string
+	clusterSPIFFEIDClassNameSource string
+	discovered                     bool
 }
 
 func normalizedInspectionIdentityConfig(config Config) (inspectionIdentityConfig, error) {
@@ -130,8 +148,10 @@ func normalizedInspectionIdentityConfig(config Config) (inspectionIdentityConfig
 		trustDomain = identity.DefaultTrustDomain
 	}
 	identityConfig := inspectionIdentityConfig{
-		trustDomain:              trustDomain,
-		clusterSPIFFEIDClassName: config.ClusterSPIFFEIDClassName,
+		trustDomain:                      trustDomain,
+		trustDomainOverride:              config.TrustDomainOverride,
+		clusterSPIFFEIDClassName:         config.ClusterSPIFFEIDClassName,
+		clusterSPIFFEIDClassNameOverride: config.ClusterSPIFFEIDClassNameOverride,
 	}
 	if err := ValidateOperatorIdentityConfig(identityConfig.trustDomain, identityConfig.clusterSPIFFEIDClassName); err != nil {
 		return inspectionIdentityConfig{}, err
@@ -157,6 +177,46 @@ func ValidateOperatorIdentityConfig(trustDomain string, clusterSPIFFEIDClassName
 		return fmt.Errorf("clusterspiffeidClassName must not include leading or trailing whitespace")
 	}
 	return nil
+}
+
+// resolveIdentityConfig applies the CLI precedence contract from docs/spec/cli.md.
+func (i *bindingInspector) resolveIdentityConfig(
+	binding *kleymv1alpha1.InferenceIdentityBinding,
+	report *BindingInspectionReport,
+) resolvedIdentityConfig {
+	config := resolvedIdentityConfig{
+		trustDomain:                    i.identityConfig.trustDomain,
+		trustDomainSource:              identityConfigSourceDefault,
+		clusterSPIFFEIDClassName:       i.identityConfig.clusterSPIFFEIDClassName,
+		clusterSPIFFEIDClassNameSource: identityConfigSourceDefault,
+	}
+
+	if binding.Status.TrustDomain != "" {
+		config.discovered = true
+		config.trustDomain = binding.Status.TrustDomain
+		config.trustDomainSource = identityConfigSourceBindingStatus
+		config.clusterSPIFFEIDClassName = binding.Status.ClusterSPIFFEIDClassName
+		config.clusterSPIFFEIDClassNameSource = identityConfigSourceBindingStatus
+	}
+	if i.identityConfig.trustDomainOverride {
+		config.trustDomain = i.identityConfig.trustDomain
+		config.trustDomainSource = identityConfigSourceFlag
+	}
+	if i.identityConfig.clusterSPIFFEIDClassNameOverride {
+		config.clusterSPIFFEIDClassName = i.identityConfig.clusterSPIFFEIDClassName
+		config.clusterSPIFFEIDClassNameSource = identityConfigSourceFlag
+	}
+
+	report.IdentityConfig = BindingInspectionIdentityConfig{
+		TrustDomain:                    config.trustDomain,
+		TrustDomainSource:              config.trustDomainSource,
+		ClusterSPIFFEIDClassName:       config.clusterSPIFFEIDClassName,
+		ClusterSPIFFEIDClassNameSource: config.clusterSPIFFEIDClassNameSource,
+	}
+	if !config.discovered {
+		report.Findings = append(report.Findings, identityConfigUndiscoveredFinding(binding, config))
+	}
+	return config
 }
 
 func newBindingInspectionScheme() *runtime.Scheme {
@@ -214,9 +274,10 @@ func (i *bindingInspector) InspectBinding(ctx context.Context, namespace string,
 	report.Capabilities.PeerBindings = BindingInspectionCapabilityPartial
 	report.BindingRef = bindingInspectionBindingRef(binding)
 	i.addCollisionFinding(binding, &report)
+	identityConfig := i.resolveIdentityConfig(binding, &report)
 
-	rendered, desiredReady := i.inspectDesiredState(ctx, binding, availableObjectiveGVKs, availablePoolGVKs, &report)
-	i.inspectObservedState(ctx, binding, rendered, desiredReady, &report)
+	rendered, desiredReady := i.inspectDesiredState(ctx, binding, availableObjectiveGVKs, availablePoolGVKs, identityConfig, &report)
+	i.inspectObservedState(ctx, binding, rendered, desiredReady, identityConfig, &report)
 	i.inspectEligibleWorkloads(ctx, binding, rendered, desiredReady, &report)
 
 	report = normalizeBindingInspectionReport(report)
@@ -260,6 +321,7 @@ func (i *bindingInspector) inspectDesiredState(
 	binding *kleymv1alpha1.InferenceIdentityBinding,
 	availableObjectiveGVKs []schema.GroupVersionKind,
 	availablePoolGVKs []schema.GroupVersionKind,
+	identityConfig resolvedIdentityConfig,
 	report *BindingInspectionReport,
 ) (identity.RenderedIdentity, bool) {
 	mode := identity.EffectiveMode(binding.Spec.Mode)
@@ -332,7 +394,7 @@ func (i *bindingInspector) inspectDesiredState(
 	}
 	rendered, err := identity.PlanIdentity(identity.PlanInput{
 		Binding:              binding,
-		TrustDomain:          i.trustDomain,
+		TrustDomain:          identityConfig.trustDomain,
 		ObjectiveName:        objectiveName,
 		PoolName:             pool.GetName(),
 		PodSelector:          poolSelector,
@@ -355,7 +417,7 @@ func (i *bindingInspector) inspectDesiredState(
 		WorkloadSelectors:   append([]string(nil), rendered.Selectors...),
 		SelectorProvenance:  &provenance,
 		Hint:                spirecm.BuildClusterSPIFFEIDHint(binding),
-		ClassName:           i.clusterSPIFFEIDClassName,
+		ClassName:           identityConfig.clusterSPIFFEIDClassName,
 		Fallback:            boolPtr(spirecm.RenderFallback()),
 	}
 	report.Capabilities.GAIEResources = BindingInspectionCapabilityFull
@@ -367,6 +429,7 @@ func (i *bindingInspector) inspectObservedState(
 	binding *kleymv1alpha1.InferenceIdentityBinding,
 	rendered identity.RenderedIdentity,
 	desiredReady bool,
+	identityConfig resolvedIdentityConfig,
 	report *BindingInspectionReport,
 ) {
 	objects, err := i.listManagedClusterSPIFFEIDs(ctx, binding)
@@ -422,7 +485,7 @@ func (i *bindingInspector) inspectObservedState(
 		return
 	}
 
-	desired := spirecm.DesiredClusterSPIFFEID(binding, rendered, i.clusterSPIFFEIDClassName)
+	desired := spirecm.DesiredClusterSPIFFEID(binding, rendered, identityConfig.clusterSPIFFEIDClassName)
 	if len(objects) == 0 {
 		report.Observed.Drift = append(report.Observed.Drift, BindingInspectionDriftEntry{
 			Field:    "metadata.name",
@@ -815,6 +878,33 @@ func unsupportedSelectorFinding(
 			Version:   kleymv1alpha1.GroupVersion.Version,
 			Kind:      "InferenceIdentityBinding",
 		}},
+	}
+}
+
+// identityConfigUndiscoveredFinding records compatibility fallback for bindings
+// reconciled before operator render settings were published in status.
+func identityConfigUndiscoveredFinding(
+	binding *kleymv1alpha1.InferenceIdentityBinding,
+	config resolvedIdentityConfig,
+) BindingInspectionFinding {
+	sourceSummary := "CLI defaults"
+	if config.trustDomainSource == identityConfigSourceFlag ||
+		config.clusterSPIFFEIDClassNameSource == identityConfigSourceFlag {
+		sourceSummary = "CLI flags and defaults"
+	}
+	if config.trustDomainSource == identityConfigSourceFlag &&
+		config.clusterSPIFFEIDClassNameSource == identityConfigSourceFlag {
+		sourceSummary = "CLI flags"
+	}
+	return BindingInspectionFinding{
+		ID:       findingIdentityConfigMissing,
+		Severity: BindingInspectionFindingSeverityWarning,
+		Reason:   reasonIdentityConfigMissing,
+		Message: fmt.Sprintf(
+			"operator config was not discovered from InferenceIdentityBinding status; using %s",
+			sourceSummary,
+		),
+		AffectedRefs: []BindingInspectionTargetRef{bindingInspectionBindingTargetRef(binding)},
 	}
 }
 

--- a/internal/inspection/inspection_test.go
+++ b/internal/inspection/inspection_test.go
@@ -105,8 +105,10 @@ func TestInspectBindingPoolOnlyEligibleWorkload(t *testing.T) {
 	}
 }
 
-func TestInspectBindingUsesConfiguredOperatorOutput(t *testing.T) {
+func TestInspectBindingUsesStatusOperatorConfig(t *testing.T) {
 	binding := testInspectionBinding()
+	binding.Status.TrustDomain = "example.org"
+	binding.Status.ClusterSPIFFEIDClassName = "kleym"
 	pool := testInspectionPool("pool-a")
 	objective := testInspectionObjective("objective-a", "pool-a")
 	rendered, err := inspectionPlanWithTrustDomain(binding, objective, pool, "example.org")
@@ -131,9 +133,114 @@ func TestInspectBindingUsesConfiguredOperatorOutput(t *testing.T) {
 	if report.Desired.ClassName != "kleym" {
 		t.Fatalf("desired className = %q, want kleym", report.Desired.ClassName)
 	}
+	if report.IdentityConfig.TrustDomainSource != identityConfigSourceBindingStatus ||
+		report.IdentityConfig.ClusterSPIFFEIDClassNameSource != identityConfigSourceBindingStatus {
+		t.Fatalf("identityConfig = %#v, want bindingStatus sources", report.IdentityConfig)
+	}
 	if len(report.Observed.ManagedClusterSPIFFEIDs) != 1 ||
 		report.Observed.ManagedClusterSPIFFEIDs[0].ClassName != "kleym" {
 		t.Fatalf("managed ClusterSPIFFEIDs = %#v, want className kleym", report.Observed.ManagedClusterSPIFFEIDs)
+	}
+	if len(report.Observed.Drift) != 0 {
+		t.Fatalf("expected no drift, got %#v", report.Observed.Drift)
+	}
+	if len(report.Findings) != 0 {
+		t.Fatalf("expected no findings, got %#v", report.Findings)
+	}
+}
+
+func TestInspectBindingFlagsOverrideStatusOperatorConfig(t *testing.T) {
+	binding := testInspectionBinding()
+	binding.Status.TrustDomain = identity.DefaultTrustDomain
+	binding.Status.ClusterSPIFFEIDClassName = ""
+	pool := testInspectionPool("pool-a")
+	objective := testInspectionObjective("objective-a", "pool-a")
+	rendered, err := inspectionPlanWithTrustDomain(binding, objective, pool, "example.org")
+	if err != nil {
+		t.Fatalf("render test identity: %v", err)
+	}
+	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered, "kleym")
+	pod := testInspectionPod("model-server-a", "model-server")
+
+	inspector := newTestBindingInspectorWithIdentityConfig(t, inspectionIdentityConfig{
+		trustDomain:                      "example.org",
+		trustDomainOverride:              true,
+		clusterSPIFFEIDClassName:         "kleym",
+		clusterSPIFFEIDClassNameOverride: true,
+	}, nil, binding, pool, objective, managed, pod)
+	report, err := inspector.InspectBinding(context.Background(), "tenant-a", "binding-a")
+	if err != nil {
+		t.Fatalf("InspectBinding returned error: %v", err)
+	}
+
+	if report.IdentityConfig.TrustDomainSource != identityConfigSourceFlag ||
+		report.IdentityConfig.ClusterSPIFFEIDClassNameSource != identityConfigSourceFlag {
+		t.Fatalf("identityConfig = %#v, want flag sources", report.IdentityConfig)
+	}
+	if report.Desired.SPIFFEID != "spiffe://example.org/ns/tenant-a/objective/objective-a" ||
+		report.Desired.ClassName != "kleym" {
+		t.Fatalf("desired = %#v, want flag-rendered output", report.Desired)
+	}
+	if len(report.Observed.Drift) != 0 {
+		t.Fatalf("expected no drift, got %#v", report.Observed.Drift)
+	}
+	if len(report.Findings) != 0 {
+		t.Fatalf("expected no findings, got %#v", report.Findings)
+	}
+}
+
+func TestInspectBindingMissingStatusOperatorConfigUsesDefaultsAndWarns(t *testing.T) {
+	binding := testInspectionBinding()
+	binding.Status.TrustDomain = ""
+	binding.Status.ClusterSPIFFEIDClassName = ""
+	pool := testInspectionPool("pool-a")
+	objective := testInspectionObjective("objective-a", "pool-a")
+	rendered, err := inspectionPlan(binding, objective, pool)
+	if err != nil {
+		t.Fatalf("render test identity: %v", err)
+	}
+	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered, "")
+	pod := testInspectionPod("model-server-a", "model-server")
+
+	inspector := newTestBindingInspector(t, nil, binding, pool, objective, managed, pod)
+	report, err := inspector.InspectBinding(context.Background(), "tenant-a", "binding-a")
+	if err != nil {
+		t.Fatalf("InspectBinding returned error: %v", err)
+	}
+
+	if report.IdentityConfig.TrustDomainSource != identityConfigSourceDefault ||
+		report.IdentityConfig.ClusterSPIFFEIDClassNameSource != identityConfigSourceDefault {
+		t.Fatalf("identityConfig = %#v, want default sources", report.IdentityConfig)
+	}
+	assertFinding(t, report.Findings, findingIdentityConfigMissing, BindingInspectionFindingSeverityWarning, reasonIdentityConfigMissing)
+	if len(report.Observed.Drift) != 0 {
+		t.Fatalf("expected no drift, got %#v", report.Observed.Drift)
+	}
+}
+
+func TestInspectBindingStatusOperatorConfigSupportsClasslessOutput(t *testing.T) {
+	binding := testInspectionPoolOnlyBinding()
+	binding.Status.TrustDomain = identity.DefaultTrustDomain
+	binding.Status.ClusterSPIFFEIDClassName = ""
+	pool := testInspectionPool("pool-a")
+	rendered, err := inspectionPlan(binding, nil, pool)
+	if err != nil {
+		t.Fatalf("render test identity: %v", err)
+	}
+	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered, "")
+	pod := testInspectionPod("model-server-a", "model-server")
+
+	inspector := newTestBindingInspector(t, nil, binding, pool, managed, pod)
+	report, err := inspector.InspectBinding(context.Background(), "tenant-a", "binding-a")
+	if err != nil {
+		t.Fatalf("InspectBinding returned error: %v", err)
+	}
+
+	if report.IdentityConfig.ClusterSPIFFEIDClassNameSource != identityConfigSourceBindingStatus {
+		t.Fatalf("identityConfig = %#v, want class source bindingStatus", report.IdentityConfig)
+	}
+	if report.Desired.ClassName != "" {
+		t.Fatalf("desired className = %q, want classless", report.Desired.ClassName)
 	}
 	if len(report.Observed.Drift) != 0 {
 		t.Fatalf("expected no drift, got %#v", report.Observed.Drift)
@@ -357,8 +464,7 @@ func newTestBindingInspectorWithIdentityConfig(
 	t.Helper()
 
 	inspector := newTestBindingInspectorWithListErrors(t, listErr, nil, objects...)
-	inspector.trustDomain = identityConfig.trustDomain
-	inspector.clusterSPIFFEIDClassName = identityConfig.clusterSPIFFEIDClassName
+	inspector.identityConfig = identityConfig
 	return inspector
 }
 
@@ -402,8 +508,7 @@ func newTestBindingInspectorWithListErrors(
 		now: func() time.Time {
 			return time.Date(2026, 5, 18, 10, 11, 12, 0, time.UTC)
 		},
-		trustDomain:              identityConfig.trustDomain,
-		clusterSPIFFEIDClassName: identityConfig.clusterSPIFFEIDClassName,
+		identityConfig: identityConfig,
 	}
 }
 
@@ -458,6 +563,10 @@ func testInspectionBinding() *kleymv1alpha1.InferenceIdentityBinding {
 			ServiceAccountName: "model-sa",
 			Mode:               kleymv1alpha1.InferenceIdentityBindingModePerObjective,
 			ContainerName:      "model-server",
+		},
+		Status: kleymv1alpha1.InferenceIdentityBindingStatus{
+			TrustDomain:              identity.DefaultTrustDomain,
+			ClusterSPIFFEIDClassName: "",
 		},
 	}
 }

--- a/internal/inspection/report.go
+++ b/internal/inspection/report.go
@@ -42,15 +42,24 @@ type BindingInspectionCapability string
 
 // BindingInspectionReport captures the JSON contract for `kleym inspect binding -o json`.
 type BindingInspectionReport struct {
-	SchemaVersion string                         `json:"schemaVersion"`
-	Kind          string                         `json:"kind"`
-	GeneratedAt   string                         `json:"generatedAt"`
-	BindingRef    BindingInspectionBindingRef    `json:"bindingRef"`
-	Resolved      BindingInspectionResolvedInput `json:"resolvedInput"`
-	Desired       BindingInspectionDesiredState  `json:"desired"`
-	Observed      BindingInspectionObservedState `json:"observed"`
-	Findings      []BindingInspectionFinding     `json:"findings"`
-	Capabilities  BindingInspectionCapabilities  `json:"capabilities"`
+	SchemaVersion  string                          `json:"schemaVersion"`
+	Kind           string                          `json:"kind"`
+	GeneratedAt    string                          `json:"generatedAt"`
+	IdentityConfig BindingInspectionIdentityConfig `json:"identityConfig,omitempty"`
+	BindingRef     BindingInspectionBindingRef     `json:"bindingRef"`
+	Resolved       BindingInspectionResolvedInput  `json:"resolvedInput"`
+	Desired        BindingInspectionDesiredState   `json:"desired"`
+	Observed       BindingInspectionObservedState  `json:"observed"`
+	Findings       []BindingInspectionFinding      `json:"findings"`
+	Capabilities   BindingInspectionCapabilities   `json:"capabilities"`
+}
+
+// BindingInspectionIdentityConfig records which identity configuration inspection used.
+type BindingInspectionIdentityConfig struct {
+	TrustDomain                    string `json:"trustDomain,omitempty"`
+	TrustDomainSource              string `json:"trustDomainSource,omitempty"`
+	ClusterSPIFFEIDClassName       string `json:"clusterSPIFFEIDClassName,omitempty"`
+	ClusterSPIFFEIDClassNameSource string `json:"clusterSPIFFEIDClassNameSource,omitempty"`
 }
 
 // BindingInspectionBindingRef identifies the binding being inspected.
@@ -220,6 +229,11 @@ func writeBindingInspectionReportText(w io.Writer, report BindingInspectionRepor
 	appendTextLine(&builder, "  PoolRef: %s", textTargetRef(report.BindingRef.PoolRef))
 	appendTextLine(&builder, "  ObjectiveRef: %s", textTargetRef(report.BindingRef.ObjectiveRef))
 	appendTextConditions(&builder, "  ", report.BindingRef.Conditions)
+
+	appendTextLine(&builder, "")
+	appendTextLine(&builder, "Identity config:")
+	appendTextLine(&builder, "  TrustDomain: %s (%s)", textString(report.IdentityConfig.TrustDomain), textString(report.IdentityConfig.TrustDomainSource))
+	appendTextLine(&builder, "  ClusterSPIFFEID className: %s (%s)", textString(report.IdentityConfig.ClusterSPIFFEIDClassName), textString(report.IdentityConfig.ClusterSPIFFEIDClassNameSource))
 
 	appendTextLine(&builder, "")
 	appendTextLine(&builder, "Identity:")

--- a/internal/inspection/report_test.go
+++ b/internal/inspection/report_test.go
@@ -31,6 +31,7 @@ func TestBindingInspectionReportJSONMinimalShape(t *testing.T) {
 		"desired",
 		"findings",
 		"generatedAt",
+		"identityConfig",
 		"kind",
 		"observed",
 		"resolvedInput",
@@ -49,7 +50,7 @@ func TestBindingInspectionReportJSONMinimalShape(t *testing.T) {
 	if got["generatedAt"] != "" {
 		t.Fatalf("expected empty generatedAt, got %#v", got["generatedAt"])
 	}
-	for _, key := range []string{"bindingRef", "resolvedInput", "desired", "observed", "capabilities"} {
+	for _, key := range []string{"bindingRef", "identityConfig", "resolvedInput", "desired", "observed", "capabilities"} {
 		section, ok := got[key].(map[string]any)
 		if !ok {
 			t.Fatalf("expected %s to encode as object, got %#v", key, got[key])
@@ -71,6 +72,12 @@ func TestBindingInspectionReportJSONRepresentativeShape(t *testing.T) {
 	fallbackFalse := false
 	report := BindingInspectionReport{
 		GeneratedAt: "2026-05-18T09:10:11Z",
+		IdentityConfig: BindingInspectionIdentityConfig{
+			TrustDomain:                    "kleym.sonda.red",
+			TrustDomainSource:              identityConfigSourceBindingStatus,
+			ClusterSPIFFEIDClassName:       "kleym",
+			ClusterSPIFFEIDClassNameSource: identityConfigSourceBindingStatus,
+		},
 		BindingRef: BindingInspectionBindingRef{
 			Namespace:  "tenant-a",
 			Name:       "binding-a",
@@ -194,6 +201,7 @@ func TestBindingInspectionReportJSONRepresentativeShape(t *testing.T) {
 	}
 
 	assertObjectKeys(t, got["bindingRef"], "conditions", "generation", "mode", "name", "namespace", "objectiveRef", "poolRef")
+	assertObjectKeys(t, got["identityConfig"], "clusterSPIFFEIDClassName", "clusterSPIFFEIDClassNameSource", "trustDomain", "trustDomainSource")
 	assertObjectKeys(t, got["resolvedInput"], "containerName", "objectiveRef", "poolRef", "poolSelector", "selectorProvenance", "servedGVKs")
 	assertObjectKeys(t, got["desired"], "className", "clusterSPIFFEIDName", "fallback", "hint", "podSelector", "selectorProvenance", "spiffeID", "workloadSelectors")
 	assertObjectKeys(t, got["observed"], "drift", "eligibleWorkloads", "managedClusterSPIFFEIDs")

--- a/test/chainsaw/binding-reconciliation/binding-ready.yaml
+++ b/test/chainsaw/binding-reconciliation/binding-ready.yaml
@@ -4,6 +4,7 @@ metadata:
   name: binding
   namespace: kleym-reference-inference
 status:
+  trustDomain: kleym.sonda.red
   computedSpiffeIDs:
     - mode: PerObjective
       spiffeID: spiffe://kleym.sonda.red/ns/kleym-reference-inference/objective/reference-objective

--- a/test/chainsaw/binding-reconciliation/pool-binding-ready.yaml
+++ b/test/chainsaw/binding-reconciliation/pool-binding-ready.yaml
@@ -4,6 +4,7 @@ metadata:
   name: pool-binding
   namespace: kleym-reference-inference
 status:
+  trustDomain: kleym.sonda.red
   computedSpiffeIDs:
     - mode: PoolOnly
       spiffeID: spiffe://kleym.sonda.red/ns/kleym-reference-inference/pool/reference-pool


### PR DESCRIPTION
## Summary

- Make `kleym inspect binding` use operator config published on binding status before falling back to CLI defaults.
- Publish the operator render config as direct status fields: `status.trustDomain` and `status.clusterSPIFFEIDClassName`.

## What I Changed And Why

- Added status fields for the operator trust domain and optional `ClusterSPIFFEID` class name so read-only inspection can recompute the same desired output as the controller.
- Updated inspection config precedence to use explicit flags first, then binding status, then CLI defaults.
- Added report source fields and a warning finding when operator config is not available from status.
- Kept trust domain and class name out of `InferenceIdentityBinding.spec`; these remain operator install settings, not per-binding intent.

## Related Issue

- Fixes #205

## Scope Check

- Follows #205 by using a Kubernetes status source of truth instead of parsing operator deployment args.
- Leaves live config reload, SPIRE Server queries, and per-binding spec config out of scope.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): updated for direct status fields.
- CLI Spec (`docs/spec/cli.md`): updated for config precedence and warning behavior.
- Other docs: updated CLI usage, inspection report, findings, and API reference.

## Follow-Up Work

- Proposed follow-up issue(s): #206 for splitting `internal/inspection` by responsibility.

## Verification

- Commands run:
  - `make generate`
  - `make manifests`
  - `make test`
  - `make lint`
  - `make docs-build`
  - `git diff --check`
- Tests not run and why: e2e Chainsaw tests were not run; this change is covered by focused controller, CLI, inspection, generated manifest, lint, and docs checks.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.
- GitHub issue content was treated as untrusted input and used only for requested product behavior; no commands or security-sensitive changes were taken from issue text.