### PR TITLE
fix(cli): narrow and split CLI inspection

### DIFF
--- a/docs/cli/_index.md
+++ b/docs/cli/_index.md
@@ -3,9 +3,9 @@ title: CLI
 weight: 20
 ---
 
-`kleym` is the read-only inspection CLI. It recomputes the identity state that
-`kleym-operator` would render, compares desired output with visible cluster
-state, and serializes the result as a `BindingInspectionReport`.
+`kleym` is the read-only inspection CLI. It renders Kleym identity output,
+shows current binding conditions, reports Kubernetes-visible pod matches, and
+serializes the result as a `BindingInspectionReport`.
 
 Use this section for command usage, result interpretation, and the stable
 machine-readable report contract.
@@ -13,7 +13,7 @@ machine-readable report contract.
 | Page | Use it for |
 | --- | --- |
 | [Usage](/cli/usage/) | Building and running `kleym inspect binding`, including flags and RBAC expectations. |
-| [Results](/cli/results/) | Choosing output formats and interpreting status, findings, drift, and capabilities. |
+| [Results](/cli/results/) | Choosing output formats and interpreting findings, matched pods, and exit behavior. |
 | [Inspection Report](/cli/inspection-report/) | Stable JSON/YAML report shape. |
 | [Findings](/cli/findings/) | Finding IDs, severities, and meanings. |
 | [Exit Codes](/cli/exit-codes/) | Process exit behavior for automation and strict mode. |

--- a/docs/cli/findings.md
+++ b/docs/cli/findings.md
@@ -29,12 +29,11 @@ reasons where possible. See [Conditions](/reference/conditions/).
 | --- | --- | --- |
 | `binding-not-found` | `error` | Requested binding is absent after a successful API lookup. |
 | `invalid-ref` | `error` | A referenced pool or objective is missing or invalid. |
-| `dependency-missing` | `error` when required | Optional missing checks belong in `capabilities`. |
+| `dependency-missing` | `error` when required | Required inputs or APIs are unavailable. |
 | `unsafe-selector` | `error` | Rendered selectors fail Kleym safety rules. |
-| `render-failure` | `error` | Desired state could not be rendered. |
+| `render-failure` | `error` | Identity output could not be rendered. |
 | `kleym-collision` | `error` | Kleym detected a deterministic identity collision. |
-| `zero-eligible-workloads` | `info` | Scale-to-zero can be valid. |
-| `observed-drift` | `warning` or `error` | Managed output differs from desired output. |
+| `zero-matched-pods` | `info` | Scale-to-zero can be valid. |
 | `identity-config-undiscovered` | `warning` | Binding status does not include operator config, so inspection used CLI flags, defaults, or both. |
 | `rbac-limited` | `warning` | Inspection continued with reduced visibility. |
 | `unsupported-selector` | `warning` | Pod inspection cannot fully evaluate a rendered selector type. |

--- a/docs/cli/inspection-report.md
+++ b/docs/cli/inspection-report.md
@@ -24,10 +24,10 @@ kleym inspect binding <name> -n <namespace> -o json
   "identityConfig": {},
   "bindingRef": {},
   "resolvedInput": {},
-  "desired": {},
-  "observed": {},
-  "findings": [],
-  "capabilities": {}
+  "renderedIdentity": {},
+  "renderedClusterSPIFFEID": {},
+  "matchedPods": [],
+  "findings": []
 }
 ```
 
@@ -35,20 +35,16 @@ kleym inspect binding <name> -n <namespace> -o json
 
 | Field | Meaning |
 | --- | --- |
-| `identityConfig` | Trust domain and `ClusterSPIFFEID` class name used to render desired output, plus per-field source (`flag`, `bindingStatus`, or `default`). |
+| `identityConfig` | Trust domain and `ClusterSPIFFEID` class name used to render output, plus per-field source (`flag`, `bindingStatus`, or `default`). |
 | `bindingRef` | Binding identity, generation, mode, refs, and current conditions. |
 | `resolvedInput` | Resolved GAIE inputs, served GVKs, selector provenance, and container name. |
-| `desired` | Desired `ClusterSPIFFEID` name, SPIFFE ID, class name, selectors, hint, and fallback value. |
-| `observed` | Managed `ClusterSPIFFEID` resources, status, drift, and eligible workloads when pod reads are available. |
+| `renderedIdentity` | SPIFFE ID and selectors rendered from the binding and resolved inputs. |
+| `renderedClusterSPIFFEID` | Deterministic managed `ClusterSPIFFEID` name and rendered spec fields. |
+| `matchedPods` | Readable pods or containers that match rendered Kubernetes-observable selectors. |
 | `findings` | Typed inspection findings. |
-| `capabilities` | Completeness for each inspection area. |
 
-Workload eligibility means a pod or container matches rendered selectors. It is
-not proof that an application fetched or used an SVID.
-
-Capability states are `full`, `partial`, `skipped`, or `unknown`. If RBAC or
-missing CRDs prevent a non-fatal check, report limited capability instead of
-guessing.
+Matched pods are not proof that SPIRE issued an SVID, that a workload was
+attested, or that an application consumed an identity.
 
 See [Results](/cli/results/) for output-format guidance and [Findings](/cli/findings/) for
 the current finding classes.

--- a/docs/cli/results.md
+++ b/docs/cli/results.md
@@ -3,14 +3,15 @@ title: Results
 weight: 20
 ---
 
-Inspection results compare desired identity state with visible cluster state and
-record typed findings.
+Inspection results show the identity and `ClusterSPIFFEID` Kleym renders for
+one binding, current binding conditions, Kubernetes-visible matched pods, and
+typed findings.
 
 ## Output Formats
 
 | Format | Use it for |
 | --- | --- |
-| `text` | Default human-readable terminal output. It starts with status, finding count, drift count, eligible workload count, and inspection completeness. |
+| `text` | Default terminal output. It uses compact sections for identity, `ClusterSPIFFEID`, conditions, matched pods, findings, and exit code. |
 | `json` | Stable machine contract for automation. |
 
 Automation should use:
@@ -19,28 +20,11 @@ Automation should use:
 kleym inspect binding <name> -n <namespace> -o json
 ```
 
-## Status
-
-Human output summarizes report status from finding severities:
-
-| Status | Meaning |
-| --- | --- |
-| `OK` | No warning or error findings. |
-| `Warning` | At least one warning finding and no error findings. |
-| `Error` | At least one error finding. |
-
-The status is an inspection result, not proof that a workload fetched or used an
-SVID.
-
-## Findings And Capabilities
+## Findings
 
 Findings identify issues or notable states, such as invalid references,
-deterministic Kleym collisions, observed drift, missing dependencies, or RBAC
-limits. See [Findings](/cli/findings/) for the current finding classes.
-
-Capabilities explain how complete each inspection area was. A check can be
-`full`, `partial`, `skipped`, or `unknown`. RBAC limits and missing optional
-resources should reduce capability instead of causing the CLI to guess.
+deterministic Kleym collisions, missing dependencies, unsupported selectors, or
+RBAC limits. See [Findings](/cli/findings/) for the current finding classes.
 
 ## Exit Behavior
 

--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -67,7 +67,7 @@ bin/kleym inspect binding <name> -n <namespace> -o json
 | `--context` | Kubeconfig context name. |
 | `--kubeconfig` | Kubeconfig file path. |
 | `--timeout` | Inspection timeout. Must be greater than zero. |
-| `--trust-domain` | Override trust domain used to recompute desired SPIFFE IDs. If operator config is unavailable and this flag is omitted, inspection falls back to `kleym.sonda.red`. |
+| `--trust-domain` | Override trust domain used to render SPIFFE IDs. If operator config is unavailable and this flag is omitted, inspection falls back to `kleym.sonda.red`. |
 | `--clusterspiffeid-class-name` | Override expected `ClusterSPIFFEID.spec.className`. If operator config is unavailable and this flag is omitted, inspection falls back to classless output. |
 
 ## Access
@@ -77,16 +77,14 @@ The CLI needs Kubernetes API access to read the requested
 discovery failure before the binding can be read is fatal and may not emit a
 complete report.
 
-After the binding is readable, limited access to peer bindings, GAIE resources,
-managed `ClusterSPIFFEID` resources, or pods is reported through findings and
-capability states when inspection can continue.
+After the binding is readable, limited access to GAIE resources or pods is
+reported through findings when inspection can continue.
 
 Full inspection may need read access to:
 
 - `InferenceIdentityBinding` in the binding namespace
 - supported GAIE `InferencePool` and `InferenceObjective` resources
-- Kleym-managed `ClusterSPIFFEID` resources
-- pods in the binding namespace when eligible workload reporting is desired
+- pods in the binding namespace when matched pod reporting is enabled
 
 ## Boundary
 

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -39,7 +39,7 @@ JSON is the stable machine contract. Automation must use `kleym inspect binding 
 
 Field meanings: `identityConfig` records render config and sources; `bindingRef` records binding identity, refs, generation, mode, and conditions; `resolvedInput` records resolved pool/objective inputs; `renderedIdentity` records SPIFFE ID and selectors; `renderedClusterSPIFFEID` records deterministic managed output; `matchedPods` records readable matching pods or containers; `findings` records inspection issues.
 
-Text output must use direct labels: `Rendered identity`, `Rendered ClusterSPIFFEID`, `Binding conditions`, `Matched pods`, `Findings`, and `Exit code`. It must not use `eligible`, `bound`, `issued`, or `attested` for pod or identity state.
+Text output must use direct labels: `Identity`, `ClusterSPIFFEID`, `Conditions`, `Matched pods`, `Findings`, and `Exit code`. It must not use `eligible`, `bound`, `issued`, or `attested` for pod or identity state.
 
 ## Inspect Binding Behavior
 

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -3,63 +3,24 @@ title: CLI Spec
 weight: 20
 ---
 
-`kleym` is a read-only inspection CLI for `InferenceIdentityBinding` state. It recomputes desired identity state, compares it with observed Kleym-managed `ClusterSPIFFEID` output, and reports findings from current Kubernetes API state.
+`kleym` is a read-only CLI for inspecting `InferenceIdentityBinding` state. `kleym inspect binding` renders Kleym identity output, shows current binding conditions, reports Kubernetes-visible pod matches, and emits findings.
 
-The CLI does not reconcile, mutate resources, issue credentials, configure gateways, evaluate policy, or talk directly to SPIRE Server.
+The CLI does not reconcile, mutate resources, compare live managed output, issue credentials, configure gateways, evaluate policy, or talk directly to SPIRE Server. Cluster overview and list behavior belong to future `kleym status` and `kleym list` commands.
 
 ## Command Surface
 
-```bash
-kleym --version
-```
+- `kleym --version`: print the linked version without contacting Kubernetes. Released binaries report the release tag; unreleased local builds default to `dev`.
+- `kleym inspect binding <name> -n <namespace>`: inspect one `InferenceIdentityBinding`.
 
-Prints the linked CLI version string and exits without contacting Kubernetes. Released binaries report the release tag. Unreleased local builds default to `dev`.
+Supported inspect flags: `-n, --namespace`, `-o, --output text|json`, `--strict`, `--context`, `--kubeconfig`, `--timeout`, `--trust-domain`, `--clusterspiffeid-class-name`.
 
-```bash
-kleym inspect binding <name> -n <namespace>
-```
-
-Inspects one `InferenceIdentityBinding` end to end.
-
-Supported flags:
-
-```bash
--n, --namespace
--o, --output text|json
---strict
---context
---kubeconfig
---timeout
---trust-domain
---clusterspiffeid-class-name
-```
-
-Default namespace is `default`. Default output is `text`. `--timeout` must be greater than zero.
-`--trust-domain` must follow the same validation rules as `kleym-operator --trust-domain`.
-`--clusterspiffeid-class-name` defaults to empty when used as a fallback or explicit override,
-matching classless `ClusterSPIFFEID` output.
+Defaults: namespace `default`, output `text`, trust domain `kleym.sonda.red`, classless `ClusterSPIFFEID` output. `--timeout` must be greater than zero. `--trust-domain` follows `kleym-operator --trust-domain` validation.
 
 ## Output Contract
 
-JSON is the stable machine contract. Text is the human-oriented report and may change between releases.
+JSON is the stable machine contract. Automation must use `kleym inspect binding <name> -n <namespace> -o json`. Text is the compact human view and may change between releases.
 
-Automation must consume:
-
-```bash
-kleym inspect binding <name> -n <namespace> -o json
-```
-
-Text output leads with a summary and must not introduce inspection semantics absent from the canonical report data.
-
-`kleym inspect binding` emits a `BindingInspectionReport` with five core sections:
-
-1. `identityConfig`: trust domain and class-name values used for desired rendering, plus their sources.
-2. `desired`: what Kleym would render from the inspected binding and resolved inputs.
-3. `observed`: Kleym-managed `ClusterSPIFFEID` resources, drift, status, and eligible workloads when pod reads are available.
-4. `findings`: typed issues or notable states discovered during inspection.
-5. `capabilities`: whether each inspection area was complete, partial, skipped, or unknown.
-
-Top-level JSON shape:
+`BindingInspectionReport` contains:
 
 ```json
 {
@@ -69,45 +30,44 @@ Top-level JSON shape:
   "identityConfig": {},
   "bindingRef": {},
   "resolvedInput": {},
-  "desired": {},
-  "observed": {},
-  "findings": [],
-  "capabilities": {}
+  "renderedIdentity": {},
+  "renderedClusterSPIFFEID": {},
+  "matchedPods": [],
+  "findings": []
 }
 ```
 
-Report fields and findings are documented in [Inspection Report][inspection-report-reference] and [Findings][findings-reference]. User-facing command guidance lives in [CLI Usage][cli-usage] and [CLI Results][cli-results].
+Field meanings: `identityConfig` records render config and sources; `bindingRef` records binding identity, refs, generation, mode, and conditions; `resolvedInput` records resolved pool/objective inputs; `renderedIdentity` records SPIFFE ID and selectors; `renderedClusterSPIFFEID` records deterministic managed output; `matchedPods` records readable matching pods or containers; `findings` records inspection issues.
+
+Text output must use direct labels: `Rendered identity`, `Rendered ClusterSPIFFEID`, `Binding conditions`, `Matched pods`, `Findings`, and `Exit code`. It must not use `eligible`, `bound`, `issued`, or `attested` for pod or identity state.
 
 ## Inspect Binding Behavior
 
-1. Resolve the binding, `poolRef`, and required or present `objectiveRef`; validate that an objective references the same pool.
-2. Choose identity config for recomputing desired output with this precedence for each field:
-   explicit CLI flag, `InferenceIdentityBinding.status.trustDomain` and `status.clusterSPIFFEIDClassName`, then CLI default.
-   The default trust domain fallback is `kleym.sonda.red`; the default class-name fallback is empty.
-3. Record the chosen trust domain, class name, and per-field source in `report.identityConfig`.
-   If binding status does not contain operator config, add a warning finding that inspection is using CLI defaults, flags, or a mix of both.
-4. Recompute desired identity state with shared Kleym logic.
-5. Evaluate Kleym collision state from peer binding fingerprints when available; otherwise use the inspected binding's current `Conflict` condition and mark peer analysis partial or unknown.
-6. Locate Kleym-managed `ClusterSPIFFEID` resources, compare desired and observed state, and evaluate eligible workloads when pod reads are available.
-7. Emit the report and exit according to finding severity and inspection completeness.
+1. Resolve the binding, `poolRef`, and required or present `objectiveRef`.
+2. Choose identity config by precedence: explicit flag, binding status, then CLI default.
+3. Record config values and sources. If binding status lacks operator config, add a warning finding.
+4. Render identity and deterministic `ClusterSPIFFEID` output with shared Kleym logic.
+5. Read pods when permitted and report pods or containers matching rendered Kubernetes-observable selectors.
+6. Preserve current binding conditions. Collision state comes from the inspected binding's `Conflict` condition, not peer re-analysis.
+7. Emit the report and exit according to finding severity.
 
-`kleym` reports eligibility, not credential use. It reports deterministic Kleym collisions and visible drift; it does not fully simulate SPIRE selection behavior or analyze unrelated non-Kleym `ClusterSPIFFEID` overlap.
+Matched pods are not proof of SVID issuance, workload attestation, identity consumption, or request-time authorization.
 
 ## Exit Behavior
 
-1. `0`: inspection succeeded and no error-severity findings exist.
-2. `2`: inspection succeeded and error-severity findings exist.
-3. `3`: binding lookup succeeded and the requested binding was not found.
-4. `4`: usage, connection, discovery, or permission failure prevented inspection.
-5. `5`: internal CLI or serialization failure.
+| Code | Meaning |
+| --- | --- |
+| `0` | Inspection succeeded and no error-severity findings exist. |
+| `2` | Inspection succeeded and error-severity findings exist. |
+| `3` | Binding lookup succeeded and the requested binding was not found. |
+| `4` | Usage, connection, discovery, or permission failure prevented inspection. |
+| `5` | Internal CLI or serialization failure. |
 
 `--strict` treats warning-severity findings as exit code `2`. See [Exit Codes][exit-codes-reference].
 
 ## Implementation Boundary
 
-The CLI and operator share pure logic for GAIE GVK discovery and resolution, pool selector derivation, selector rendering, SPIFFE ID rendering, deterministic `ClusterSPIFFEID` naming, and Kleym collision fingerprinting.
-
-`kleym` does not import controller orchestration, finalizer handling, watches, status patching, or resource mutation logic.
+The CLI and operator share pure GAIE resolution, selector derivation, selector rendering, SPIFFE ID rendering, and deterministic `ClusterSPIFFEID` naming logic. `kleym` does not import controller orchestration, finalizer handling, watches, status patching, or resource mutation logic.
 
 ## References
 

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -53,6 +53,7 @@ func newInspectCommand(opts *Options) *cobra.Command {
 
 			report, inspectErr := inspector.InspectBinding(ctx, opts.Namespace, args[0])
 			code, err := inspectionExitCode(report, inspectErr, opts.Strict)
+			report.ExitCode = &code
 			if !shouldWriteBindingInspectionReport(inspectErr) {
 				if err != nil {
 					return withExitCode(code, err)

--- a/internal/cli/inspect_test.go
+++ b/internal/cli/inspect_test.go
@@ -120,9 +120,12 @@ func TestInspectBindingDefaultTextUsesRunner(t *testing.T) {
 	fakeReport := inspection.NewBindingInspectionReport()
 	fakeReport.GeneratedAt = "2026-05-18T10:11:12Z"
 	fakeReport.BindingRef = inspection.BindingInspectionBindingRef{Namespace: "tenant-a", Name: "binding-a", Mode: "PerObjective"}
-	fakeReport.Desired = inspection.BindingInspectionDesiredState{
-		ClusterSPIFFEIDName: "tenant-a-binding-a-1234abcd",
-		SPIFFEID:            "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
+	fakeReport.RenderedIdentity = inspection.BindingInspectionRenderedIdentity{
+		SPIFFEID: "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
+	}
+	fakeReport.RenderedClusterSPIFFEID = inspection.BindingInspectionRenderedClusterSPIFFEID{
+		Name:     "tenant-a-binding-a-1234abcd",
+		SPIFFEID: "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
 	}
 	newBindingInspectionRunner = func(_ *Options) (inspection.BindingInspector, error) {
 		return fixedInspectionRunner{report: fakeReport}, nil
@@ -144,12 +147,14 @@ func TestInspectBindingDefaultTextUsesRunner(t *testing.T) {
 
 	out := stdout.String()
 	for _, want := range []string{
-		"BindingInspectionReport",
-		"Name: tenant-a/binding-a",
+		"Binding: tenant-a/binding-a",
 		"Mode: PerObjective",
-		"ClusterSPIFFEID: tenant-a-binding-a-1234abcd",
+		"Identity:",
 		"SPIFFE ID: spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
-		"Findings:\n  none",
+		"ClusterSPIFFEID:",
+		"Name: tenant-a-binding-a-1234abcd",
+		"Findings: none",
+		"Exit code: 0",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("text output missing %q\n%s", want, out)
@@ -303,20 +308,20 @@ func TestInspectionExitCodeMapping(t *testing.T) {
 		{
 			name: "warning is non-fatal without strict",
 			report: inspection.BindingInspectionReport{Findings: []inspection.BindingInspectionFinding{{
-				ID:       "observed-drift",
+				ID:       "rbac-limited",
 				Severity: inspection.BindingInspectionFindingSeverityWarning,
-				Reason:   "ObservedDrift",
-				Message:  "drift",
+				Reason:   "Forbidden",
+				Message:  "pods are not readable",
 			}}},
 			wantCode: exitOK,
 		},
 		{
 			name: "warning is inspection issue with strict",
 			report: inspection.BindingInspectionReport{Findings: []inspection.BindingInspectionFinding{{
-				ID:       "observed-drift",
+				ID:       "rbac-limited",
 				Severity: inspection.BindingInspectionFindingSeverityWarning,
-				Reason:   "ObservedDrift",
-				Message:  "drift",
+				Reason:   "Forbidden",
+				Message:  "pods are not readable",
 			}}},
 			strict:   true,
 			wantCode: exitInspectionIssue,

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -55,7 +55,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.Context, "context", "", "Name of the kubeconfig context to use")
 	cmd.PersistentFlags().StringVar(&opts.Kubeconfig, "kubeconfig", "", "Path to the kubeconfig file")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", 30*time.Second, "Inspection timeout")
-	cmd.PersistentFlags().StringVar(&opts.TrustDomain, "trust-domain", identity.DefaultTrustDomain, "SPIRE Server trust domain used when recomputing desired SPIFFE IDs")
+	cmd.PersistentFlags().StringVar(&opts.TrustDomain, "trust-domain", identity.DefaultTrustDomain, "SPIRE Server trust domain used when rendering SPIFFE IDs")
 	cmd.PersistentFlags().StringVar(&opts.ClusterSPIFFEIDClassName, "clusterspiffeid-class-name", "", "Optional SPIRE Controller Manager ClusterSPIFFEID className expected on managed resources")
 
 	cmd.AddCommand(newInspectCommand(opts))

--- a/internal/inspection/inspection.go
+++ b/internal/inspection/inspection.go
@@ -2,7 +2,6 @@ package inspection
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -35,18 +34,15 @@ const (
 	findingUnsafeSelector        = "unsafe-selector"
 	findingRenderFailure         = "render-failure"
 	findingKleymCollision        = "kleym-collision"
-	findingZeroEligibleWorkload  = "zero-eligible-workloads"
+	findingZeroMatchedPods       = "zero-matched-pods"
 	findingUnsupportedSelector   = "unsupported-selector"
-	findingObservedDrift         = "observed-drift"
 	findingRBACLimited           = "rbac-limited"
 	findingIdentityConfigMissing = "identity-config-undiscovered"
-	reasonZeroEligibleWorkload   = "ZeroEligibleWorkloads"
+	reasonZeroMatchedPods        = "ZeroMatchedPods"
 	reasonUnsupportedSelector    = "UnsupportedSelector"
-	reasonObservedDrift          = "ObservedDrift"
 	reasonRBACLimited            = "Forbidden"
 	reasonIdentityConfigMissing  = "IdentityConfigUndiscovered"
 	conditionTypeConflict        = "Conflict"
-	clusterSPIFFEIDResourceName  = "clusterspiffeids"
 	podResourceName              = "pods"
 )
 
@@ -276,9 +272,8 @@ func (i *bindingInspector) InspectBinding(ctx context.Context, namespace string,
 	i.addCollisionFinding(binding, &report)
 	identityConfig := i.resolveIdentityConfig(binding, &report)
 
-	rendered, desiredReady := i.inspectDesiredState(ctx, binding, availableObjectiveGVKs, availablePoolGVKs, identityConfig, &report)
-	i.inspectObservedState(ctx, binding, rendered, desiredReady, identityConfig, &report)
-	i.inspectEligibleWorkloads(ctx, binding, rendered, desiredReady, &report)
+	rendered, renderedReady := i.inspectRenderedIdentity(ctx, binding, availableObjectiveGVKs, availablePoolGVKs, identityConfig, &report)
+	i.inspectMatchedPods(ctx, binding, rendered, renderedReady, &report)
 
 	report = normalizeBindingInspectionReport(report)
 	if HasErrorSeverityFinding(report.Findings) {
@@ -316,7 +311,7 @@ func filterAvailableInspectionGVKs(
 	return available, nil
 }
 
-func (i *bindingInspector) inspectDesiredState(
+func (i *bindingInspector) inspectRenderedIdentity(
 	ctx context.Context,
 	binding *kleymv1alpha1.InferenceIdentityBinding,
 	availableObjectiveGVKs []schema.GroupVersionKind,
@@ -410,122 +405,37 @@ func (i *bindingInspector) inspectDesiredState(
 	report.Resolved.PoolSelector = poolSelector
 	report.Resolved.ContainerName = binding.Spec.ContainerName
 	report.Resolved.SelectorProvenance = &provenance
-	report.Desired = BindingInspectionDesiredState{
-		ClusterSPIFFEIDName: spirecm.BuildClusterSPIFFEIDName(binding.Namespace, binding.Name, rendered.Mode, rendered.SpiffeID),
-		SPIFFEID:            rendered.SpiffeID,
-		PodSelector:         rendered.PodSelector,
-		WorkloadSelectors:   append([]string(nil), rendered.Selectors...),
-		SelectorProvenance:  &provenance,
-		Hint:                spirecm.BuildClusterSPIFFEIDHint(binding),
-		ClassName:           identityConfig.clusterSPIFFEIDClassName,
-		Fallback:            boolPtr(spirecm.RenderFallback()),
+	clusterSPIFFEIDName := spirecm.BuildClusterSPIFFEIDName(binding.Namespace, binding.Name, rendered.Mode, rendered.SpiffeID)
+	clusterSPIFFEIDHint := spirecm.BuildClusterSPIFFEIDHint(binding)
+	clusterSPIFFEIDFallback := boolPtr(spirecm.RenderFallback())
+	report.RenderedIdentity = BindingInspectionRenderedIdentity{
+		SPIFFEID:           rendered.SpiffeID,
+		PodSelector:        rendered.PodSelector,
+		WorkloadSelectors:  append([]string(nil), rendered.Selectors...),
+		SelectorProvenance: &provenance,
+	}
+	report.RenderedClusterSPIFFEID = BindingInspectionRenderedClusterSPIFFEID{
+		Name:              clusterSPIFFEIDName,
+		SPIFFEID:          rendered.SpiffeID,
+		PodSelector:       rendered.PodSelector,
+		WorkloadSelectors: append([]string(nil), rendered.Selectors...),
+		Hint:              clusterSPIFFEIDHint,
+		ClassName:         identityConfig.clusterSPIFFEIDClassName,
+		Fallback:          clusterSPIFFEIDFallback,
 	}
 	report.Capabilities.GAIEResources = BindingInspectionCapabilityFull
 	return rendered, true
 }
 
-func (i *bindingInspector) inspectObservedState(
+// inspectMatchedPods reports live pod/container selector matches when identity output can be rendered.
+func (i *bindingInspector) inspectMatchedPods(
 	ctx context.Context,
 	binding *kleymv1alpha1.InferenceIdentityBinding,
 	rendered identity.RenderedIdentity,
-	desiredReady bool,
-	identityConfig resolvedIdentityConfig,
+	renderedReady bool,
 	report *BindingInspectionReport,
 ) {
-	objects, err := i.listManagedClusterSPIFFEIDs(ctx, binding)
-	if err != nil {
-		switch {
-		case meta.IsNoMatchError(err):
-			report.Capabilities.ClusterSPIFFEIDs = BindingInspectionCapabilityUnknown
-			report.Findings = append(report.Findings, BindingInspectionFinding{
-				ID:       findingDependencyMissing,
-				Severity: BindingInspectionFindingSeverityError,
-				Reason:   "ClusterSPIFFEIDCRDMissing",
-				Message:  "ClusterSPIFFEID CRD is not installed",
-				AffectedRefs: []BindingInspectionTargetRef{{
-					Name:  clusterSPIFFEIDResourceName,
-					Group: spirecm.ClusterSPIFFEIDGVK().Group,
-					Kind:  spirecm.ClusterSPIFFEIDGVK().Kind,
-				}},
-			})
-		case apierrors.IsForbidden(err):
-			report.Capabilities.ClusterSPIFFEIDs = BindingInspectionCapabilityPartial
-			report.Findings = append(report.Findings, BindingInspectionFinding{
-				ID:           findingRBACLimited,
-				Severity:     BindingInspectionFindingSeverityWarning,
-				Reason:       reasonRBACLimited,
-				Message:      "ClusterSPIFFEID resources are not readable",
-				AffectedRefs: []BindingInspectionTargetRef{{Name: clusterSPIFFEIDResourceName}},
-			})
-		default:
-			report.Capabilities.ClusterSPIFFEIDs = BindingInspectionCapabilityUnknown
-			report.Findings = append(report.Findings, BindingInspectionFinding{
-				ID:           findingDependencyMissing,
-				Severity:     BindingInspectionFindingSeverityError,
-				Reason:       "ClusterSPIFFEIDListFailed",
-				Message:      err.Error(),
-				AffectedRefs: []BindingInspectionTargetRef{{Name: clusterSPIFFEIDResourceName}},
-			})
-		}
-		return
-	}
-
-	report.Capabilities.ClusterSPIFFEIDs = BindingInspectionCapabilityFull
-	for _, object := range objects {
-		report.Observed.ManagedClusterSPIFFEIDs = append(
-			report.Observed.ManagedClusterSPIFFEIDs,
-			managedClusterSPIFFEIDReport(object),
-		)
-	}
-	sort.Slice(report.Observed.ManagedClusterSPIFFEIDs, func(left, right int) bool {
-		return report.Observed.ManagedClusterSPIFFEIDs[left].Name < report.Observed.ManagedClusterSPIFFEIDs[right].Name
-	})
-
-	if !desiredReady {
-		return
-	}
-
-	desired := spirecm.DesiredClusterSPIFFEID(binding, rendered, identityConfig.clusterSPIFFEIDClassName)
-	if len(objects) == 0 {
-		report.Observed.Drift = append(report.Observed.Drift, BindingInspectionDriftEntry{
-			Field:    "metadata.name",
-			Desired:  desired.GetName(),
-			Observed: "",
-		})
-	}
-	for _, object := range objects {
-		report.Observed.Drift = append(report.Observed.Drift, driftEntries(desired, object)...)
-	}
-	if len(report.Observed.Drift) > 0 {
-		sort.Slice(report.Observed.Drift, func(left, right int) bool {
-			if report.Observed.Drift[left].Field == report.Observed.Drift[right].Field {
-				return report.Observed.Drift[left].Observed < report.Observed.Drift[right].Observed
-			}
-			return report.Observed.Drift[left].Field < report.Observed.Drift[right].Field
-		})
-		report.Findings = append(report.Findings, BindingInspectionFinding{
-			ID:       findingObservedDrift,
-			Severity: BindingInspectionFindingSeverityWarning,
-			Reason:   reasonObservedDrift,
-			Message:  "observed managed ClusterSPIFFEID state differs from desired state",
-			AffectedRefs: []BindingInspectionTargetRef{{
-				Name:  desired.GetName(),
-				Group: spirecm.ClusterSPIFFEIDGVK().Group,
-				Kind:  spirecm.ClusterSPIFFEIDGVK().Kind,
-			}},
-		})
-	}
-}
-
-// inspectEligibleWorkloads reports live pod/container selector matches when desired state can be rendered.
-func (i *bindingInspector) inspectEligibleWorkloads(
-	ctx context.Context,
-	binding *kleymv1alpha1.InferenceIdentityBinding,
-	rendered identity.RenderedIdentity,
-	desiredReady bool,
-	report *BindingInspectionReport,
-) {
-	if !desiredReady {
+	if !renderedReady {
 		return
 	}
 
@@ -536,7 +446,7 @@ func (i *bindingInspector) inspectEligibleWorkloads(
 		return
 	}
 
-	pods, err := i.listEligiblePods(ctx, binding, rendered)
+	pods, err := i.listMatchingPods(ctx, binding, rendered)
 	if err != nil {
 		if apierrors.IsForbidden(err) {
 			report.Capabilities.Pods = BindingInspectionCapabilityPartial
@@ -561,18 +471,18 @@ func (i *bindingInspector) inspectEligibleWorkloads(
 	}
 
 	report.Capabilities.Pods = BindingInspectionCapabilityFull
-	report.Observed.EligibleWorkloads = eligibleWorkloadsFromPods(pods, selection, report)
-	sort.Slice(report.Observed.EligibleWorkloads, func(left, right int) bool {
-		return eligibleWorkloadSortKey(report.Observed.EligibleWorkloads[left]) <
-			eligibleWorkloadSortKey(report.Observed.EligibleWorkloads[right])
+	report.MatchedPods = matchedPodsFromPods(pods, selection, report)
+	sort.Slice(report.MatchedPods, func(left, right int) bool {
+		return matchedPodSortKey(report.MatchedPods[left]) <
+			matchedPodSortKey(report.MatchedPods[right])
 	})
-	if len(report.Observed.EligibleWorkloads) == 0 {
-		report.Findings = append(report.Findings, zeroEligibleWorkloadsFinding(binding))
+	if len(report.MatchedPods) == 0 {
+		report.Findings = append(report.Findings, zeroMatchedPodsFinding(binding))
 	}
 }
 
-// listEligiblePods narrows pod reads to the rendered pod selector and binding namespace.
-func (i *bindingInspector) listEligiblePods(
+// listMatchingPods narrows pod reads to the rendered pod selector and binding namespace.
+func (i *bindingInspector) listMatchingPods(
 	ctx context.Context,
 	binding *kleymv1alpha1.InferenceIdentityBinding,
 	rendered identity.RenderedIdentity,
@@ -594,31 +504,13 @@ func (i *bindingInspector) listEligiblePods(
 	return podList.Items, nil
 }
 
-func (i *bindingInspector) listManagedClusterSPIFFEIDs(
-	ctx context.Context,
-	binding *kleymv1alpha1.InferenceIdentityBinding,
-) ([]*unstructured.Unstructured, error) {
-	list := &unstructured.UnstructuredList{}
-	gvk := spirecm.ClusterSPIFFEIDGVK()
-	list.SetGroupVersionKind(gvk.GroupVersion().WithKind(gvk.Kind + "List"))
-	if err := i.client.List(ctx, list, client.MatchingLabels(spirecm.ManagedClusterSPIFFEIDLabels(binding))); err != nil {
-		return nil, err
-	}
-
-	items := make([]*unstructured.Unstructured, 0, len(list.Items))
-	for item := range list.Items {
-		items = append(items, list.Items[item].DeepCopy())
-	}
-	return items, nil
-}
-
-// eligibleWorkloadsFromPods evaluates live pod/container matches for the already-rendered identity selectors.
-func eligibleWorkloadsFromPods(
+// matchedPodsFromPods evaluates live pod/container matches for the already-rendered identity selectors.
+func matchedPodsFromPods(
 	pods []corev1.Pod,
 	selection workloadSelection,
 	report *BindingInspectionReport,
-) []BindingInspectionEligibleWorkload {
-	workloads := []BindingInspectionEligibleWorkload{}
+) []BindingInspectionMatchedPod {
+	workloads := []BindingInspectionMatchedPod{}
 	for _, pod := range pods {
 		if !podMatchesSelection(pod, selection) {
 			continue
@@ -626,14 +518,14 @@ func eligibleWorkloadsFromPods(
 
 		matchingContainers := matchingPodContainers(pod, selection)
 		if selection.ContainerSelectorType == "" {
-			workloads = append(workloads, BindingInspectionEligibleWorkload{
+			workloads = append(workloads, BindingInspectionMatchedPod{
 				Namespace: pod.Namespace,
 				Pod:       pod.Name,
 			})
 			continue
 		}
 		for _, container := range matchingContainers {
-			workloads = append(workloads, BindingInspectionEligibleWorkload{
+			workloads = append(workloads, BindingInspectionMatchedPod{
 				Namespace: pod.Namespace,
 				Pod:       pod.Name,
 				Container: container.Name,
@@ -804,14 +696,14 @@ func podSelectorMatchLabels(selector map[string]any) (map[string]string, error) 
 	}
 	matchLabels, ok := rawMatchLabels.(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("desired pod selector matchLabels must be an object")
+		return nil, fmt.Errorf("rendered pod selector matchLabels must be an object")
 	}
 
 	labels := make(map[string]string, len(matchLabels))
 	for key, value := range matchLabels {
 		text, ok := value.(string)
 		if !ok {
-			return nil, fmt.Errorf("desired pod selector matchLabels[%q] must be a string", key)
+			return nil, fmt.Errorf("rendered pod selector matchLabels[%q] must be a string", key)
 		}
 		labels[key] = text
 	}
@@ -841,12 +733,12 @@ func (i *bindingInspector) addCollisionFinding(
 	})
 }
 
-// zeroEligibleWorkloadsFinding records that readable pods did not match the rendered identity selectors.
-func zeroEligibleWorkloadsFinding(binding *kleymv1alpha1.InferenceIdentityBinding) BindingInspectionFinding {
+// zeroMatchedPodsFinding records that readable pods did not match the rendered identity selectors.
+func zeroMatchedPodsFinding(binding *kleymv1alpha1.InferenceIdentityBinding) BindingInspectionFinding {
 	return BindingInspectionFinding{
-		ID:       findingZeroEligibleWorkload,
+		ID:       findingZeroMatchedPods,
 		Severity: BindingInspectionFindingSeverityInfo,
-		Reason:   reasonZeroEligibleWorkload,
+		Reason:   reasonZeroMatchedPods,
 		Message:  "no currently readable pods match the rendered identity selectors",
 		AffectedRefs: []BindingInspectionTargetRef{{
 			Namespace: binding.Namespace,
@@ -868,7 +760,7 @@ func unsupportedSelectorFinding(
 		Severity: BindingInspectionFindingSeverityWarning,
 		Reason:   reasonUnsupportedSelector,
 		Message: fmt.Sprintf(
-			"pod eligibility cannot be fully evaluated because rendered selectors are unsupported by CLI pod inspection: %s",
+			"matched pods cannot be fully evaluated because rendered selectors are unsupported by CLI pod inspection: %s",
 			strings.Join(selectors, ", "),
 		),
 		AffectedRefs: []BindingInspectionTargetRef{{
@@ -1019,57 +911,6 @@ func selectorProvenance(
 	}
 }
 
-func managedClusterSPIFFEIDReport(object *unstructured.Unstructured) BindingInspectionManagedClusterSPIFFEID {
-	spec, _, _ := unstructured.NestedMap(object.Object, "spec")
-	spiffeID, _ := spec["spiffeIDTemplate"].(string)
-	podSelector, _ := spec["podSelector"].(map[string]any)
-	hint, _ := spec["hint"].(string)
-	className, _ := spec["className"].(string)
-	fallback, hasFallback := spec["fallback"].(bool)
-
-	report := BindingInspectionManagedClusterSPIFFEID{
-		Name:              object.GetName(),
-		SPIFFEID:          spiffeID,
-		PodSelector:       podSelector,
-		WorkloadSelectors: stringSliceFromAny(spec["workloadSelectorTemplates"]),
-		Hint:              hint,
-		ClassName:         className,
-		Conditions:        clusterSPIFFEIDConditions(object),
-	}
-	if hasFallback {
-		report.Fallback = boolPtr(fallback)
-	}
-	return report
-}
-
-func clusterSPIFFEIDConditions(object *unstructured.Unstructured) []metav1.Condition {
-	rawConditions, found, err := unstructured.NestedSlice(object.Object, "status", "conditions")
-	if err != nil || !found {
-		return nil
-	}
-	data, err := json.Marshal(rawConditions)
-	if err != nil {
-		return nil
-	}
-	var conditions []metav1.Condition
-	if err := json.Unmarshal(data, &conditions); err != nil {
-		return nil
-	}
-	return conditions
-}
-
-func driftEntries(desired *unstructured.Unstructured, observed *unstructured.Unstructured) []BindingInspectionDriftEntry {
-	entries := make([]BindingInspectionDriftEntry, 0)
-	for _, entry := range spirecm.DriftEntries(desired, observed) {
-		entries = append(entries, BindingInspectionDriftEntry{
-			Field:    entry.Field,
-			Desired:  entry.Desired,
-			Observed: entry.Observed,
-		})
-	}
-	return entries
-}
-
 // HasErrorSeverityFinding reports whether findings contain any error-severity item.
 func HasErrorSeverityFinding(findings []BindingInspectionFinding) bool {
 	for _, finding := range findings {
@@ -1090,27 +931,8 @@ func HasWarningSeverityFinding(findings []BindingInspectionFinding) bool {
 	return false
 }
 
-func eligibleWorkloadSortKey(workload BindingInspectionEligibleWorkload) string {
+func matchedPodSortKey(workload BindingInspectionMatchedPod) string {
 	return workload.Namespace + "/" + workload.Pod + "/" + workload.Container
-}
-
-func stringSliceFromAny(value any) []string {
-	switch typed := value.(type) {
-	case []string:
-		return append([]string(nil), typed...)
-	case []any:
-		result := make([]string, 0, len(typed))
-		for _, item := range typed {
-			text, ok := item.(string)
-			if !ok {
-				continue
-			}
-			result = append(result, text)
-		}
-		return result
-	default:
-		return nil
-	}
 }
 
 func setFromStrings(values []string) map[string]struct{} {

--- a/internal/inspection/inspection_test.go
+++ b/internal/inspection/inspection_test.go
@@ -46,32 +46,25 @@ func TestInspectBindingSuccessReport(t *testing.T) {
 		t.Fatalf("bindingRef = %#v", report.BindingRef)
 	}
 	expectedName := spirecm.BuildClusterSPIFFEIDName(binding.Namespace, binding.Name, rendered.Mode, rendered.SpiffeID)
-	if report.Desired.ClusterSPIFFEIDName != expectedName {
-		t.Fatalf("desired name = %q, want %q", report.Desired.ClusterSPIFFEIDName, expectedName)
+	if report.RenderedClusterSPIFFEID.Name != expectedName {
+		t.Fatalf("rendered ClusterSPIFFEID name = %q, want %q", report.RenderedClusterSPIFFEID.Name, expectedName)
 	}
-	if len(report.Observed.ManagedClusterSPIFFEIDs) != 1 {
-		t.Fatalf("managed ClusterSPIFFEIDs = %d, want 1", len(report.Observed.ManagedClusterSPIFFEIDs))
-	}
-	if len(report.Observed.EligibleWorkloads) != 1 ||
-		report.Observed.EligibleWorkloads[0].Container != "model-server" {
-		t.Fatalf("eligible workloads = %#v, want model-server container", report.Observed.EligibleWorkloads)
-	}
-	if len(report.Observed.Drift) != 0 {
-		t.Fatalf("expected no drift, got %#v", report.Observed.Drift)
+	if len(report.MatchedPods) != 1 ||
+		report.MatchedPods[0].Container != "model-server" {
+		t.Fatalf("matched pods = %#v, want model-server container", report.MatchedPods)
 	}
 	if len(report.Findings) != 0 {
 		t.Fatalf("expected no findings, got %#v", report.Findings)
 	}
 	if report.Capabilities.Binding != BindingInspectionCapabilityFull ||
 		report.Capabilities.GAIEResources != BindingInspectionCapabilityFull ||
-		report.Capabilities.ClusterSPIFFEIDs != BindingInspectionCapabilityFull ||
 		report.Capabilities.PeerBindings != BindingInspectionCapabilityPartial ||
 		report.Capabilities.Pods != BindingInspectionCapabilityFull {
 		t.Fatalf("unexpected capabilities: %#v", report.Capabilities)
 	}
 }
 
-func TestInspectBindingPoolOnlyEligibleWorkload(t *testing.T) {
+func TestInspectBindingPoolOnlyMatchedPod(t *testing.T) {
 	binding := testInspectionPoolOnlyBinding()
 	pool := testInspectionPool("pool-a")
 	rendered, err := inspectionPlan(binding, nil, pool)
@@ -90,12 +83,12 @@ func TestInspectBindingPoolOnlyEligibleWorkload(t *testing.T) {
 	if report.BindingRef.Mode != string(kleymv1alpha1.InferenceIdentityBindingModePoolOnly) {
 		t.Fatalf("bindingRef mode = %q, want PoolOnly", report.BindingRef.Mode)
 	}
-	if len(report.Observed.EligibleWorkloads) != 1 {
-		t.Fatalf("eligible workloads = %#v, want one pod", report.Observed.EligibleWorkloads)
+	if len(report.MatchedPods) != 1 {
+		t.Fatalf("matched pods = %#v, want one pod", report.MatchedPods)
 	}
-	workload := report.Observed.EligibleWorkloads[0]
+	workload := report.MatchedPods[0]
 	if workload.Namespace != "tenant-a" || workload.Pod != "model-server-a" || workload.Container != "" {
-		t.Fatalf("eligible workload = %#v, want pod-level workload without container", workload)
+		t.Fatalf("matched pod = %#v, want pod-level match without container", workload)
 	}
 	if len(report.Findings) != 0 {
 		t.Fatalf("expected no findings, got %#v", report.Findings)
@@ -127,22 +120,15 @@ func TestInspectBindingUsesStatusOperatorConfig(t *testing.T) {
 		t.Fatalf("InspectBinding returned error: %v", err)
 	}
 
-	if report.Desired.SPIFFEID != "spiffe://example.org/ns/tenant-a/objective/objective-a" {
-		t.Fatalf("desired spiffeID = %q, want configured trust domain", report.Desired.SPIFFEID)
+	if report.RenderedIdentity.SPIFFEID != "spiffe://example.org/ns/tenant-a/objective/objective-a" {
+		t.Fatalf("rendered spiffeID = %q, want configured trust domain", report.RenderedIdentity.SPIFFEID)
 	}
-	if report.Desired.ClassName != "kleym" {
-		t.Fatalf("desired className = %q, want kleym", report.Desired.ClassName)
+	if report.RenderedClusterSPIFFEID.ClassName != "kleym" {
+		t.Fatalf("rendered className = %q, want kleym", report.RenderedClusterSPIFFEID.ClassName)
 	}
 	if report.IdentityConfig.TrustDomainSource != identityConfigSourceBindingStatus ||
 		report.IdentityConfig.ClusterSPIFFEIDClassNameSource != identityConfigSourceBindingStatus {
 		t.Fatalf("identityConfig = %#v, want bindingStatus sources", report.IdentityConfig)
-	}
-	if len(report.Observed.ManagedClusterSPIFFEIDs) != 1 ||
-		report.Observed.ManagedClusterSPIFFEIDs[0].ClassName != "kleym" {
-		t.Fatalf("managed ClusterSPIFFEIDs = %#v, want className kleym", report.Observed.ManagedClusterSPIFFEIDs)
-	}
-	if len(report.Observed.Drift) != 0 {
-		t.Fatalf("expected no drift, got %#v", report.Observed.Drift)
 	}
 	if len(report.Findings) != 0 {
 		t.Fatalf("expected no findings, got %#v", report.Findings)
@@ -177,12 +163,9 @@ func TestInspectBindingFlagsOverrideStatusOperatorConfig(t *testing.T) {
 		report.IdentityConfig.ClusterSPIFFEIDClassNameSource != identityConfigSourceFlag {
 		t.Fatalf("identityConfig = %#v, want flag sources", report.IdentityConfig)
 	}
-	if report.Desired.SPIFFEID != "spiffe://example.org/ns/tenant-a/objective/objective-a" ||
-		report.Desired.ClassName != "kleym" {
-		t.Fatalf("desired = %#v, want flag-rendered output", report.Desired)
-	}
-	if len(report.Observed.Drift) != 0 {
-		t.Fatalf("expected no drift, got %#v", report.Observed.Drift)
+	if report.RenderedIdentity.SPIFFEID != "spiffe://example.org/ns/tenant-a/objective/objective-a" ||
+		report.RenderedClusterSPIFFEID.ClassName != "kleym" {
+		t.Fatalf("rendered output = %#v / %#v, want flag-rendered output", report.RenderedIdentity, report.RenderedClusterSPIFFEID)
 	}
 	if len(report.Findings) != 0 {
 		t.Fatalf("expected no findings, got %#v", report.Findings)
@@ -213,9 +196,6 @@ func TestInspectBindingMissingStatusOperatorConfigUsesDefaultsAndWarns(t *testin
 		t.Fatalf("identityConfig = %#v, want default sources", report.IdentityConfig)
 	}
 	assertFinding(t, report.Findings, findingIdentityConfigMissing, BindingInspectionFindingSeverityWarning, reasonIdentityConfigMissing)
-	if len(report.Observed.Drift) != 0 {
-		t.Fatalf("expected no drift, got %#v", report.Observed.Drift)
-	}
 }
 
 func TestInspectBindingStatusOperatorConfigSupportsClasslessOutput(t *testing.T) {
@@ -239,11 +219,8 @@ func TestInspectBindingStatusOperatorConfigSupportsClasslessOutput(t *testing.T)
 	if report.IdentityConfig.ClusterSPIFFEIDClassNameSource != identityConfigSourceBindingStatus {
 		t.Fatalf("identityConfig = %#v, want class source bindingStatus", report.IdentityConfig)
 	}
-	if report.Desired.ClassName != "" {
-		t.Fatalf("desired className = %q, want classless", report.Desired.ClassName)
-	}
-	if len(report.Observed.Drift) != 0 {
-		t.Fatalf("expected no drift, got %#v", report.Observed.Drift)
+	if report.RenderedClusterSPIFFEID.ClassName != "" {
+		t.Fatalf("rendered className = %q, want classless", report.RenderedClusterSPIFFEID.ClassName)
 	}
 	if len(report.Findings) != 0 {
 		t.Fatalf("expected no findings, got %#v", report.Findings)
@@ -294,7 +271,7 @@ func TestInspectBindingInvalidServiceAccountNameFinding(t *testing.T) {
 	assertFinding(t, report.Findings, findingRenderFailure, BindingInspectionFindingSeverityError, "InvalidServiceAccountName")
 }
 
-func TestInspectBindingObservedDriftFinding(t *testing.T) {
+func TestInspectBindingIgnoresManagedClusterSPIFFEIDState(t *testing.T) {
 	binding := testInspectionBinding()
 	pool := testInspectionPool("pool-a")
 	objective := testInspectionObjective("objective-a", "pool-a")
@@ -303,43 +280,43 @@ func TestInspectBindingObservedDriftFinding(t *testing.T) {
 		t.Fatalf("render test identity: %v", err)
 	}
 	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered, "")
-	if err := unstructured.SetNestedField(managed.Object, "spiffe://drifted.example.test/ns/tenant-a/objective/objective-a", "spec", "spiffeIDTemplate"); err != nil {
-		t.Fatalf("set drifted spiffeIDTemplate: %v", err)
+	if err := unstructured.SetNestedField(managed.Object, "spiffe://wrong.example.test/ns/tenant-a/objective/objective-a", "spec", "spiffeIDTemplate"); err != nil {
+		t.Fatalf("set mismatched spiffeIDTemplate: %v", err)
 	}
+	pod := testInspectionPod("model-server-a", "model-server")
 
-	inspector := newTestBindingInspector(t, nil, binding, pool, objective, managed)
+	inspector := newTestBindingInspector(t, nil, binding, pool, objective, managed, pod)
 	report, err := inspector.InspectBinding(context.Background(), "tenant-a", "binding-a")
 	if err != nil {
 		t.Fatalf("InspectBinding returned error: %v", err)
 	}
 
-	assertFinding(t, report.Findings, findingObservedDrift, BindingInspectionFindingSeverityWarning, reasonObservedDrift)
-	if len(report.Observed.Drift) == 0 {
-		t.Fatalf("expected drift entries")
-	}
-	if !driftContainsField(report.Observed.Drift, "spec.spiffeIDTemplate") {
-		t.Fatalf("expected spiffeIDTemplate drift, got %#v", report.Observed.Drift)
+	if len(report.Findings) != 0 {
+		t.Fatalf("expected no findings, got %#v", report.Findings)
 	}
 }
 
-func TestInspectBindingMissingManagedOutputDrift(t *testing.T) {
+func TestInspectBindingDoesNotRequireManagedClusterSPIFFEID(t *testing.T) {
 	binding := testInspectionBinding()
 	pool := testInspectionPool("pool-a")
 	objective := testInspectionObjective("objective-a", "pool-a")
-	inspector := newTestBindingInspector(t, nil, binding, pool, objective)
+	pod := testInspectionPod("model-server-a", "model-server")
+	inspector := newTestBindingInspector(t, nil, binding, pool, objective, pod)
 
 	report, err := inspector.InspectBinding(context.Background(), "tenant-a", "binding-a")
 	if err != nil {
 		t.Fatalf("InspectBinding returned error: %v", err)
 	}
 
-	assertFinding(t, report.Findings, findingObservedDrift, BindingInspectionFindingSeverityWarning, reasonObservedDrift)
-	if !driftContainsField(report.Observed.Drift, "metadata.name") {
-		t.Fatalf("expected missing managed object drift, got %#v", report.Observed.Drift)
+	if len(report.Findings) != 0 {
+		t.Fatalf("expected no findings, got %#v", report.Findings)
+	}
+	if report.RenderedClusterSPIFFEID.Name == "" {
+		t.Fatalf("expected rendered ClusterSPIFFEID output")
 	}
 }
 
-func TestInspectBindingZeroEligibleWorkloadsFinding(t *testing.T) {
+func TestInspectBindingZeroMatchedPodsFinding(t *testing.T) {
 	binding := testInspectionBinding()
 	pool := testInspectionPool("pool-a")
 	objective := testInspectionObjective("objective-a", "pool-a")
@@ -355,32 +332,30 @@ func TestInspectBindingZeroEligibleWorkloadsFinding(t *testing.T) {
 		t.Fatalf("InspectBinding returned error: %v", err)
 	}
 
-	assertFinding(t, report.Findings, findingZeroEligibleWorkload, BindingInspectionFindingSeverityInfo, reasonZeroEligibleWorkload)
+	assertFinding(t, report.Findings, findingZeroMatchedPods, BindingInspectionFindingSeverityInfo, reasonZeroMatchedPods)
 	if report.Capabilities.Pods != BindingInspectionCapabilityFull {
 		t.Fatalf("pods capability = %q, want full", report.Capabilities.Pods)
 	}
 }
 
-func TestInspectBindingRBACLimitedClusterSPIFFEIDs(t *testing.T) {
+func TestInspectBindingIgnoresClusterSPIFFEIDListRBAC(t *testing.T) {
 	binding := testInspectionBinding()
 	pool := testInspectionPool("pool-a")
 	objective := testInspectionObjective("objective-a", "pool-a")
+	pod := testInspectionPod("model-server-a", "model-server")
 	forbidden := apierrors.NewForbidden(
-		schema.GroupResource{Group: spirecm.ClusterSPIFFEIDGVK().Group, Resource: clusterSPIFFEIDResourceName},
+		schema.GroupResource{Group: spirecm.ClusterSPIFFEIDGVK().Group, Resource: "clusterspiffeids"},
 		"",
 		errors.New("denied"),
 	)
-	inspector := newTestBindingInspector(t, forbidden, binding, pool, objective)
+	inspector := newTestBindingInspector(t, forbidden, binding, pool, objective, pod)
 
 	report, err := inspector.InspectBinding(context.Background(), "tenant-a", "binding-a")
 	if err != nil {
 		t.Fatalf("InspectBinding returned error: %v", err)
 	}
 
-	assertFinding(t, report.Findings, findingRBACLimited, BindingInspectionFindingSeverityWarning, reasonRBACLimited)
-	if report.Capabilities.ClusterSPIFFEIDs != BindingInspectionCapabilityPartial {
-		t.Fatalf("clusterspiffeids capability = %q, want partial", report.Capabilities.ClusterSPIFFEIDs)
-	}
+	assertNoFinding(t, report.Findings, findingRBACLimited)
 }
 
 func TestInspectBindingRBACLimitedPods(t *testing.T) {
@@ -410,25 +385,23 @@ func TestInspectBindingRBACLimitedPods(t *testing.T) {
 	}
 }
 
-func TestInspectBindingNoMatchClusterSPIFFEIDCapability(t *testing.T) {
+func TestInspectBindingDoesNotRequireClusterSPIFFEIDCRD(t *testing.T) {
 	binding := testInspectionBinding()
 	pool := testInspectionPool("pool-a")
 	objective := testInspectionObjective("objective-a", "pool-a")
+	pod := testInspectionPod("model-server-a", "model-server")
 	noMatch := &meta.NoKindMatchError{
 		GroupKind:        spirecm.ClusterSPIFFEIDGVK().GroupKind(),
 		SearchedVersions: []string{spirecm.ClusterSPIFFEIDGVK().Version},
 	}
-	inspector := newTestBindingInspector(t, noMatch, binding, pool, objective)
+	inspector := newTestBindingInspector(t, noMatch, binding, pool, objective, pod)
 
 	report, err := inspector.InspectBinding(context.Background(), "tenant-a", "binding-a")
-	if !errors.Is(err, ErrBindingInspectionErrorFindings) {
-		t.Fatalf("InspectBinding error = %v, want error findings", err)
+	if err != nil {
+		t.Fatalf("InspectBinding returned error: %v", err)
 	}
 
-	assertFinding(t, report.Findings, findingDependencyMissing, BindingInspectionFindingSeverityError, "ClusterSPIFFEIDCRDMissing")
-	if report.Capabilities.ClusterSPIFFEIDs != BindingInspectionCapabilityUnknown {
-		t.Fatalf("clusterspiffeids capability = %q, want unknown", report.Capabilities.ClusterSPIFFEIDs)
-	}
+	assertNoFinding(t, report.Findings, findingDependencyMissing)
 }
 
 func TestInspectBindingCollisionConditionFinding(t *testing.T) {
@@ -631,13 +604,14 @@ func assertFinding(
 	t.Fatalf("finding %s/%s/%s not found in %#v", id, severity, reason, findings)
 }
 
-func driftContainsField(entries []BindingInspectionDriftEntry, field string) bool {
-	for _, entry := range entries {
-		if entry.Field == field {
-			return true
+func assertNoFinding(t *testing.T, findings []BindingInspectionFinding, id string) {
+	t.Helper()
+
+	for _, finding := range findings {
+		if finding.ID == id {
+			t.Fatalf("unexpected finding %s in %#v", id, findings)
 		}
 	}
-	return false
 }
 
 type fixedInspectionRunner struct {
@@ -725,13 +699,6 @@ func inspectionPlanWithTrustDomain(
 		PodSelector:          poolSelector,
 		PoolDerivedSelectors: poolDerivedSelectors,
 	})
-}
-
-func TestStringSliceFromAnySkipsNonStrings(t *testing.T) {
-	got := stringSliceFromAny([]any{"a", 1, "b"})
-	if strings.Join(got, ",") != "a,b" {
-		t.Fatalf("stringSliceFromAny = %#v", got)
-	}
 }
 
 var _ client.Client = listErrorClient{}

--- a/internal/inspection/report.go
+++ b/internal/inspection/report.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,21 +38,24 @@ const (
 // BindingInspectionFindingSeverity is the stable severity enum for machine-readable findings.
 type BindingInspectionFindingSeverity string
 
-// BindingInspectionCapability is the stable completeness enum for machine-readable capabilities.
+// BindingInspectionCapability is the internal completeness enum used while building findings and text output.
 type BindingInspectionCapability string
 
 // BindingInspectionReport captures the JSON contract for `kleym inspect binding -o json`.
 type BindingInspectionReport struct {
-	SchemaVersion  string                          `json:"schemaVersion"`
-	Kind           string                          `json:"kind"`
-	GeneratedAt    string                          `json:"generatedAt"`
-	IdentityConfig BindingInspectionIdentityConfig `json:"identityConfig,omitempty"`
-	BindingRef     BindingInspectionBindingRef     `json:"bindingRef"`
-	Resolved       BindingInspectionResolvedInput  `json:"resolvedInput"`
-	Desired        BindingInspectionDesiredState   `json:"desired"`
-	Observed       BindingInspectionObservedState  `json:"observed"`
-	Findings       []BindingInspectionFinding      `json:"findings"`
-	Capabilities   BindingInspectionCapabilities   `json:"capabilities"`
+	SchemaVersion           string                                   `json:"schemaVersion"`
+	Kind                    string                                   `json:"kind"`
+	GeneratedAt             string                                   `json:"generatedAt"`
+	IdentityConfig          BindingInspectionIdentityConfig          `json:"identityConfig,omitempty"`
+	BindingRef              BindingInspectionBindingRef              `json:"bindingRef"`
+	Resolved                BindingInspectionResolvedInput           `json:"resolvedInput"`
+	RenderedIdentity        BindingInspectionRenderedIdentity        `json:"renderedIdentity"`
+	RenderedClusterSPIFFEID BindingInspectionRenderedClusterSPIFFEID `json:"renderedClusterSPIFFEID"`
+	MatchedPods             []BindingInspectionMatchedPod            `json:"matchedPods"`
+	Findings                []BindingInspectionFinding               `json:"findings"`
+
+	Capabilities BindingInspectionCapabilities `json:"-"`
+	ExitCode     *int                          `json:"-"`
 }
 
 // BindingInspectionIdentityConfig records which identity configuration inspection used.
@@ -106,46 +110,27 @@ type BindingInspectionSelectorProvenance struct {
 	SafetySelectors      []string `json:"safetySelectors,omitempty"`
 }
 
-// BindingInspectionDesiredState captures the deterministic output kleym would render.
-type BindingInspectionDesiredState struct {
-	ClusterSPIFFEIDName string                               `json:"clusterSPIFFEIDName,omitempty"`
-	SPIFFEID            string                               `json:"spiffeID,omitempty"`
-	PodSelector         map[string]any                       `json:"podSelector,omitempty"`
-	WorkloadSelectors   []string                             `json:"workloadSelectors,omitempty"`
-	SelectorProvenance  *BindingInspectionSelectorProvenance `json:"selectorProvenance,omitempty"`
-	Hint                string                               `json:"hint,omitempty"`
-	ClassName           string                               `json:"className,omitempty"`
-	Fallback            *bool                                `json:"fallback,omitempty"`
+// BindingInspectionRenderedIdentity captures the identity fields rendered from the binding.
+type BindingInspectionRenderedIdentity struct {
+	SPIFFEID           string                               `json:"spiffeID,omitempty"`
+	PodSelector        map[string]any                       `json:"podSelector,omitempty"`
+	WorkloadSelectors  []string                             `json:"workloadSelectors,omitempty"`
+	SelectorProvenance *BindingInspectionSelectorProvenance `json:"selectorProvenance,omitempty"`
 }
 
-// BindingInspectionObservedState captures current cluster state relevant to the binding.
-type BindingInspectionObservedState struct {
-	ManagedClusterSPIFFEIDs []BindingInspectionManagedClusterSPIFFEID `json:"managedClusterSPIFFEIDs,omitempty"`
-	Drift                   []BindingInspectionDriftEntry             `json:"drift,omitempty"`
-	EligibleWorkloads       []BindingInspectionEligibleWorkload       `json:"eligibleWorkloads,omitempty"`
+// BindingInspectionRenderedClusterSPIFFEID captures the managed object fields Kleym renders.
+type BindingInspectionRenderedClusterSPIFFEID struct {
+	Name              string         `json:"name,omitempty"`
+	SPIFFEID          string         `json:"spiffeID,omitempty"`
+	PodSelector       map[string]any `json:"podSelector,omitempty"`
+	WorkloadSelectors []string       `json:"workloadSelectors,omitempty"`
+	Hint              string         `json:"hint,omitempty"`
+	ClassName         string         `json:"className,omitempty"`
+	Fallback          *bool          `json:"fallback,omitempty"`
 }
 
-// BindingInspectionManagedClusterSPIFFEID summarizes one managed rendered object.
-type BindingInspectionManagedClusterSPIFFEID struct {
-	Name              string             `json:"name,omitempty"`
-	SPIFFEID          string             `json:"spiffeID,omitempty"`
-	PodSelector       map[string]any     `json:"podSelector,omitempty"`
-	WorkloadSelectors []string           `json:"workloadSelectors,omitempty"`
-	Hint              string             `json:"hint,omitempty"`
-	ClassName         string             `json:"className,omitempty"`
-	Fallback          *bool              `json:"fallback,omitempty"`
-	Conditions        []metav1.Condition `json:"conditions,omitempty"`
-}
-
-// BindingInspectionDriftEntry summarizes one desired-versus-observed mismatch.
-type BindingInspectionDriftEntry struct {
-	Field    string `json:"field,omitempty"`
-	Desired  string `json:"desired,omitempty"`
-	Observed string `json:"observed,omitempty"`
-}
-
-// BindingInspectionEligibleWorkload records one currently matching pod or container.
-type BindingInspectionEligibleWorkload struct {
+// BindingInspectionMatchedPod records one currently matching pod or container.
+type BindingInspectionMatchedPod struct {
 	Namespace string `json:"namespace,omitempty"`
 	Pod       string `json:"pod,omitempty"`
 	Container string `json:"container,omitempty"`
@@ -160,7 +145,7 @@ type BindingInspectionFinding struct {
 	AffectedRefs []BindingInspectionTargetRef     `json:"affectedRefs"`
 }
 
-// BindingInspectionCapabilities records which inspection areas were complete.
+// BindingInspectionCapabilities records internal inspection completeness.
 type BindingInspectionCapabilities struct {
 	Binding          BindingInspectionCapability `json:"binding,omitempty"`
 	GAIEResources    BindingInspectionCapability `json:"gaieResources,omitempty"`
@@ -184,6 +169,9 @@ func normalizeBindingInspectionReport(report BindingInspectionReport) BindingIns
 	if report.Findings == nil {
 		report.Findings = []BindingInspectionFinding{}
 	}
+	if report.MatchedPods == nil {
+		report.MatchedPods = []BindingInspectionMatchedPod{}
+	}
 	for i := range report.Findings {
 		if report.Findings[i].AffectedRefs == nil {
 			report.Findings[i].AffectedRefs = []BindingInspectionTargetRef{}
@@ -204,94 +192,33 @@ func writeBindingInspectionReportText(w io.Writer, report BindingInspectionRepor
 	report = normalizeBindingInspectionReport(report)
 
 	var builder strings.Builder
-	appendTextLine(&builder, "BindingInspectionReport")
-	appendTextLine(&builder, "GeneratedAt: %s", textString(report.GeneratedAt))
-	appendTextLine(&builder, "")
-	appendTextLine(&builder, "Summary:")
-	appendTextLine(&builder, "  Status: %s", inspectionTextStatus(report.Findings))
-	appendTextLine(&builder, "  Findings: %s", textCountOrNone(len(report.Findings)))
-	appendTextLine(&builder, "  Drift: %s", textCountOrNone(len(report.Observed.Drift)))
-	appendTextLine(&builder, "  Eligible workloads: %d", len(report.Observed.EligibleWorkloads))
-	appendTextLine(&builder, "  Inspection completeness: %s", inspectionTextCompleteness(report.Capabilities))
-	partialChecks := inspectionTextCapabilityNames(report.Capabilities, BindingInspectionCapabilityPartial)
-	if len(partialChecks) > 0 {
-		appendTextLine(&builder, "  Partial checks:")
-		for _, check := range partialChecks {
-			appendTextLine(&builder, "    - %s", check)
-		}
+	appendTextLine(&builder, "Binding: %s", textNamespacedName(report.BindingRef.Namespace, report.BindingRef.Name))
+	appendTextLine(&builder, "Mode: %s", textString(report.BindingRef.Mode))
+	appendTextLine(&builder, "Source: %s", textShortTargetRef(firstTargetRef(report.Resolved.PoolRef, report.BindingRef.PoolRef), "InferencePool"))
+	if report.BindingRef.Mode == "PerObjective" || report.BindingRef.ObjectiveRef != nil || report.Resolved.ObjectiveRef != nil {
+		appendTextLine(&builder, "Objective: %s", textShortTargetRef(firstTargetRef(report.Resolved.ObjectiveRef, report.BindingRef.ObjectiveRef), "InferenceObjective"))
 	}
-
-	appendTextLine(&builder, "")
-	appendTextLine(&builder, "Binding:")
-	appendTextLine(&builder, "  Name: %s", textNamespacedName(report.BindingRef.Namespace, report.BindingRef.Name))
-	appendTextLine(&builder, "  Generation: %d", report.BindingRef.Generation)
-	appendTextLine(&builder, "  Mode: %s", textString(report.BindingRef.Mode))
-	appendTextLine(&builder, "  PoolRef: %s", textTargetRef(report.BindingRef.PoolRef))
-	appendTextLine(&builder, "  ObjectiveRef: %s", textTargetRef(report.BindingRef.ObjectiveRef))
-	appendTextConditions(&builder, "  ", report.BindingRef.Conditions)
-
-	appendTextLine(&builder, "")
-	appendTextLine(&builder, "Identity config:")
-	appendTextLine(&builder, "  TrustDomain: %s (%s)", textString(report.IdentityConfig.TrustDomain), textString(report.IdentityConfig.TrustDomainSource))
-	appendTextLine(&builder, "  ClusterSPIFFEID className: %s (%s)", textString(report.IdentityConfig.ClusterSPIFFEIDClassName), textString(report.IdentityConfig.ClusterSPIFFEIDClassNameSource))
 
 	appendTextLine(&builder, "")
 	appendTextLine(&builder, "Identity:")
-	appendTextLine(&builder, "  ClusterSPIFFEID: %s", textString(report.Desired.ClusterSPIFFEIDName))
-	appendTextLine(&builder, "  SPIFFE ID: %s", textString(report.Desired.SPIFFEID))
-	appendTextLine(&builder, "  ClassName: %s", textString(report.Desired.ClassName))
-	appendTextLine(&builder, "  Hint: %s", textString(report.Desired.Hint))
-	appendTextLine(&builder, "  Fallback: %s", textBool(report.Desired.Fallback))
+	appendTextIdentity(&builder, report.RenderedIdentity)
 
 	appendTextLine(&builder, "")
-	appendTextLine(&builder, "Selectors:")
-	appendTextLine(&builder, "  Pod selector: %s", textStableValue(report.Desired.PodSelector))
-	appendTextStringList(&builder, "  Workload selectors", report.Desired.WorkloadSelectors)
+	appendTextLine(&builder, "ClusterSPIFFEID:")
+	appendTextClusterSPIFFEID(&builder, report.RenderedClusterSPIFFEID)
 
 	appendTextLine(&builder, "")
-	appendTextLine(&builder, "Observed:")
-	appendTextLine(&builder, "  Managed ClusterSPIFFEIDs: %d", len(report.Observed.ManagedClusterSPIFFEIDs))
-	for _, managed := range report.Observed.ManagedClusterSPIFFEIDs {
-		appendTextLine(&builder, "    - %s", textString(managed.Name))
-		if len(report.Observed.Drift) == 0 {
-			appendTextLine(&builder, "      Status: matches desired")
-		} else {
-			appendTextLine(&builder, "      Status: drift detected")
-			appendTextDriftEntries(&builder, "      ", report.Observed.Drift)
-		}
-		appendTextConditions(&builder, "      ", managed.Conditions)
-	}
-	if len(report.Observed.ManagedClusterSPIFFEIDs) == 0 && len(report.Observed.Drift) > 0 {
-		appendTextDriftEntries(&builder, "  ", report.Observed.Drift)
-	}
-	appendTextEligibleWorkloads(&builder, report.Observed.EligibleWorkloads)
+	appendTextLine(&builder, "Conditions:")
+	appendTextConditionList(&builder, "  ", report.BindingRef.Conditions)
 
 	appendTextLine(&builder, "")
-	appendTextLine(&builder, "Findings:")
-	if len(report.Findings) == 0 {
-		appendTextLine(&builder, "  none")
-	} else {
-		for _, finding := range report.Findings {
-			appendTextLine(&builder, "  - Severity: %s", textString(string(finding.Severity)))
-			appendTextLine(&builder, "    Reason: %s", textString(finding.Reason))
-			appendTextLine(&builder, "    Message: %s", textString(finding.Message))
-			appendTextLine(&builder, "    AffectedRefs:")
-			if len(finding.AffectedRefs) == 0 {
-				appendTextLine(&builder, "      none")
-			}
-			for i := range finding.AffectedRefs {
-				appendTextLine(&builder, "      - %s", textTargetRef(&finding.AffectedRefs[i]))
-			}
-		}
-	}
+	appendTextLine(&builder, "Matched pods:")
+	appendTextMatchedPods(&builder, report)
 
 	appendTextLine(&builder, "")
-	appendTextLine(&builder, "Capabilities:")
-	appendTextLine(&builder, "  Binding: %s", textString(string(report.Capabilities.Binding)))
-	appendTextLine(&builder, "  GAIE resources: %s", textString(string(report.Capabilities.GAIEResources)))
-	appendTextLine(&builder, "  ClusterSPIFFEIDs: %s", textString(string(report.Capabilities.ClusterSPIFFEIDs)))
-	appendTextLine(&builder, "  Peer bindings: %s", textString(string(report.Capabilities.PeerBindings)))
-	appendTextLine(&builder, "  Pods: %s", textString(string(report.Capabilities.Pods)))
+	appendTextFindings(&builder, report.Findings)
+
+	appendTextLine(&builder, "Exit code: %d", textExitCode(report))
 
 	_, err := io.WriteString(w, builder.String())
 	return err
@@ -326,14 +253,69 @@ func appendTextStringList(builder *strings.Builder, label string, values []strin
 	}
 }
 
-func appendTextConditions(builder *strings.Builder, indent string, conditions []metav1.Condition) {
-	appendTextLine(builder, "%sConditions:", indent)
+func appendTextIdentity(builder *strings.Builder, identity BindingInspectionRenderedIdentity) {
+	if identity.SPIFFEID == "" {
+		appendTextLine(builder, "  not rendered")
+		return
+	}
+	appendTextLine(builder, "  SPIFFE ID: %s", identity.SPIFFEID)
+	appendTextSelectorSummary(builder, identity.WorkloadSelectors)
+}
+
+func appendTextClusterSPIFFEID(builder *strings.Builder, clusterspiffeid BindingInspectionRenderedClusterSPIFFEID) {
+	if clusterspiffeid.Name == "" {
+		appendTextLine(builder, "  not rendered")
+		return
+	}
+	appendTextLine(builder, "  Name: %s", clusterspiffeid.Name)
+	appendTextLine(builder, "  ClassName: %s", textString(clusterspiffeid.ClassName))
+	appendTextLine(builder, "  Hint: %s", textString(clusterspiffeid.Hint))
+	if clusterspiffeid.Fallback != nil && *clusterspiffeid.Fallback {
+		appendTextLine(builder, "  Fallback: true")
+	}
+}
+
+func appendTextSelectorSummary(builder *strings.Builder, selectors []string) {
+	selection := workloadSelectionFromSelectors(selectors)
+	appendTextLine(builder, "  Selectors:")
+	if selection.Namespace != "" {
+		appendTextLine(builder, "    namespace: %s", selection.Namespace)
+	}
+	if selection.ServiceAccount != "" {
+		appendTextLine(builder, "    serviceAccount: %s", selection.ServiceAccount)
+	}
+	appendTextPodLabels(builder, selection.PodLabels)
+	if selection.ContainerSelectorType == "name" {
+		appendTextLine(builder, "    container: %s", selection.ContainerValue)
+	}
+	if len(selection.UnsupportedSelectors) > 0 {
+		appendTextStringList(builder, "    unsupported", selection.UnsupportedSelectors)
+	}
+}
+
+func appendTextPodLabels(builder *strings.Builder, labels map[string]string) {
+	if len(labels) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	values := make([]string, 0, len(keys))
+	for _, key := range keys {
+		values = append(values, key+"="+labels[key])
+	}
+	appendTextLine(builder, "    podLabels: %s", strings.Join(values, ", "))
+}
+
+func appendTextConditionList(builder *strings.Builder, indent string, conditions []metav1.Condition) {
 	if len(conditions) == 0 {
-		appendTextLine(builder, "%s  none", indent)
+		appendTextLine(builder, "%snone", indent)
 		return
 	}
 	for _, condition := range conditions {
-		appendTextLine(builder, "%s  %s=%s", indent, condition.Type, condition.Status)
+		appendTextLine(builder, "%s%s=%s", indent, condition.Type, condition.Status)
 		if !textConditionNeedsDetail(condition) {
 			continue
 		}
@@ -342,31 +324,44 @@ func appendTextConditions(builder *strings.Builder, indent string, conditions []
 	}
 }
 
-func appendTextDriftEntries(builder *strings.Builder, indent string, entries []BindingInspectionDriftEntry) {
-	appendTextLine(builder, "%sDrift:", indent)
-	if len(entries) == 0 {
-		appendTextLine(builder, "%s  none", indent)
+func appendTextMatchedPods(builder *strings.Builder, report BindingInspectionReport) {
+	if report.RenderedIdentity.SPIFFEID == "" {
+		appendTextLine(builder, "  skipped")
 		return
 	}
-	for _, drift := range entries {
-		appendTextLine(builder, "%s  - Field: %s", indent, textDriftField(drift.Field))
-		appendTextLine(builder, "%s    Desired: %s", indent, textString(drift.Desired))
-		appendTextLine(builder, "%s    Observed: %s", indent, textString(drift.Observed))
-	}
-}
-
-func appendTextEligibleWorkloads(builder *strings.Builder, workloads []BindingInspectionEligibleWorkload) {
-	appendTextLine(builder, "  Eligible workloads:")
-	if len(workloads) == 0 {
-		appendTextLine(builder, "    none")
+	if report.Capabilities.Pods == BindingInspectionCapabilityPartial ||
+		report.Capabilities.Pods == BindingInspectionCapabilityUnknown {
+		appendTextLine(builder, "  unknown")
 		return
 	}
-	for _, workload := range workloads {
+	if report.Capabilities.Pods == BindingInspectionCapabilitySkipped {
+		appendTextLine(builder, "  skipped")
+		return
+	}
+	if len(report.MatchedPods) == 0 {
+		appendTextLine(builder, "  none")
+		return
+	}
+	for _, workload := range report.MatchedPods {
 		line := textNamespacedName(workload.Namespace, workload.Pod)
 		if workload.Container != "" {
 			line += " container=" + workload.Container
 		}
-		appendTextLine(builder, "    - %s", line)
+		appendTextLine(builder, "  %s", line)
+	}
+}
+
+func appendTextFindings(builder *strings.Builder, findings []BindingInspectionFinding) {
+	if len(findings) == 0 {
+		appendTextLine(builder, "Findings: none")
+		return
+	}
+	appendTextLine(builder, "Findings:")
+	for _, finding := range findings {
+		appendTextLine(builder, "  %s %s", textFindingSeverity(finding.Severity), textString(finding.Reason))
+		if finding.Message != "" {
+			appendTextLine(builder, "    %s", finding.Message)
+		}
 	}
 }
 
@@ -379,74 +374,26 @@ func leadingSpaces(value string) int {
 	return len(value)
 }
 
-func inspectionTextStatus(findings []BindingInspectionFinding) string {
-	if HasErrorSeverityFinding(findings) {
+func textExitCode(report BindingInspectionReport) int {
+	if report.ExitCode != nil {
+		return *report.ExitCode
+	}
+	if HasErrorSeverityFinding(report.Findings) {
+		return 2
+	}
+	return 0
+}
+
+func textFindingSeverity(severity BindingInspectionFindingSeverity) string {
+	switch severity {
+	case BindingInspectionFindingSeverityError:
 		return "Error"
-	}
-	if HasWarningSeverityFinding(findings) {
+	case BindingInspectionFindingSeverityWarning:
 		return "Warning"
-	}
-	return "OK"
-}
-
-func inspectionTextCompleteness(capabilities BindingInspectionCapabilities) string {
-	checks := inspectionTextCapabilityChecks(capabilities)
-	hasCapability := false
-	hasSkipped := false
-	hasUnknown := false
-	for _, check := range checks {
-		if check.value == "" {
-			hasUnknown = true
-			continue
-		}
-		hasCapability = true
-		switch check.value {
-		case BindingInspectionCapabilityPartial:
-			return string(BindingInspectionCapabilityPartial)
-		case BindingInspectionCapabilitySkipped:
-			hasSkipped = true
-		case BindingInspectionCapabilityUnknown:
-			hasUnknown = true
-		case BindingInspectionCapabilityFull:
-		default:
-			hasUnknown = true
-		}
-	}
-	if hasSkipped {
-		return string(BindingInspectionCapabilitySkipped)
-	}
-	if hasUnknown || !hasCapability {
-		return string(BindingInspectionCapabilityUnknown)
-	}
-	return string(BindingInspectionCapabilityFull)
-}
-
-func inspectionTextCapabilityNames(
-	capabilities BindingInspectionCapabilities,
-	want BindingInspectionCapability,
-) []string {
-	checks := inspectionTextCapabilityChecks(capabilities)
-	names := make([]string, 0, len(checks))
-	for _, check := range checks {
-		if check.value == want {
-			names = append(names, check.name)
-		}
-	}
-	return names
-}
-
-type inspectionTextCapabilityCheck struct {
-	name  string
-	value BindingInspectionCapability
-}
-
-func inspectionTextCapabilityChecks(capabilities BindingInspectionCapabilities) []inspectionTextCapabilityCheck {
-	return []inspectionTextCapabilityCheck{
-		{name: "Binding", value: capabilities.Binding},
-		{name: "GAIE resources", value: capabilities.GAIEResources},
-		{name: "ClusterSPIFFEIDs", value: capabilities.ClusterSPIFFEIDs},
-		{name: "Peer bindings", value: capabilities.PeerBindings},
-		{name: "Pods", value: capabilities.Pods},
+	case BindingInspectionFindingSeverityInfo:
+		return "Info"
+	default:
+		return textString(string(severity))
 	}
 }
 
@@ -464,45 +411,11 @@ func textConditionNeedsDetail(condition metav1.Condition) bool {
 	}
 }
 
-func textCountOrNone(count int) string {
-	if count == 0 {
-		return "none"
-	}
-	return fmt.Sprintf("%d", count)
-}
-
-func textDriftField(field string) string {
-	switch field {
-	case "spec.spiffeIDTemplate":
-		return "spiffeID"
-	case "spec.podSelector":
-		return "podSelector"
-	case "spec.workloadSelectorTemplates":
-		return "workloadSelectorTemplates"
-	case "spec.hint":
-		return "hint"
-	case "spec.fallback":
-		return "fallback"
-	default:
-		return field
-	}
-}
-
 func textString(value string) string {
 	if value == "" {
 		return "(none)"
 	}
 	return value
-}
-
-func textBool(value *bool) string {
-	if value == nil {
-		return "(none)"
-	}
-	if *value {
-		return "true"
-	}
-	return "false"
 }
 
 func textNamespacedName(namespace string, name string) string {
@@ -515,53 +428,22 @@ func textNamespacedName(namespace string, name string) string {
 	return namespace + "/" + name
 }
 
-func textTargetRef(ref *BindingInspectionTargetRef) string {
+func textShortTargetRef(ref *BindingInspectionTargetRef, fallbackKind string) string {
 	if ref == nil {
-		return "(none)"
+		return "(missing)"
 	}
-	parts := make([]string, 0, 2)
-	if ref.Kind != "" {
-		kind := ref.Kind
-		if ref.Version != "" {
-			kind = ref.Version + "/" + kind
-		}
-		if ref.Group != "" {
-			kind = ref.Group + "/" + kind
-		}
-		parts = append(parts, kind)
+	kind := ref.Kind
+	if kind == "" {
+		kind = fallbackKind
 	}
-	parts = append(parts, textNamespacedName(ref.Namespace, ref.Name))
-	return strings.Join(parts, " ")
+	return strings.TrimSpace(kind + " " + textNamespacedName(ref.Namespace, ref.Name))
 }
 
-func textStableValue(value any) string {
-	if value == nil {
-		return "(none)"
-	}
-	text := stableValueString(value)
-	if text == "" {
-		return "(none)"
-	}
-	return text
-}
-
-func stableValueString(value any) string {
-	if value == nil {
-		return ""
-	}
-	switch typed := value.(type) {
-	case string:
-		return typed
-	case bool:
-		if typed {
-			return "true"
+func firstTargetRef(refs ...*BindingInspectionTargetRef) *BindingInspectionTargetRef {
+	for _, ref := range refs {
+		if ref != nil {
+			return ref
 		}
-		return "false"
-	default:
-		data, err := json.Marshal(typed)
-		if err != nil {
-			return fmt.Sprint(typed)
-		}
-		return string(data)
 	}
+	return nil
 }

--- a/internal/inspection/report_test.go
+++ b/internal/inspection/report_test.go
@@ -27,13 +27,13 @@ func TestBindingInspectionReportJSONMinimalShape(t *testing.T) {
 
 	wantTopLevelKeys := []string{
 		"bindingRef",
-		"capabilities",
-		"desired",
 		"findings",
 		"generatedAt",
 		"identityConfig",
 		"kind",
-		"observed",
+		"matchedPods",
+		"renderedClusterSPIFFEID",
+		"renderedIdentity",
 		"resolvedInput",
 		"schemaVersion",
 	}
@@ -50,7 +50,7 @@ func TestBindingInspectionReportJSONMinimalShape(t *testing.T) {
 	if got["generatedAt"] != "" {
 		t.Fatalf("expected empty generatedAt, got %#v", got["generatedAt"])
 	}
-	for _, key := range []string{"bindingRef", "identityConfig", "resolvedInput", "desired", "observed", "capabilities"} {
+	for _, key := range []string{"bindingRef", "identityConfig", "resolvedInput", "renderedIdentity", "renderedClusterSPIFFEID"} {
 		section, ok := got[key].(map[string]any)
 		if !ok {
 			t.Fatalf("expected %s to encode as object, got %#v", key, got[key])
@@ -65,6 +65,13 @@ func TestBindingInspectionReportJSONMinimalShape(t *testing.T) {
 	}
 	if len(findings) != 0 {
 		t.Fatalf("expected empty findings array, got %#v", findings)
+	}
+	matchedPods, ok := got["matchedPods"].([]any)
+	if !ok {
+		t.Fatalf("expected matchedPods array, got %#v", got["matchedPods"])
+	}
+	if len(matchedPods) != 0 {
+		t.Fatalf("expected empty matchedPods array, got %#v", matchedPods)
 	}
 }
 
@@ -127,9 +134,8 @@ func TestBindingInspectionReportJSONRepresentativeShape(t *testing.T) {
 				SafetySelectors:      []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
 			},
 		},
-		Desired: BindingInspectionDesiredState{
-			ClusterSPIFFEIDName: "tenant-a-binding-a-1234abcd",
-			SPIFFEID:            "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
+		RenderedIdentity: BindingInspectionRenderedIdentity{
+			SPIFFEID: "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
 			PodSelector: map[string]any{
 				"matchLabels": map[string]any{"app": "pool-a"},
 			},
@@ -144,50 +150,37 @@ func TestBindingInspectionReportJSONRepresentativeShape(t *testing.T) {
 				ContainerSelector:    "k8s:container-name:model-server",
 				SafetySelectors:      []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
 			},
+		},
+		RenderedClusterSPIFFEID: BindingInspectionRenderedClusterSPIFFEID{
+			Name:     "tenant-a-binding-a-1234abcd",
+			SPIFFEID: "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
+			PodSelector: map[string]any{
+				"matchLabels": map[string]any{"app": "pool-a"},
+			},
+			WorkloadSelectors: []string{
+				"k8s:ns:tenant-a",
+				"k8s:sa:model-sa",
+				"k8s:pod-label:app:pool-a",
+				"k8s:container-name:model-server",
+			},
 			Hint:      "tenant-a/binding-a",
 			ClassName: "kleym",
 			Fallback:  &fallbackFalse,
 		},
-		Observed: BindingInspectionObservedState{
-			ManagedClusterSPIFFEIDs: []BindingInspectionManagedClusterSPIFFEID{{
-				Name:     "tenant-a-binding-a-1234abcd",
-				SPIFFEID: "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
-				PodSelector: map[string]any{
-					"matchLabels": map[string]any{"app": "pool-a"},
-				},
-				WorkloadSelectors: []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
-				Hint:              "tenant-a/binding-a",
-				ClassName:         "kleym",
-				Fallback:          &fallbackFalse,
-			}},
-			Drift: []BindingInspectionDriftEntry{{
-				Field:    "spec.workloadSelectorTemplates",
-				Desired:  "k8s:container-name:model-server",
-				Observed: "k8s:container-name:old-server",
-			}},
-			EligibleWorkloads: []BindingInspectionEligibleWorkload{{
-				Namespace: "tenant-a",
-				Pod:       "pool-a-5f9488d7fb-q1w2e",
-				Container: "model-server",
-			}},
-		},
+		MatchedPods: []BindingInspectionMatchedPod{{
+			Namespace: "tenant-a",
+			Pod:       "pool-a-5f9488d7fb-q1w2e",
+			Container: "model-server",
+		}},
 		Findings: []BindingInspectionFinding{{
-			ID:       "observed-drift",
+			ID:       "rbac-limited",
 			Severity: BindingInspectionFindingSeverityWarning,
-			Reason:   "SelectorDrift",
-			Message:  "observed workload selectors differ from desired state",
+			Reason:   "Forbidden",
+			Message:  "pods are not readable",
 			AffectedRefs: []BindingInspectionTargetRef{{
-				Name: "tenant-a-binding-a-1234abcd",
-				Kind: "ClusterSPIFFEID",
+				Name: "pods",
 			}},
 		}},
-		Capabilities: BindingInspectionCapabilities{
-			Binding:          BindingInspectionCapabilityFull,
-			GAIEResources:    BindingInspectionCapabilityFull,
-			ClusterSPIFFEIDs: BindingInspectionCapabilityFull,
-			PeerBindings:     BindingInspectionCapabilityPartial,
-			Pods:             BindingInspectionCapabilitySkipped,
-		},
 	}
 
 	data, err := json.Marshal(normalizeBindingInspectionReport(report))
@@ -203,9 +196,12 @@ func TestBindingInspectionReportJSONRepresentativeShape(t *testing.T) {
 	assertObjectKeys(t, got["bindingRef"], "conditions", "generation", "mode", "name", "namespace", "objectiveRef", "poolRef")
 	assertObjectKeys(t, got["identityConfig"], "clusterSPIFFEIDClassName", "clusterSPIFFEIDClassNameSource", "trustDomain", "trustDomainSource")
 	assertObjectKeys(t, got["resolvedInput"], "containerName", "objectiveRef", "poolRef", "poolSelector", "selectorProvenance", "servedGVKs")
-	assertObjectKeys(t, got["desired"], "className", "clusterSPIFFEIDName", "fallback", "hint", "podSelector", "selectorProvenance", "spiffeID", "workloadSelectors")
-	assertObjectKeys(t, got["observed"], "drift", "eligibleWorkloads", "managedClusterSPIFFEIDs")
-	assertObjectKeys(t, got["capabilities"], "binding", "clusterspiffeids", "gaieResources", "peerBindings", "pods")
+	assertObjectKeys(t, got["renderedIdentity"], "podSelector", "selectorProvenance", "spiffeID", "workloadSelectors")
+	assertObjectKeys(t, got["renderedClusterSPIFFEID"], "className", "fallback", "hint", "name", "podSelector", "spiffeID", "workloadSelectors")
+	matchedPods := got["matchedPods"].([]any)
+	if len(matchedPods) != 1 {
+		t.Fatalf("matchedPods = %#v, want one pod", matchedPods)
+	}
 
 	resolved := got["resolvedInput"].(map[string]any)
 	assertObjectKeys(t, resolved["selectorProvenance"], "containerSelector", "poolDerivedSelectors", "safetySelectors")
@@ -318,47 +314,30 @@ func TestWriteBindingInspectionReportTextRepresentativeReport(t *testing.T) {
 				Kind:      "InferenceObjective",
 			},
 		},
-		Desired: BindingInspectionDesiredState{
-			ClusterSPIFFEIDName: "tenant-a-binding-a-1234abcd",
-			SPIFFEID:            "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
-			PodSelector:         map[string]any{"matchLabels": map[string]any{"app": "pool-a"}},
-			WorkloadSelectors:   []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
-			Hint:                "tenant-a/binding-a",
-			Fallback:            &fallbackFalse,
+		RenderedIdentity: BindingInspectionRenderedIdentity{
+			SPIFFEID:          "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
+			PodSelector:       map[string]any{"matchLabels": map[string]any{"app": "pool-a"}},
+			WorkloadSelectors: []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
 		},
-		Observed: BindingInspectionObservedState{
-			ManagedClusterSPIFFEIDs: []BindingInspectionManagedClusterSPIFFEID{{
-				Name:              "tenant-a-binding-a-1234abcd",
-				SPIFFEID:          "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
-				PodSelector:       map[string]any{"matchLabels": map[string]any{"app": "pool-a"}},
-				WorkloadSelectors: []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
-				Hint:              "tenant-a/binding-a",
-				Fallback:          &fallbackFalse,
-			}},
-			Drift: []BindingInspectionDriftEntry{{
-				Field:    "spec.workloadSelectorTemplates",
-				Desired:  "k8s:container-name:model-server",
-				Observed: "k8s:container-name:old-server",
-			}},
-			EligibleWorkloads: []BindingInspectionEligibleWorkload{{
-				Namespace: "tenant-a",
-				Pod:       "pool-a-12345",
-				Container: "model-server",
-			}},
+		RenderedClusterSPIFFEID: BindingInspectionRenderedClusterSPIFFEID{
+			Name:              "tenant-a-binding-a-1234abcd",
+			SPIFFEID:          "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
+			PodSelector:       map[string]any{"matchLabels": map[string]any{"app": "pool-a"}},
+			WorkloadSelectors: []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
+			Hint:              "tenant-a/binding-a",
+			Fallback:          &fallbackFalse,
 		},
-		Findings: []BindingInspectionFinding{{
-			ID:       findingObservedDrift,
-			Severity: BindingInspectionFindingSeverityWarning,
-			Reason:   reasonObservedDrift,
-			Message:  "observed managed ClusterSPIFFEID state differs from desired state",
+		MatchedPods: []BindingInspectionMatchedPod{{
+			Namespace: "tenant-a",
+			Pod:       "pool-a-12345",
+			Container: "model-server",
 		}},
-		Capabilities: BindingInspectionCapabilities{
-			Binding:          BindingInspectionCapabilityFull,
-			GAIEResources:    BindingInspectionCapabilityFull,
-			ClusterSPIFFEIDs: BindingInspectionCapabilityFull,
-			PeerBindings:     BindingInspectionCapabilityPartial,
-			Pods:             BindingInspectionCapabilitySkipped,
-		},
+		Findings: []BindingInspectionFinding{{
+			ID:       findingRBACLimited,
+			Severity: BindingInspectionFindingSeverityWarning,
+			Reason:   reasonRBACLimited,
+			Message:  "pods are not readable",
+		}},
 	}
 
 	var out bytes.Buffer
@@ -367,35 +346,22 @@ func TestWriteBindingInspectionReportTextRepresentativeReport(t *testing.T) {
 	}
 	text := out.String()
 	for _, want := range []string{
-		"BindingInspectionReport",
-		"GeneratedAt: 2026-05-18T09:10:11Z",
-		"Summary:",
-		"Status: Warning",
-		"Findings: 1",
-		"Drift: 1",
-		"Eligible workloads: 1",
-		"Inspection completeness: partial",
-		"Partial checks:\n    - Peer bindings",
-		"Name: tenant-a/binding-a",
-		"PoolRef: inference.networking.k8s.io/v1/InferencePool tenant-a/pool-a",
+		"Binding: tenant-a/binding-a",
+		"Mode: PerObjective",
+		"Source: InferencePool tenant-a/pool-a",
+		"Objective: InferenceObjective tenant-a/objective-a",
 		"Identity:",
-		"ClusterSPIFFEID: tenant-a-binding-a-1234abcd",
-		"Selectors:",
-		"Pod selector: {\"matchLabels\":{\"app\":\"pool-a\"}}",
-		"Observed:",
-		"Managed ClusterSPIFFEIDs: 1",
-		"Status: drift detected",
-		"Field: workloadSelectorTemplates",
-		"Desired: k8s:container-name:model-server",
-		"Observed: k8s:container-name:old-server",
-		"Eligible workloads:",
-		"- tenant-a/pool-a-12345 container=model-server",
+		"SPIFFE ID: spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
+		"namespace: tenant-a",
+		"serviceAccount: model-sa",
+		"ClusterSPIFFEID:",
+		"Name: tenant-a-binding-a-1234abcd",
+		"Matched pods:",
+		"tenant-a/pool-a-12345 container=model-server",
 		"Findings:",
-		"Severity: warning",
-		"Reason: ObservedDrift",
-		"Message: observed managed ClusterSPIFFEID state differs from desired state",
-		"Capabilities:",
-		"Peer bindings: partial",
+		"Warning Forbidden",
+		"pods are not readable",
+		"Exit code: 0",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("text output missing %q\n%s", want, text)
@@ -403,7 +369,7 @@ func TestWriteBindingInspectionReportTextRepresentativeReport(t *testing.T) {
 	}
 }
 
-func TestWriteBindingInspectionReportTextHealthyPartialSummary(t *testing.T) {
+func TestWriteBindingInspectionReportTextHealthy(t *testing.T) {
 	fallbackFalse := false
 	report := BindingInspectionReport{
 		GeneratedAt: "2026-05-18T09:10:11Z",
@@ -412,30 +378,26 @@ func TestWriteBindingInspectionReportTextHealthyPartialSummary(t *testing.T) {
 			Name:      "binding-a",
 			Mode:      "PerObjective",
 		},
-		Desired: BindingInspectionDesiredState{
-			ClusterSPIFFEIDName: "tenant-a-binding-a-1234abcd",
-			SPIFFEID:            "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
-			PodSelector:         map[string]any{"matchLabels": map[string]any{"app": "pool-a"}},
-			WorkloadSelectors:   []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
-			Hint:                "tenant-a/binding-a",
-			Fallback:            &fallbackFalse,
+		RenderedIdentity: BindingInspectionRenderedIdentity{
+			SPIFFEID:          "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
+			PodSelector:       map[string]any{"matchLabels": map[string]any{"app": "pool-a"}},
+			WorkloadSelectors: []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
 		},
-		Observed: BindingInspectionObservedState{
-			ManagedClusterSPIFFEIDs: []BindingInspectionManagedClusterSPIFFEID{{
-				Name: "tenant-a-binding-a-1234abcd",
-			}},
-			EligibleWorkloads: []BindingInspectionEligibleWorkload{{
-				Namespace: "tenant-a",
-				Pod:       "pool-a-12345",
-				Container: "model-server",
-			}},
+		RenderedClusterSPIFFEID: BindingInspectionRenderedClusterSPIFFEID{
+			Name:              "tenant-a-binding-a-1234abcd",
+			SPIFFEID:          "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
+			PodSelector:       map[string]any{"matchLabels": map[string]any{"app": "pool-a"}},
+			WorkloadSelectors: []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
+			Hint:              "tenant-a/binding-a",
+			Fallback:          &fallbackFalse,
 		},
+		MatchedPods: []BindingInspectionMatchedPod{{
+			Namespace: "tenant-a",
+			Pod:       "pool-a-12345",
+			Container: "model-server",
+		}},
 		Capabilities: BindingInspectionCapabilities{
-			Binding:          BindingInspectionCapabilityFull,
-			GAIEResources:    BindingInspectionCapabilityFull,
-			ClusterSPIFFEIDs: BindingInspectionCapabilityFull,
-			PeerBindings:     BindingInspectionCapabilityPartial,
-			Pods:             BindingInspectionCapabilityFull,
+			Pods: BindingInspectionCapabilityFull,
 		},
 	}
 
@@ -445,23 +407,20 @@ func TestWriteBindingInspectionReportTextHealthyPartialSummary(t *testing.T) {
 	}
 	text := out.String()
 	for _, want := range []string{
-		"Summary:\n  Status: OK",
+		"Binding: tenant-a/binding-a",
+		"Identity:",
+		"ClusterSPIFFEID:",
+		"Matched pods:",
+		"tenant-a/pool-a-12345 container=model-server",
 		"Findings: none",
-		"Drift: none",
-		"Eligible workloads: 1",
-		"Inspection completeness: partial",
-		"Partial checks:\n    - Peer bindings",
-		"Status: matches desired",
-		"Findings:\n  none",
+		"Exit code: 0",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("text output missing %q\n%s", want, text)
 		}
 	}
 	for _, unwanted := range []string{
-		"SPIFFE ID: (none)",
-		"Pod selector: (none)",
-		"Workload selectors:\n              none",
+		"Capabilities:",
 	} {
 		if strings.Contains(text, unwanted) {
 			t.Fatalf("text output unexpectedly contains %q\n%s", unwanted, text)
@@ -512,7 +471,7 @@ func TestWriteBindingInspectionReportTextEmptyFindings(t *testing.T) {
 	if err := WriteBindingInspectionReport(&out, outputText, NewBindingInspectionReport()); err != nil {
 		t.Fatalf("write text report: %v", err)
 	}
-	if got := out.String(); !strings.Contains(got, "Findings:\n  none\n") {
+	if got := out.String(); !strings.Contains(got, "Findings: none\n") {
 		t.Fatalf("expected empty findings text, got:\n%s", got)
 	}
 }

--- a/test/e2e/inspectbindingassert/main.go
+++ b/test/e2e/inspectbindingassert/main.go
@@ -9,11 +9,11 @@ import (
 )
 
 const (
-	referenceNamespace             = "kleym-reference-inference"
-	referenceBinding               = "binding"
-	referenceSPIFFEID              = "spiffe://kleym.sonda.red/ns/kleym-reference-inference/objective/reference-objective"
-	referenceClusterSPIFFEID       = "kleym-kleym-reference-inference-binding-objective-3b2d9110"
-	referenceEligibleContainerName = "model-server"
+	referenceNamespace            = "kleym-reference-inference"
+	referenceBinding              = "binding"
+	referenceSPIFFEID             = "spiffe://kleym.sonda.red/ns/kleym-reference-inference/objective/reference-objective"
+	referenceClusterSPIFFEID      = "kleym-kleym-reference-inference-binding-objective-3b2d9110"
+	referenceMatchedContainerName = "model-server"
 )
 
 func main() {
@@ -56,30 +56,19 @@ func assertSuccess(report inspection.BindingInspectionReport) {
 	assertEqual("bindingRef.namespace", report.BindingRef.Namespace, referenceNamespace)
 	assertEqual("bindingRef.name", report.BindingRef.Name, referenceBinding)
 	assertEqual("bindingRef.mode", report.BindingRef.Mode, "PerObjective")
-	assertEqual("desired.clusterSPIFFEIDName", report.Desired.ClusterSPIFFEIDName, referenceClusterSPIFFEID)
-	assertEqual("desired.spiffeID", report.Desired.SPIFFEID, referenceSPIFFEID)
-	assertEqual("capabilities.clusterspiffeids", string(report.Capabilities.ClusterSPIFFEIDs), "full")
-	assertEqual("capabilities.pods", string(report.Capabilities.Pods), "full")
+	assertEqual("renderedClusterSPIFFEID.name", report.RenderedClusterSPIFFEID.Name, referenceClusterSPIFFEID)
+	assertEqual("renderedIdentity.spiffeID", report.RenderedIdentity.SPIFFEID, referenceSPIFFEID)
 
 	if len(report.Findings) != 0 {
 		failf("findings = %d, want 0: %#v", len(report.Findings), report.Findings)
 	}
-	if len(report.Observed.Drift) != 0 {
-		failf("observed.drift = %d, want 0: %#v", len(report.Observed.Drift), report.Observed.Drift)
-	}
-	if len(report.Observed.ManagedClusterSPIFFEIDs) != 1 {
-		failf("managed ClusterSPIFFEIDs = %d, want 1", len(report.Observed.ManagedClusterSPIFFEIDs))
-	}
-	assertEqual("observed.managedClusterSPIFFEIDs[0].name", report.Observed.ManagedClusterSPIFFEIDs[0].Name, referenceClusterSPIFFEID)
-	assertEqual("observed.managedClusterSPIFFEIDs[0].spiffeID", report.Observed.ManagedClusterSPIFFEIDs[0].SPIFFEID, referenceSPIFFEID)
-	assertEligibleContainer(report)
+	assertMatchedContainer(report)
 }
 
 // assertNotFound verifies the CLI still emits machine-readable JSON for a missing binding.
 func assertNotFound(report inspection.BindingInspectionReport) {
 	assertCommonShape(report)
 	assertEqual("bindingRef.namespace", report.BindingRef.Namespace, referenceNamespace)
-	assertEqual("capabilities.binding", string(report.Capabilities.Binding), "full")
 
 	for _, finding := range report.Findings {
 		if finding.ID == "binding-not-found" && finding.Severity == inspection.BindingInspectionFindingSeverityError {
@@ -98,14 +87,14 @@ func assertCommonShape(report inspection.BindingInspectionReport) {
 	}
 }
 
-// assertEligibleContainer proves live pod visibility contributed to the inspection result.
-func assertEligibleContainer(report inspection.BindingInspectionReport) {
-	for _, workload := range report.Observed.EligibleWorkloads {
-		if workload.Namespace == referenceNamespace && workload.Container == referenceEligibleContainerName {
+// assertMatchedContainer proves live pod visibility contributed to the inspection result.
+func assertMatchedContainer(report inspection.BindingInspectionReport) {
+	for _, workload := range report.MatchedPods {
+		if workload.Namespace == referenceNamespace && workload.Container == referenceMatchedContainerName {
 			return
 		}
 	}
-	failf("missing eligible %q container workload: %#v", referenceEligibleContainerName, report.Observed.EligibleWorkloads)
+	failf("missing matched %q container workload: %#v", referenceMatchedContainerName, report.MatchedPods)
 }
 
 func assertEqual(field string, got string, want string) {


### PR DESCRIPTION
## Summary

- Narrows `kleym inspect binding` to rendered identity inspection instead of broad observed operator audit.
- Replaces broad `desired`/`observed` drift semantics with `renderedIdentity`, `renderedClusterSPIFFEID`, `matchedPods`, and `findings`.
- Uses binding `Conflict` condition for collision findings instead of CLI peer re-analysis.
- Updates CLI docs and tests around the narrower inspection contract.

## Boundary

`inspect binding` reports Kubernetes-visible selector matching only. It does not prove SVID issuance, workload attestation, identity consumption, policy authorization, SPIRE runtime state, or live managed object drift.

## Validation

- [x] `make test`
- [x] `make lint`
- [x] Run `kleym inspect binding <name> -n <namespace>` against a demo binding and verify text output does not imply issuance or attestation.

Closes #206