### PR TITLE
feat(api): add printer columns for bindings

### DIFF
--- a/api/v1alpha1/inferenceidentitybinding_types.go
+++ b/api/v1alpha1/inferenceidentitybinding_types.go
@@ -179,6 +179,12 @@ type InferenceIdentityBindingStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="MODE",type=string,JSONPath=`.spec.mode`
+// +kubebuilder:printcolumn:name="POOL",type=string,JSONPath=`.spec.poolRef.name`
+// +kubebuilder:printcolumn:name="OBJECTIVE",type=string,JSONPath=`.spec.objectiveRef.name`
+// +kubebuilder:printcolumn:name="READY",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="REASON",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
+// +kubebuilder:printcolumn:name="SPIFFE ID",type=string,JSONPath=`.status.computedSpiffeIDs[0].spiffeID`
 
 // InferenceIdentityBinding is the Schema for the inferenceidentitybindings API.
 type InferenceIdentityBinding struct {

--- a/config/crd/bases/kleym.sonda.red_inferenceidentitybindings.yaml
+++ b/config/crd/bases/kleym.sonda.red_inferenceidentitybindings.yaml
@@ -14,7 +14,26 @@ spec:
     singular: inferenceidentitybinding
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.mode
+      name: MODE
+      type: string
+    - jsonPath: .spec.poolRef.name
+      name: POOL
+      type: string
+    - jsonPath: .spec.objectiveRef.name
+      name: OBJECTIVE
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: READY
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: REASON
+      type: string
+    - jsonPath: .status.computedSpiffeIDs[0].spiffeID
+      name: SPIFFE ID
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: InferenceIdentityBinding is the Schema for the inferenceidentitybindings

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -56,6 +56,23 @@ Current validation rules enforced by the CRD:
 | `computedSpiffeIDs` | Computed SPIFFE IDs with the mode that produced them. |
 | `renderedSelectors` | Final selector set used for each rendered identity. |
 
+## Kubectl Columns
+
+`kubectl get inferenceidentitybindings.kleym.sonda.red` shows these CRD printer
+columns for compact binding overviews:
+
+| Column | Source |
+| --- | --- |
+| `MODE` | `spec.mode` |
+| `POOL` | `spec.poolRef.name` |
+| `OBJECTIVE` | `spec.objectiveRef.name` |
+| `READY` | `status.conditions[Ready].status` |
+| `REASON` | `status.conditions[Ready].reason` |
+| `SPIFFE ID` | `status.computedSpiffeIDs[0].spiffeID` |
+
+Use `-A` to list bindings across namespaces. Status-derived columns are empty
+until the operator has reconciled the binding and written status.
+
 ## Current Defaults
 
 The controller always renders deterministic SPIFFE IDs under its configured trust domain:

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -3,9 +3,9 @@ title: CLI Spec
 weight: 20
 ---
 
-`kleym` is a read-only CLI for inspecting `InferenceIdentityBinding` state. `kleym inspect binding` renders Kleym identity output, shows current binding conditions, reports Kubernetes-visible pod matches, and emits findings.
+`kleym` is a read-only CLI for inspecting one `InferenceIdentityBinding` at a time. `kleym inspect binding` renders Kleym identity output, shows current binding conditions, reports Kubernetes-visible pod matches, and emits findings.
 
-The CLI does not reconcile, mutate resources, compare live managed output, issue credentials, configure gateways, evaluate policy, or talk directly to SPIRE Server. Cluster overview and list behavior belong to future `kleym status` and `kleym list` commands.
+The CLI does not reconcile, mutate resources, compare live managed output, issue credentials, configure gateways, evaluate policy, or talk directly to SPIRE Server. Cluster overview and list behavior use Kubernetes-native CRD printer columns through `kubectl get inferenceidentitybindings.kleym.sonda.red`.
 
 ## Command Surface
 

--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -42,6 +42,7 @@ When `--clusterspiffeid-class-name` is empty, SPIRE Controller Manager must be c
 6. `containerName` is required for `PerObjective` and must be empty for `PoolOnly`.
 7. Status records `trustDomain`, `clusterSPIFFEIDClassName`, `computedSpiffeIDs`, `renderedSelectors`, and conditions. Conditions include `Ready`, `Conflict`, `InvalidRef`, `UnsafeSelector`, and `RenderFailure`.
 8. `trustDomain` and `clusterSPIFFEIDClassName` record the operator config values used for the latest status update. They are observation data for read-only inspection compatibility; they do not make trust domain or class name per-binding spec intent.
+9. The CRD exposes printer columns for `MODE`, `POOL`, `OBJECTIVE`, `READY`, `REASON`, and `SPIFFE ID` so `kubectl get inferenceidentitybindings.kleym.sonda.red -A` is the primary binding list view.
 
 Field details live in [API Reference][api-reference]. Condition details live in [Conditions Reference][conditions-reference].
 


### PR DESCRIPTION
## Summary

- Add CRD printer columns for `InferenceIdentityBinding` so `kubectl get inferenceidentitybindings.kleym.sonda.red -A` provides a compact binding overview.

## What I Changed And Why

- Added kubebuilder print column markers for mode, pool, objective, readiness, ready reason, and the first computed SPIFFE ID.
- Regenerated the `InferenceIdentityBinding` CRD manifest so the printer columns are installed with the API.
- Updated the API reference, CLI spec, and operator spec to make Kubernetes-native listing the primary binding list view after issue #200 was reduced from a dedicated CLI command.

## Related Issue

- Fixes #200

## Scope Check

- This follows the revised issue direction to avoid implementing `kleym list bindings` and instead make `kubectl get inferenceidentitybindings.kleym.sonda.red -A` useful.
- Intentionally left out CLI list command behavior, JSON list reports, matched pod counts, `CLASS`, and `TRUST DOMAIN` columns because those were out of scope or deferred in the issue discussion.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): updated to document the CRD printer-column list view.
- CLI Spec (`docs/spec/cli.md`): updated to keep one-binding inspection as the CLI boundary and point cluster overview/list behavior to Kubernetes printer columns.
- Other docs: updated `docs/reference/api.md` with the column list and status-column behavior.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `git diff --check`
  - `kustomize build config/crd`
  - `make manifests`
  - `make test`
  - `make lint`
- Tests not run and why: none beyond the commands above.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or trust-boundary enforcement.
- GitHub issue/comment context was treated as untrusted project context; no untrusted instructions were used to execute commands, expose secrets, or broaden scope.