### PR TITLE
chore(docs): clarify human-friendly naming guidance

### DIFF
--- a/.agents/skills/kleym-cli-change/SKILL.md
+++ b/.agents/skills/kleym-cli-change/SKILL.md
@@ -17,6 +17,7 @@ Use this skill before modifying the `kleym` CLI. The CLI behavior is defined by 
 ## Implementation Rules
 
 - Keep Cobra command handlers thin: parse flags, call inspection logic, format output, and return exit codes.
+- Optimize CLI names and output labels for first-read human understanding. Prefer direct domain terms over internally derived terminology. JSON keys must stay stable, but new keys should be simple, explicit, and explainable without knowing reconciliation internals.
 - Do not put identity derivation, selector safety, collision detection, GVK resolution, or rendering logic inside command files.
 - Reuse the same pure render, resolve, selector, naming, and collision logic as the operator.
 - Do not import controller reconciliation, watches, finalizers, status patching, or mutation paths into CLI code.

--- a/.agents/skills/kleym-controller-change/SKILL.md
+++ b/.agents/skills/kleym-controller-change/SKILL.md
@@ -32,6 +32,7 @@ Do not spread status mutations across helper functions unless unavoidable.
 ## Guardrails
 
 - Preserve human ownership of CRD semantics, reconciliation behavior, identity derivation rules, and failure behavior.
+- Treat status, condition, reason, helper, and rendered-output names as human-facing API. Prefer short, direct names that describe the observable domain fact. Avoid compound internal-process names such as drift/render/observe blends when simple fields or conditions would be clearer.
 - Set or refresh all known conditions every reconcile pass. Use `observedGeneration`.
 - Prefer pure helper functions for render, validation, and collision detection.
 - Keep side effects in a narrow apply phase.

--- a/.agents/skills/kleym-ticket-planning/SKILL.md
+++ b/.agents/skills/kleym-ticket-planning/SKILL.md
@@ -37,6 +37,12 @@ Prefer the lowest model tier that is safe for the work. Escalate only when corre
 5. Include a recommended model assistance tier.
 6. Apply the matching `complexity/T*` label when triaging or creating through GitHub.
 
+## Issue Body Style
+
+- Do not use unchecked Markdown task lists in GitHub issue bodies.
+- Write acceptance criteria and validation expectations as plain bullets or prose. The pull request template is the place for test checklists.
+- Preserve checkboxes only when the user explicitly requests a checklist or when editing existing issue content where the checkbox state itself is meaningful project data.
+
 ## Planning Implementation
 
 1. Read the issue complexity tier first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Keep the search tight. Read the directly relevant discussion and any immediately
 ## Code Style Baseline
 
 - Prefer simple, readable Go over clever patterns. If a stdlib function exists, use it.
+- Optimize names for human understanding before agent convenience. Prefer direct, domain-obvious names for functions, status fields, condition reasons, CLI labels, JSON fields, and tests. Do not encode multi-step internal reasoning into compound names when clearer state can be represented with simple fields or explicit structure.
 - Do not introduce generics, functional patterns, custom iterator types, new abstractions, packages, helpers, frameworks, controllers, CRDs, or public API fields unless the task explicitly requires them.
 - When using controller-runtime patterns, reflection, type assertions, unstructured APIs, custom error types, or template rendering, add a short comment explaining why the pattern is needed.
 - Use named constants for magic numbers. Document the source when the value comes from an RFC, Kubernetes convention, or SPIRE behavior.


### PR DESCRIPTION
## Summary

- Add repo and skill guidance that names should optimize for human understanding.
- Add issue-body guidance to avoid unchecked task lists unless checkbox state is meaningful.

## What I Changed And Why

- Added a global `AGENTS.md` naming rule covering functions, status fields, condition reasons, CLI labels, JSON fields, and tests.
- Added controller-skill guidance treating status, condition, reason, helper, and rendered-output names as human-facing API.
- Added CLI-skill guidance for direct, first-read output labels and JSON keys.
- Added ticket-planning guidance to keep issue acceptance criteria as prose or bullets instead of unchecked task lists.

## Related Issue

- Not ticket-driven.

## Scope Check

- This PR is limited to repo-local agent and workflow instructions.
- No product behavior, API shape, CLI behavior, or tests were changed.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because operator behavior did not change.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI behavior did not change.
- Other docs: updated `AGENTS.md` and repo-local skill instructions.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `git status --short`
  - `git diff -- AGENTS.md .agents/skills/kleym-controller-change/SKILL.md .agents/skills/kleym-cli-change/SKILL.md`
  - `git show --stat --oneline --decorate HEAD`
  - `git show -- .agents/skills/kleym-ticket-planning/SKILL.md`
- Tests not run and why: not run; this is instructions-only and does not affect code, generated docs, or build tooling.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.