### PR TITLE
feat(cli): add status cluster overview

### DIFF
--- a/docs/cli/exit-codes.md
+++ b/docs/cli/exit-codes.md
@@ -5,15 +5,15 @@ aliases:
   - /reference/exit-codes/
 ---
 
-Exit codes distinguish clean inspections, detected identity issues, and fatal
-CLI failures.
+Exit codes distinguish clean status or inspection runs, detected identity
+issues, and fatal CLI failures.
 
 | Code | Meaning |
 | --- | --- |
-| `0` | Inspection succeeded and no error-severity findings exist. |
-| `2` | Inspection succeeded and error-severity findings exist. |
+| `0` | Status or inspection succeeded and no error-severity findings exist. |
+| `2` | Status or inspection succeeded and error-severity findings exist. |
 | `3` | Binding lookup succeeded and the requested binding was not found. |
-| `4` | Usage, connection, discovery, or permission failure prevented inspection. |
+| `4` | Usage, connection, discovery, or permission failure prevented status or inspection evaluation. |
 | `5` | Internal CLI or serialization failure. |
 
 `--strict` treats warning-severity findings as exit code `2`.

--- a/docs/cli/findings.md
+++ b/docs/cli/findings.md
@@ -28,6 +28,9 @@ reasons where possible. See [Conditions](/reference/conditions/).
 | ID | Default severity | Notes |
 | --- | --- | --- |
 | `binding-not-found` | `error` | Requested binding is absent after a successful API lookup. |
+| `operator-unavailable` | `error` | The Kleym operator Deployment is not discoverable or has no ready replicas. |
+| `crd-missing` | `error` | A CRD required for status evaluation is not installed. |
+| `binding-unhealthy` | `error` | A visible binding reports `Ready=False`. |
 | `invalid-ref` | `error` | A referenced pool or objective is missing or invalid. |
 | `dependency-missing` | `error` when required | Required inputs or APIs are unavailable. |
 | `unsafe-selector` | `error` | Rendered selectors fail Kleym safety rules. |

--- a/docs/cli/inspection-report.md
+++ b/docs/cli/inspection-report.md
@@ -5,8 +5,10 @@ aliases:
   - /reference/inspection-report/
 ---
 
-`BindingInspectionReport` is the canonical inspection result. JSON is the stable
-machine contract. Text is the human-oriented view over the same report data.
+`BindingInspectionReport` is the canonical single-binding inspection result.
+`KleymStatusReport` is the canonical cluster overview result. JSON is the
+stable machine contract. Text is the human-oriented view over the same report
+data.
 
 Generate the canonical report with:
 
@@ -14,7 +16,29 @@ Generate the canonical report with:
 kleym inspect binding <name> -n <namespace> -o json
 ```
 
-## Top-Level Shape
+Generate the canonical status report with:
+
+```sh
+kleym status -o json
+```
+
+## Status Shape
+
+```json
+{
+  "schemaVersion": "v1alpha1",
+  "kind": "KleymStatusReport",
+  "generatedAt": "",
+  "status": "",
+  "cliVersion": "",
+  "components": {},
+  "config": {},
+  "summary": {},
+  "findings": []
+}
+```
+
+## Inspection Shape
 
 ```json
 {
@@ -31,7 +55,7 @@ kleym inspect binding <name> -n <namespace> -o json
 }
 ```
 
-## Core Fields
+## Inspection Fields
 
 | Field | Meaning |
 | --- | --- |
@@ -42,6 +66,17 @@ kleym inspect binding <name> -n <namespace> -o json
 | `renderedClusterSPIFFEID` | Deterministic managed `ClusterSPIFFEID` name and rendered spec fields. |
 | `matchedPods` | Readable pods or containers that match rendered Kubernetes-observable selectors. |
 | `findings` | Typed inspection findings. |
+
+## Status Fields
+
+| Field | Meaning |
+| --- | --- |
+| `status` | Aggregate status: `OK`, `WARNING`, or `ERROR`. |
+| `cliVersion` | Linked CLI version. |
+| `components` | Overall Kleym health, operator deployment details, Kleym API versions, SPIRE CRD versions, and Gateway API Inference Extension CRD versions. |
+| `config` | Visible trust domain and `ClusterSPIFFEID` class configuration. |
+| `summary.bindings` | Counts of bindings by `ok`, `warning`, `error`, total, and true condition counts. |
+| `findings` | Typed status findings. |
 
 Matched pods are not proof that SPIRE issued an SVID, that a workload was
 attested, or that an application consumed an identity.

--- a/docs/cli/results.md
+++ b/docs/cli/results.md
@@ -3,6 +3,10 @@ title: Results
 weight: 20
 ---
 
+Status results summarize the visible Kleym installation, operator readiness,
+identity configuration, required CRDs, binding condition counts, and typed
+findings.
+
 Inspection results show the identity and `ClusterSPIFFEID` Kleym renders for
 one binding, current binding conditions, Kubernetes-visible matched pods, and
 typed findings.
@@ -11,25 +15,32 @@ typed findings.
 
 | Format | Use it for |
 | --- | --- |
-| `text` | Default terminal output. It uses compact sections for identity, `ClusterSPIFFEID`, conditions, matched pods, findings, and exit code. |
+| `text` | Default terminal output. Status uses grouped `Kleym`, `Bindings`, and `Dependencies` sections. Inspection uses sections for identity, `ClusterSPIFFEID`, conditions, matched pods, findings, and exit code. |
 | `json` | Stable machine contract for automation. |
 
 Automation should use:
 
 ```sh
+kleym status -o json
 kleym inspect binding <name> -n <namespace> -o json
 ```
 
+Status text uses `Available`, `Warning`, `Unavailable`, and `unknown` for
+component availability. It does not claim that SVIDs were issued, workloads
+were attested, or identities were consumed.
+
 ## Findings
 
-Findings identify issues or notable states, such as invalid references,
-deterministic Kleym collisions, missing dependencies, unsupported selectors, or
-RBAC limits. See [Findings](/cli/findings/) for the current finding classes.
+Findings identify issues or notable states, such as missing CRDs, unavailable
+operator replicas, invalid references, deterministic Kleym collisions, missing
+dependencies, unsupported selectors, or RBAC limits. See
+[Findings](/cli/findings/) for the current finding classes.
 
 ## Exit Behavior
 
-Exit code `0` means inspection completed without error-severity findings. Exit
-code `2` means inspection completed and found at least one error-severity
-finding. With `--strict`, warning-severity findings also return `2`.
+Exit code `0` means status or inspection completed without error-severity
+findings. Exit code `2` means status or inspection completed and found at least
+one error-severity finding. With `--strict`, warning-severity inspection
+findings also return `2`.
 
 See [Exit Codes](/cli/exit-codes/) for the complete process contract.

--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -35,6 +35,12 @@ Print the linked version without contacting Kubernetes:
 bin/kleym --version
 ```
 
+Show a cluster overview:
+
+```sh
+bin/kleym status
+```
+
 Inspect one binding:
 
 ```sh
@@ -54,6 +60,7 @@ bin/kleym inspect binding <name> -n <namespace> \
 Use JSON for automation:
 
 ```sh
+bin/kleym status -o json
 bin/kleym inspect binding <name> -n <namespace> -o json
 ```
 
@@ -61,32 +68,34 @@ bin/kleym inspect binding <name> -n <namespace> -o json
 
 | Flag | Meaning |
 | --- | --- |
-| `-n`, `--namespace` | Binding namespace. Defaults to `default`. |
+| `-n`, `--namespace` | Binding namespace for `inspect binding`. Defaults to `default`. |
 | `-o`, `--output` | Output format: `text` or `json`. Defaults to `text`. |
-| `--strict` | Treat warning-severity findings as an inspection issue exit. |
+| `--strict` | Treat warning-severity findings as an inspection issue exit for `inspect binding`. |
 | `--context` | Kubeconfig context name. |
 | `--kubeconfig` | Kubeconfig file path. |
-| `--timeout` | Inspection timeout. Must be greater than zero. |
-| `--trust-domain` | Override trust domain used to render SPIFFE IDs. If operator config is unavailable and this flag is omitted, inspection falls back to `kleym.sonda.red`. |
-| `--clusterspiffeid-class-name` | Override expected `ClusterSPIFFEID.spec.className`. If operator config is unavailable and this flag is omitted, inspection falls back to classless output. |
+| `--timeout` | Command timeout. Must be greater than zero. |
+| `--trust-domain` | Override trust domain used by `inspect binding` to render SPIFFE IDs. If operator config is unavailable and this flag is omitted, inspection falls back to `kleym.sonda.red`. |
+| `--clusterspiffeid-class-name` | Override expected `ClusterSPIFFEID.spec.className` for `inspect binding`. If operator config is unavailable and this flag is omitted, inspection falls back to classless output. |
 
 ## Access
 
-The CLI needs Kubernetes API access to read the requested
-`InferenceIdentityBinding`. A permission, connection, authentication, or
-discovery failure before the binding can be read is fatal and may not emit a
-complete report.
+The CLI needs Kubernetes API access to read the requested resources. A
+permission, connection, authentication, or discovery failure that prevents
+status evaluation or binding inspection is fatal and may not emit a complete
+report.
 
 After the binding is readable, limited access to GAIE resources or pods is
 reported through findings when inspection can continue.
 
 Full inspection may need read access to:
 
+- Kleym operator Deployments for `kleym status`
+- `InferenceIdentityBinding` resources for `kleym status`
 - `InferenceIdentityBinding` in the binding namespace
 - supported GAIE `InferencePool` and `InferenceObjective` resources
 - pods in the binding namespace when matched pod reporting is enabled
 
 ## Boundary
 
-`kleym inspect binding` is read-only. It does not create, update, delete,
-reconcile, or patch Kubernetes resources.
+`kleym status` and `kleym inspect binding` are read-only. They do not create,
+update, delete, reconcile, or patch Kubernetes resources.

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -3,14 +3,17 @@ title: CLI Spec
 weight: 20
 ---
 
-`kleym` is a read-only CLI for inspecting one `InferenceIdentityBinding` at a time. `kleym inspect binding` renders Kleym identity output, shows current binding conditions, reports Kubernetes-visible pod matches, and emits findings.
+`kleym` is a read-only CLI for inspecting Kleym identity state. `kleym status` summarizes the visible cluster-level Kleym installation and binding health. `kleym inspect binding` renders Kleym identity output for one `InferenceIdentityBinding`, shows current binding conditions, reports Kubernetes-visible pod matches, and emits findings.
 
-The CLI does not reconcile, mutate resources, compare live managed output, issue credentials, configure gateways, evaluate policy, or talk directly to SPIRE Server. Cluster overview and list behavior use Kubernetes-native CRD printer columns through `kubectl get inferenceidentitybindings.kleym.sonda.red`.
+The CLI does not reconcile, mutate resources, compare live managed output, issue credentials, configure gateways, evaluate policy, or talk directly to SPIRE Server. Binding list behavior uses Kubernetes-native CRD printer columns through `kubectl get inferenceidentitybindings.kleym.sonda.red`.
 
 ## Command Surface
 
 - `kleym --version`: print the linked version without contacting Kubernetes. Released binaries report the release tag; unreleased local builds default to `dev`.
+- `kleym status`: summarize visible Kleym installation health, CRD availability, binding health, condition counts, and findings.
 - `kleym inspect binding <name> -n <namespace>`: inspect one `InferenceIdentityBinding`.
+
+Supported status flags: `-o, --output text|json`, `--context`, `--kubeconfig`, `--timeout`.
 
 Supported inspect flags: `-n, --namespace`, `-o, --output text|json`, `--strict`, `--context`, `--kubeconfig`, `--timeout`, `--trust-domain`, `--clusterspiffeid-class-name`.
 
@@ -18,7 +21,25 @@ Defaults: namespace `default`, output `text`, trust domain `kleym.sonda.red`, cl
 
 ## Output Contract
 
-JSON is the stable machine contract. Automation must use `kleym inspect binding <name> -n <namespace> -o json`. Text is the compact human view and may change between releases.
+JSON is the stable machine contract. Automation must use `kleym status -o json` or `kleym inspect binding <name> -n <namespace> -o json`. Text is the compact human view and may change between releases.
+
+`KleymStatusReport` contains:
+
+```json
+{
+  "schemaVersion": "v1alpha1",
+  "kind": "KleymStatusReport",
+  "generatedAt": "",
+  "status": "",
+  "cliVersion": "",
+  "components": {},
+  "config": {},
+  "summary": {},
+  "findings": []
+}
+```
+
+Field meanings: `status` is the aggregate result (`OK`, `WARNING`, or `ERROR`); `cliVersion` records the linked CLI version; `components` records overall Kleym health, operator deployment details, Kleym API versions, SPIRE CRD versions, and Gateway API Inference Extension CRD versions; `config` records visible trust domain and `ClusterSPIFFEID` class configuration; `summary` records binding counts and condition counts; `findings` records status issues.
 
 `BindingInspectionReport` contains:
 
@@ -41,6 +62,21 @@ Field meanings: `identityConfig` records render config and sources; `bindingRef`
 
 Text output must use direct labels: `Identity`, `ClusterSPIFFEID`, `Conditions`, `Matched pods`, `Findings`, and `Exit code`. It must not use `eligible`, `bound`, `issued`, or `attested` for pod or identity state.
 
+Status text output must group the report under `Kleym`, `Bindings`, and `Dependencies`. Component availability uses `Available`, `Warning`, `Unavailable`, and `unknown`.
+
+## Status Behavior
+
+1. Check whether required Kleym, SPIRE Controller Manager, and Gateway API Inference Extension CRDs are served, including visible served versions.
+2. Discover the Kleym operator Deployment by the standard `app.kubernetes.io/name=kleym` and `app.kubernetes.io/component=operator` labels and report deployment name, ready replicas, total replicas, image tag version, and whether at least one replica is ready.
+3. List visible `InferenceIdentityBinding` resources across namespaces.
+4. Record visible trust domain and `ClusterSPIFFEID` class from binding status, with operator Deployment args as fallback when bindings are not available.
+5. Count bindings as `OK` when `Ready=True`, `WARNING` when readiness is missing or unknown, and `ERROR` when `Ready=False`.
+6. Count true `Ready`, `Conflict`, `InvalidRef`, `UnsafeSelector`, and `RenderFailure` binding conditions.
+7. Report collision visibility through the `Conflict` condition count. The CLI must not recompute peer collisions.
+8. Emit findings and exit according to finding severity.
+
+Status does not compare live managed `ClusterSPIFFEID` output, prove SVID issuance, prove workload attestation, prove identity consumption, or perform request-time authorization checks.
+
 ## Inspect Binding Behavior
 
 1. Resolve the binding, `poolRef`, and required or present `objectiveRef`.
@@ -57,10 +93,10 @@ Matched pods are not proof of SVID issuance, workload attestation, identity cons
 
 | Code | Meaning |
 | --- | --- |
-| `0` | Inspection succeeded and no error-severity findings exist. |
-| `2` | Inspection succeeded and error-severity findings exist. |
+| `0` | Inspection or status evaluation succeeded and no error-severity findings exist. |
+| `2` | Inspection or status evaluation succeeded and error-severity findings exist. |
 | `3` | Binding lookup succeeded and the requested binding was not found. |
-| `4` | Usage, connection, discovery, or permission failure prevented inspection. |
+| `4` | Usage, connection, discovery, or permission failure prevented inspection or status evaluation. |
 | `5` | Internal CLI or serialization failure. |
 
 `--strict` treats warning-severity findings as exit code `2`. See [Exit Codes][exit-codes-reference].

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/sonda-red/kleym/internal/identity"
 	"github.com/sonda-red/kleym/internal/inspection"
 	"github.com/spf13/cobra"
 )
@@ -31,6 +32,10 @@ func newInspectCommand(opts *Options) *cobra.Command {
 		Use:   "inspect",
 		Short: "Inspect Kleym resources",
 	}
+	inspectCmd.PersistentFlags().StringVarP(&opts.Namespace, "namespace", "n", defaultNamespace, "Namespace for binding lookup")
+	inspectCmd.PersistentFlags().BoolVar(&opts.Strict, "strict", false, "Treat warning findings as errors")
+	inspectCmd.PersistentFlags().StringVar(&opts.TrustDomain, "trust-domain", identity.DefaultTrustDomain, "SPIRE Server trust domain used when rendering SPIFFE IDs")
+	inspectCmd.PersistentFlags().StringVar(&opts.ClusterSPIFFEIDClassName, "clusterspiffeid-class-name", "", "Optional SPIRE Controller Manager ClusterSPIFFEID className expected on managed resources")
 
 	bindingCmd := &cobra.Command{
 		Use:   "binding <name>",

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sonda-red/kleym/internal/identity"
 	"github.com/sonda-red/kleym/internal/inspection"
 	"github.com/sonda-red/kleym/internal/version"
 	"github.com/spf13/cobra"
@@ -49,15 +48,12 @@ func NewRootCommand() *cobra.Command {
 	})
 	cmd.SetVersionTemplate("{{printf \"%s\\n\" .Version}}")
 
-	cmd.PersistentFlags().StringVarP(&opts.Namespace, "namespace", "n", defaultNamespace, "Namespace for binding lookup")
 	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", outputText, "Output format: "+strings.Join(validOutputFormats, "|"))
-	cmd.PersistentFlags().BoolVar(&opts.Strict, "strict", false, "Treat warning findings as errors")
 	cmd.PersistentFlags().StringVar(&opts.Context, "context", "", "Name of the kubeconfig context to use")
 	cmd.PersistentFlags().StringVar(&opts.Kubeconfig, "kubeconfig", "", "Path to the kubeconfig file")
-	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", 30*time.Second, "Inspection timeout")
-	cmd.PersistentFlags().StringVar(&opts.TrustDomain, "trust-domain", identity.DefaultTrustDomain, "SPIRE Server trust domain used when rendering SPIFFE IDs")
-	cmd.PersistentFlags().StringVar(&opts.ClusterSPIFFEIDClassName, "clusterspiffeid-class-name", "", "Optional SPIRE Controller Manager ClusterSPIFFEID className expected on managed resources")
+	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", 30*time.Second, "Command timeout")
 
+	cmd.AddCommand(newStatusCommand(opts))
 	cmd.AddCommand(newInspectCommand(opts))
 	return cmd
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/sonda-red/kleym/internal/inspection"
+	"github.com/sonda-red/kleym/internal/version"
+	"github.com/spf13/cobra"
+)
+
+var errStatusHasErrorFindings = errors.New("status completed with error findings")
+
+var newStatusRunner = func(opts *Options) (inspection.StatusInspector, error) {
+	return inspection.NewKubernetesStatusInspector(inspection.Config{
+		Context:    opts.Context,
+		Kubeconfig: opts.Kubeconfig,
+		Timeout:    opts.Timeout,
+	})
+}
+
+// newStatusCommand creates the cluster overview command under the root CLI.
+func newStatusCommand(opts *Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show Kleym cluster status",
+		Args: func(cmd *cobra.Command, args []string) error {
+			return withExitCode(exitUsage, cobra.NoArgs(cmd, args))
+		},
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			return validateStatusOptions(opts)
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			runner, err := newStatusRunner(opts)
+			if err != nil {
+				return withExitCode(exitUsage, err)
+			}
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), opts.Timeout)
+			defer cancel()
+
+			report, statusErr := runner.Status(ctx)
+			report.CLIVersion = version.Version
+			code, err := statusExitCode(statusErr)
+			report.ExitCode = &code
+			if !shouldWriteStatusReport(statusErr) {
+				if err != nil {
+					return withExitCode(code, err)
+				}
+				return nil
+			}
+			if writeErr := inspection.WriteStatusReport(cmd.OutOrStdout(), opts.Output, report); writeErr != nil {
+				return withExitCode(exitInternal, writeErr)
+			}
+			if err != nil {
+				return withExitCode(code, err)
+			}
+			return nil
+		},
+	}
+}
+
+func validateStatusOptions(opts *Options) error {
+	if !isValidOutputFormat(opts.Output) {
+		return withExitCode(exitUsage, fmt.Errorf("invalid --output %q: must be one of %s", opts.Output, strings.Join(validOutputFormats, "|")))
+	}
+	if opts.Timeout <= 0 {
+		return withExitCode(exitUsage, fmt.Errorf("invalid --timeout %s: must be greater than 0", opts.Timeout))
+	}
+	return nil
+}
+
+func shouldWriteStatusReport(statusErr error) bool {
+	return statusErr == nil || errors.Is(statusErr, inspection.ErrStatusReportErrorFindings)
+}
+
+func statusExitCode(statusErr error) (int, error) {
+	if statusErr == nil {
+		return exitOK, nil
+	}
+	if errors.Is(statusErr, inspection.ErrStatusReportErrorFindings) {
+		return exitInspectionIssue, errStatusHasErrorFindings
+	}
+	return exitUsage, statusErr
+}

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -1,0 +1,292 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sonda-red/kleym/internal/inspection"
+)
+
+func TestStatusJSONUsesRunner(t *testing.T) {
+	originalFactory := newStatusRunner
+	t.Cleanup(func() { newStatusRunner = originalFactory })
+
+	fakeReport := inspection.NewStatusReport()
+	fakeReport.GeneratedAt = "2026-05-18T10:11:12Z"
+	fakeReport.Status = inspection.StatusResultOK
+	fakeReport.Components.Kleym.Status = inspection.StatusResultOK
+	newStatusRunner = func(_ *Options) (inspection.StatusInspector, error) {
+		return fixedStatusRunner{report: fakeReport}, nil
+	}
+
+	cmd := NewRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"status", "-o", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("status returned error: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr, got:\n%s", stderr.String())
+	}
+
+	var got inspection.StatusReport
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal status output: %v\n%s", err, stdout.String())
+	}
+	if got.Kind != inspection.StatusReportKind || got.Status != inspection.StatusResultOK {
+		t.Fatalf("status report = %#v, want OK KleymStatusReport", got)
+	}
+}
+
+func TestStatusDefaultTextUsesRunner(t *testing.T) {
+	originalFactory := newStatusRunner
+	t.Cleanup(func() { newStatusRunner = originalFactory })
+
+	fakeReport := inspection.NewStatusReport()
+	fakeReport.Status = inspection.StatusResultOK
+	fakeReport.Components.Kleym.Status = inspection.StatusResultOK
+	fakeReport.Components.Operator = inspection.OperatorStatus{
+		Status:        inspection.StatusResultOK,
+		Deployment:    "kleym-system/kleym-operator",
+		ReadyReplicas: 1,
+		Replicas:      1,
+		Version:       "v0.3.0",
+	}
+	fakeReport.Components.KleymCRDs = inspection.KleymAPIStatus{
+		Status:                   inspection.StatusResultOK,
+		InferenceIdentityBinding: "v1alpha1",
+	}
+	fakeReport.Components.SPIRECRDs = inspection.SPIRECRDStatus{
+		Status:          inspection.StatusResultOK,
+		ClusterSPIFFEID: "v1alpha1",
+	}
+	fakeReport.Components.GAIECRDs = inspection.GAIEStatus{
+		Status:             inspection.StatusResultOK,
+		InferencePool:      "v1,v1alpha2",
+		InferenceObjective: "v1alpha2",
+	}
+	fakeReport.Config.TrustDomain = "example.org"
+	fakeReport.Config.ClusterSPIFFEIDClassName = "kleym"
+	fakeReport.Config.ClusterSPIFFEIDClassNameKnown = true
+	fakeReport.Summary.Bindings.Total = 1
+	fakeReport.Summary.Bindings.Conditions.Ready = 1
+	newStatusRunner = func(_ *Options) (inspection.StatusInspector, error) {
+		return fixedStatusRunner{report: fakeReport}, nil
+	}
+
+	cmd := NewRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"status"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("status returned error: %v", err)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"Kleym",
+		"  CLI: dev",
+		"  Operator: Available",
+		"    Deployment: kleym-system/kleym-operator",
+		"    Ready: 1/1",
+		"    Version: v0.3.0",
+		"    trustDomain: example.org",
+		"    clusterSPIFFEIDClass: kleym",
+		"    InferenceIdentityBinding: v1alpha1",
+		"Bindings",
+		"  Total: 1",
+		"    Ready: 1",
+		"Dependencies",
+		"  GAIE: Available",
+		"    InferencePool: v1,v1alpha2",
+		"    InferenceObjective: v1alpha2",
+		"  SPIRE: Available",
+		"    ClusterSPIFFEID: v1alpha1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("text output missing %q\n%s", want, out)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr, got:\n%s", stderr.String())
+	}
+}
+
+func TestStatusTextShowsUnknownClassWhenConfigUnavailable(t *testing.T) {
+	originalFactory := newStatusRunner
+	t.Cleanup(func() { newStatusRunner = originalFactory })
+
+	fakeReport := inspection.NewStatusReport()
+	fakeReport.Status = inspection.StatusResultError
+	fakeReport.Components.Operator.Status = inspection.StatusResultError
+	newStatusRunner = func(_ *Options) (inspection.StatusInspector, error) {
+		return fixedStatusRunner{report: fakeReport}, nil
+	}
+
+	cmd := NewRootCommand()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"status"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("status returned error: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "    trustDomain: unknown") ||
+		!strings.Contains(out, "    clusterSPIFFEIDClass: unknown") {
+		t.Fatalf("text output did not show unknown config\n%s", out)
+	}
+}
+
+func TestStatusErrorFindingsWriteReport(t *testing.T) {
+	originalFactory := newStatusRunner
+	t.Cleanup(func() { newStatusRunner = originalFactory })
+
+	fakeReport := inspection.NewStatusReport()
+	fakeReport.Status = inspection.StatusResultError
+	fakeReport.Findings = []inspection.BindingInspectionFinding{{
+		ID:       "crd-missing",
+		Severity: inspection.BindingInspectionFindingSeverityError,
+		Reason:   "ClusterSPIFFEIDCRDMissing",
+		Message:  "ClusterSPIFFEID CRD is not installed",
+	}}
+	newStatusRunner = func(_ *Options) (inspection.StatusInspector, error) {
+		return fixedStatusRunner{report: fakeReport, err: inspection.ErrStatusReportErrorFindings}, nil
+	}
+
+	cmd := NewRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"status", "-o", "json"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected status to return an error")
+	}
+	if !errors.Is(err, errStatusHasErrorFindings) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := codeForError(err); got != exitInspectionIssue {
+		t.Fatalf("exit code = %d, want %d", got, exitInspectionIssue)
+	}
+	if stdout.Len() == 0 {
+		t.Fatal("expected status report on stdout")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr, got:\n%s", stderr.String())
+	}
+}
+
+func TestStatusRejectsInspectOnlyFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "namespace",
+			args:    []string{"status", "-n", "tenant-a"},
+			wantErr: "unknown shorthand flag: 'n'",
+		},
+		{
+			name:    "strict",
+			args:    []string{"status", "--strict"},
+			wantErr: "unknown flag: --strict",
+		},
+		{
+			name:    "trust domain",
+			args:    []string{"status", "--trust-domain", "example.org"},
+			wantErr: "unknown flag: --trust-domain",
+		},
+		{
+			name:    "clusterspiffeid class",
+			args:    []string{"status", "--clusterspiffeid-class-name", "kleym"},
+			wantErr: "unknown flag: --clusterspiffeid-class-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewRootCommand()
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected status to reject inspect-only flag")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want %q", err, tt.wantErr)
+			}
+			if got := codeForError(err); got != exitUsage {
+				t.Fatalf("exit code = %d, want %d", got, exitUsage)
+			}
+		})
+	}
+}
+
+func TestStatusExitCodeMapping(t *testing.T) {
+	setupErr := errors.New("load Kubernetes config")
+	tests := []struct {
+		name      string
+		statusErr error
+		wantCode  int
+		wantErr   error
+	}{
+		{name: "success", wantCode: exitOK},
+		{
+			name:      "error findings",
+			statusErr: inspection.ErrStatusReportErrorFindings,
+			wantCode:  exitInspectionIssue,
+			wantErr:   errStatusHasErrorFindings,
+		},
+		{
+			name:      "setup failure",
+			statusErr: setupErr,
+			wantCode:  exitUsage,
+			wantErr:   setupErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCode, gotErr := statusExitCode(tt.statusErr)
+			if gotCode != tt.wantCode {
+				t.Fatalf("exit code = %d, want %d", gotCode, tt.wantCode)
+			}
+			if tt.wantErr == nil && gotErr != nil {
+				t.Fatalf("expected no error, got %v", gotErr)
+			}
+			if tt.wantErr != nil && !errors.Is(gotErr, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", gotErr, tt.wantErr)
+			}
+		})
+	}
+}
+
+type fixedStatusRunner struct {
+	report inspection.StatusReport
+	err    error
+}
+
+func (r fixedStatusRunner) Status(_ context.Context) (inspection.StatusReport, error) {
+	return r.report, r.err
+}
+
+var _ inspection.StatusInspector = fixedStatusRunner{}

--- a/internal/inspection/status.go
+++ b/internal/inspection/status.go
@@ -1,0 +1,477 @@
+package inspection
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	kleymv1alpha1 "github.com/sonda-red/kleym/api/v1alpha1"
+	"github.com/sonda-red/kleym/internal/gaie"
+	"github.com/sonda-red/kleym/internal/spirecm"
+)
+
+const (
+	findingOperatorUnavailable  = "operator-unavailable"
+	findingCRDMissing           = "crd-missing"
+	findingBindingUnhealthy     = "binding-unhealthy"
+	reasonOperatorNotFound      = "OperatorNotFound"
+	reasonOperatorUnavailable   = "OperatorUnavailable"
+	reasonKleymCRDMissing       = "InferenceIdentityBindingCRDMissing"
+	reasonGAIECRDMissing        = "GAIECRDMissing"
+	operatorLabelName           = "kleym"
+	operatorLabelComponent      = "operator"
+	conditionTypeReady          = "Ready"
+	conditionTypeInvalidRef     = "InvalidRef"
+	conditionTypeUnsafeSelector = "UnsafeSelector"
+	conditionTypeRenderFailure  = "RenderFailure"
+)
+
+var (
+	// ErrStatusReportErrorFindings reports a completed status evaluation with error-severity findings.
+	ErrStatusReportErrorFindings = errors.New("status report contains error findings")
+)
+
+// StatusInspector builds a cluster-level status report.
+type StatusInspector interface {
+	Status(ctx context.Context) (StatusReport, error)
+}
+
+type statusInspector struct {
+	client client.Client
+	mapper meta.RESTMapper
+	now    func() time.Time
+}
+
+// NewKubernetesStatusInspector returns a read-only Kubernetes-backed status inspector.
+func NewKubernetesStatusInspector(config Config) (StatusInspector, error) {
+	configOverrides := &clientcmd.ConfigOverrides{CurrentContext: config.Context}
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if config.Kubeconfig != "" {
+		loadingRules.ExplicitPath = config.Kubeconfig
+	}
+
+	restConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("load Kubernetes config: %w", err)
+	}
+	restConfig.Timeout = config.Timeout
+
+	scheme := newBindingInspectionScheme()
+	_ = appsv1.AddToScheme(scheme)
+	httpClient, err := rest.HTTPClientFor(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("create Kubernetes HTTP client: %w", err)
+	}
+	mapper, err := apiutil.NewDynamicRESTMapper(restConfig, httpClient)
+	if err != nil {
+		return nil, fmt.Errorf("create Kubernetes REST mapper: %w", err)
+	}
+	kubeClient, err := client.New(restConfig, client.Options{Scheme: scheme, Mapper: mapper})
+	if err != nil {
+		return nil, fmt.Errorf("create Kubernetes client: %w", err)
+	}
+
+	return &statusInspector{
+		client: kubeClient,
+		mapper: mapper,
+		now:    time.Now,
+	}, nil
+}
+
+// Status aggregates Kubernetes-visible Kleym installation and binding state.
+func (i *statusInspector) Status(ctx context.Context) (StatusReport, error) {
+	report := NewStatusReport()
+	report.GeneratedAt = i.now().UTC().Format(time.RFC3339)
+
+	if err := i.inspectCRDs(&report); err != nil {
+		return report, err
+	}
+	if err := i.inspectOperator(ctx, &report); err != nil {
+		return report, err
+	}
+	if report.Components.KleymCRDs.Status == StatusResultError {
+		i.finishStatusReport(&report)
+		return report, ErrStatusReportErrorFindings
+	}
+
+	bindings := &kleymv1alpha1.InferenceIdentityBindingList{}
+	if err := i.client.List(ctx, bindings); err != nil {
+		return report, fmt.Errorf("list InferenceIdentityBindings: %w", err)
+	}
+
+	inspectBindings(bindings.Items, &report)
+	i.finishStatusReport(&report)
+	if HasErrorSeverityFinding(report.Findings) {
+		return report, ErrStatusReportErrorFindings
+	}
+	return report, nil
+}
+
+func (i *statusInspector) inspectCRDs(report *StatusReport) error {
+	kleymCRDAvailable, err := i.crdAvailable(kleymv1alpha1.GroupVersion.WithKind("InferenceIdentityBinding"))
+	if err != nil {
+		return err
+	}
+	if kleymCRDAvailable {
+		report.Components.KleymCRDs = KleymAPIStatus{
+			Status:                   StatusResultOK,
+			InferenceIdentityBinding: kleymv1alpha1.GroupVersion.Version,
+		}
+	} else {
+		report.Components.KleymCRDs = KleymAPIStatus{Status: StatusResultError, Message: "missing InferenceIdentityBinding"}
+		report.Findings = append(report.Findings, crdMissingFinding(reasonKleymCRDMissing, "InferenceIdentityBinding CRD is not installed"))
+	}
+
+	spireCRDAvailable, err := i.crdAvailable(spirecm.ClusterSPIFFEIDGVK())
+	if err != nil {
+		return err
+	}
+	if spireCRDAvailable {
+		report.Components.SPIRECRDs = SPIRECRDStatus{
+			Status:          StatusResultOK,
+			ClusterSPIFFEID: spirecm.ClusterSPIFFEIDGVK().Version,
+		}
+	} else {
+		report.Components.SPIRECRDs = SPIRECRDStatus{Status: StatusResultError, Message: "missing ClusterSPIFFEID"}
+		report.Findings = append(report.Findings, crdMissingFinding("ClusterSPIFFEIDCRDMissing", "ClusterSPIFFEID CRD is not installed"))
+	}
+
+	poolVersions, err := i.availableVersions(gaie.InferencePoolGVKs())
+	if err != nil {
+		return err
+	}
+	objectiveVersions, err := i.availableVersions(gaie.InferenceObjectiveGVKs())
+	if err != nil {
+		return err
+	}
+	if len(poolVersions) > 0 {
+		report.Components.GAIECRDs = GAIEStatus{
+			Status:             StatusResultOK,
+			InferencePool:      strings.Join(poolVersions, ","),
+			InferenceObjective: textVersions(objectiveVersions),
+		}
+		return nil
+	}
+	report.Components.GAIECRDs = GAIEStatus{
+		Status:             StatusResultError,
+		Message:            "missing InferencePool",
+		InferencePool:      "unavailable",
+		InferenceObjective: textVersions(objectiveVersions),
+	}
+	report.Findings = append(report.Findings, crdMissingFinding(reasonGAIECRDMissing, "InferencePool CRD is not installed"))
+	return nil
+}
+
+func (i *statusInspector) crdAvailable(gvk schema.GroupVersionKind) (bool, error) {
+	_, err := i.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err == nil {
+		return true, nil
+	}
+	if meta.IsNoMatchError(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("resolve REST mapping for %s: %w", gvk.String(), err)
+}
+
+func (i *statusInspector) availableVersions(gvks []schema.GroupVersionKind) ([]string, error) {
+	versions := []string{}
+	for _, gvk := range gvks {
+		available, err := i.crdAvailable(gvk)
+		if err != nil {
+			return nil, err
+		}
+		if available {
+			versions = append(versions, gvk.Version)
+		}
+	}
+	return versions, nil
+}
+
+func (i *statusInspector) inspectOperator(ctx context.Context, report *StatusReport) error {
+	deployments := &appsv1.DeploymentList{}
+	if err := i.client.List(ctx, deployments, client.MatchingLabels{
+		"app.kubernetes.io/name":      operatorLabelName,
+		"app.kubernetes.io/component": operatorLabelComponent,
+	}); err != nil {
+		return fmt.Errorf("list Kleym operator deployments: %w", err)
+	}
+
+	if len(deployments.Items) == 0 {
+		report.Components.Operator = OperatorStatus{Status: StatusResultError, Message: "not found"}
+		report.Findings = append(report.Findings, BindingInspectionFinding{
+			ID:       findingOperatorUnavailable,
+			Severity: BindingInspectionFindingSeverityError,
+			Reason:   reasonOperatorNotFound,
+			Message:  "Kleym operator Deployment was not found",
+		})
+		return nil
+	}
+
+	report.Components.Operator = operatorStatusFromDeployment(&deployments.Items[0], StatusResultError, "no ready replicas")
+	for _, deployment := range deployments.Items {
+		if deployment.Status.ReadyReplicas > 0 {
+			report.Components.Operator = operatorStatusFromDeployment(&deployment, StatusResultOK, "")
+			fillConfigFromDeployment(&deployment, report)
+			return nil
+		}
+	}
+
+	report.Findings = append(report.Findings, BindingInspectionFinding{
+		ID:       findingOperatorUnavailable,
+		Severity: BindingInspectionFindingSeverityError,
+		Reason:   reasonOperatorUnavailable,
+		Message:  "Kleym operator Deployment has no ready replicas",
+	})
+	return nil
+}
+
+func operatorStatusFromDeployment(deployment *appsv1.Deployment, status StatusResult, message string) OperatorStatus {
+	replicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		replicas = *deployment.Spec.Replicas
+	}
+	if deployment.Status.ReadyReplicas > replicas {
+		replicas = deployment.Status.ReadyReplicas
+	}
+	return OperatorStatus{
+		Status:        status,
+		Message:       message,
+		Deployment:    deployment.Namespace + "/" + deployment.Name,
+		ReadyReplicas: deployment.Status.ReadyReplicas,
+		Replicas:      replicas,
+		Version:       operatorVersion(deployment),
+	}
+}
+
+func operatorVersion(deployment *appsv1.Deployment) string {
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name != operatorLabelComponent {
+			continue
+		}
+		return imageTag(container.Image)
+	}
+	if len(deployment.Spec.Template.Spec.Containers) == 0 {
+		return ""
+	}
+	return imageTag(deployment.Spec.Template.Spec.Containers[0].Image)
+}
+
+func imageTag(image string) string {
+	if image == "" {
+		return ""
+	}
+	if digestIndex := strings.LastIndex(image, "@"); digestIndex >= 0 {
+		return image[digestIndex+1:]
+	}
+	slashIndex := strings.LastIndex(image, "/")
+	colonIndex := strings.LastIndex(image, ":")
+	if colonIndex > slashIndex {
+		return image[colonIndex+1:]
+	}
+	return ""
+}
+
+func fillConfigFromDeployment(deployment *appsv1.Deployment, report *StatusReport) {
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name != operatorLabelComponent {
+			continue
+		}
+		fillConfigFromArgs(container.Args, report)
+		return
+	}
+	if len(deployment.Spec.Template.Spec.Containers) > 0 {
+		fillConfigFromArgs(deployment.Spec.Template.Spec.Containers[0].Args, report)
+	}
+}
+
+func fillConfigFromArgs(args []string, report *StatusReport) {
+	trustDomainFound := false
+	className := ""
+	classNameFound := false
+	for _, arg := range args {
+		if value, ok := strings.CutPrefix(arg, "--trust-domain="); ok && report.Config.TrustDomain == "" {
+			report.Config.TrustDomain = value
+			trustDomainFound = true
+			continue
+		}
+		if value, ok := strings.CutPrefix(arg, "--clusterspiffeid-class-name="); ok {
+			className = value
+			classNameFound = true
+		}
+	}
+	if !report.Config.ClusterSPIFFEIDClassNameKnown && (trustDomainFound || classNameFound) {
+		report.Config.ClusterSPIFFEIDClassName = className
+		report.Config.ClusterSPIFFEIDClassNameKnown = true
+	}
+}
+
+type statusConfigObservations struct {
+	trustDomains map[string]struct{}
+	classNames   map[string]struct{}
+}
+
+func newStatusConfigObservations() statusConfigObservations {
+	return statusConfigObservations{
+		trustDomains: map[string]struct{}{},
+		classNames:   map[string]struct{}{},
+	}
+}
+
+func (o statusConfigObservations) addBinding(binding *kleymv1alpha1.InferenceIdentityBinding) {
+	if binding.Status.TrustDomain == "" {
+		return
+	}
+	o.trustDomains[binding.Status.TrustDomain] = struct{}{}
+	o.classNames[binding.Status.ClusterSPIFFEIDClassName] = struct{}{}
+}
+
+func fillConfigFromBindingObservations(observations statusConfigObservations, report *StatusReport) {
+	if report.Config.TrustDomain == "" {
+		if value, ok := observedConfigValue(observations.trustDomains); ok {
+			report.Config.TrustDomain = value
+		}
+	}
+	if !report.Config.ClusterSPIFFEIDClassNameKnown {
+		if value, ok := observedConfigValue(observations.classNames); ok {
+			report.Config.ClusterSPIFFEIDClassName = value
+			report.Config.ClusterSPIFFEIDClassNameKnown = true
+		}
+	}
+}
+
+func observedConfigValue(values map[string]struct{}) (string, bool) {
+	switch len(values) {
+	case 0:
+		return "", false
+	case 1:
+		for value := range values {
+			return value, true
+		}
+	}
+	return "mixed", true
+}
+
+func addBindingConditionCounts(
+	binding *kleymv1alpha1.InferenceIdentityBinding,
+	summary *BindingConditionSummary,
+) {
+	if conditionIsTrue(binding, conditionTypeReady) {
+		summary.Ready++
+	}
+	if conditionIsTrue(binding, conditionTypeConflict) {
+		summary.Conflict++
+	}
+	if conditionIsTrue(binding, conditionTypeInvalidRef) {
+		summary.InvalidRef++
+	}
+	if conditionIsTrue(binding, conditionTypeUnsafeSelector) {
+		summary.UnsafeSelector++
+	}
+	if conditionIsTrue(binding, conditionTypeRenderFailure) {
+		summary.RenderFailure++
+	}
+}
+
+func conditionIsTrue(binding *kleymv1alpha1.InferenceIdentityBinding, conditionType string) bool {
+	condition := meta.FindStatusCondition(binding.Status.Conditions, conditionType)
+	return condition != nil && condition.Status == metav1.ConditionTrue
+}
+
+func textVersions(versions []string) string {
+	if len(versions) == 0 {
+		return "unavailable"
+	}
+	return strings.Join(versions, ",")
+}
+
+func inspectBindings(bindings []kleymv1alpha1.InferenceIdentityBinding, report *StatusReport) {
+	configObservations := newStatusConfigObservations()
+
+	for index := range bindings {
+		binding := &bindings[index]
+		report.Summary.Bindings.Total++
+		addBindingConditionCounts(binding, &report.Summary.Bindings.Conditions)
+		configObservations.addBinding(binding)
+		switch bindingResult(binding) {
+		case StatusResultOK:
+			report.Summary.Bindings.OK++
+		case StatusResultWarning:
+			report.Summary.Bindings.Warning++
+		default:
+			report.Summary.Bindings.Error++
+			report.Findings = append(report.Findings, bindingUnhealthyFinding(binding))
+		}
+
+	}
+
+	fillConfigFromBindingObservations(configObservations, report)
+}
+
+func bindingResult(binding *kleymv1alpha1.InferenceIdentityBinding) StatusResult {
+	ready := meta.FindStatusCondition(binding.Status.Conditions, conditionTypeReady)
+	if ready == nil || ready.Status == metav1.ConditionUnknown {
+		return StatusResultWarning
+	}
+	if ready.Status == metav1.ConditionTrue {
+		return StatusResultOK
+	}
+	return StatusResultError
+}
+
+func (i *statusInspector) finishStatusReport(report *StatusReport) {
+	if HasErrorSeverityFinding(report.Findings) {
+		report.Status = StatusResultError
+		report.Components.Kleym = ComponentStatus{Status: StatusResultError}
+		return
+	}
+	if HasWarningSeverityFinding(report.Findings) || report.Summary.Bindings.Warning > 0 {
+		report.Status = StatusResultWarning
+		report.Components.Kleym = ComponentStatus{Status: StatusResultWarning}
+		return
+	}
+	report.Status = StatusResultOK
+	report.Components.Kleym = ComponentStatus{Status: StatusResultOK}
+}
+
+func crdMissingFinding(reason string, message string) BindingInspectionFinding {
+	return BindingInspectionFinding{
+		ID:       findingCRDMissing,
+		Severity: BindingInspectionFindingSeverityError,
+		Reason:   reason,
+		Message:  message,
+	}
+}
+
+func bindingUnhealthyFinding(binding *kleymv1alpha1.InferenceIdentityBinding) BindingInspectionFinding {
+	condition := meta.FindStatusCondition(binding.Status.Conditions, conditionTypeReady)
+	reason := "BindingNotReady"
+	message := "binding is not ready"
+	if condition != nil {
+		reason = condition.Reason
+		message = condition.Message
+	}
+	return BindingInspectionFinding{
+		ID:       findingBindingUnhealthy,
+		Severity: BindingInspectionFindingSeverityError,
+		Reason:   reason,
+		Message:  message,
+		AffectedRefs: []BindingInspectionTargetRef{{
+			Namespace: binding.Namespace,
+			Name:      binding.Name,
+			Group:     kleymv1alpha1.GroupVersion.Group,
+			Version:   kleymv1alpha1.GroupVersion.Version,
+			Kind:      "InferenceIdentityBinding",
+		}},
+	}
+}

--- a/internal/inspection/status_report.go
+++ b/internal/inspection/status_report.go
@@ -1,0 +1,236 @@
+package inspection
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	// StatusReportSchemaVersion is the stable machine-readable status report version from docs/spec/cli.md.
+	StatusReportSchemaVersion = "v1alpha1"
+	// StatusReportKind is the stable report kind from docs/spec/cli.md.
+	StatusReportKind = "KleymStatusReport"
+)
+
+const (
+	StatusResultOK      StatusResult = "OK"
+	StatusResultWarning StatusResult = "WARNING"
+	StatusResultError   StatusResult = "ERROR"
+	StatusResultUnknown StatusResult = "unknown"
+)
+
+// StatusResult is the stable result enum used by `kleym status`.
+type StatusResult string
+
+// StatusReport captures the JSON contract for `kleym status -o json`.
+type StatusReport struct {
+	SchemaVersion string                     `json:"schemaVersion"`
+	Kind          string                     `json:"kind"`
+	GeneratedAt   string                     `json:"generatedAt"`
+	Status        StatusResult               `json:"status"`
+	CLIVersion    string                     `json:"cliVersion,omitempty"`
+	Components    StatusComponents           `json:"components"`
+	Config        StatusConfig               `json:"config,omitempty"`
+	Summary       StatusSummary              `json:"summary"`
+	Findings      []BindingInspectionFinding `json:"findings"`
+
+	ExitCode *int `json:"-"`
+}
+
+// StatusComponents records aggregate status for discoverable installation pieces.
+type StatusComponents struct {
+	Kleym     ComponentStatus `json:"kleym"`
+	Operator  OperatorStatus  `json:"operator"`
+	KleymCRDs KleymAPIStatus  `json:"kleymCRDs"`
+	SPIRECRDs SPIRECRDStatus  `json:"spireCRDs"`
+	GAIECRDs  GAIEStatus      `json:"gaieCRDs"`
+}
+
+// ComponentStatus describes one cluster-visible status component.
+type ComponentStatus struct {
+	Status  StatusResult `json:"status"`
+	Message string       `json:"message,omitempty"`
+}
+
+// OperatorStatus describes the Kleym operator Deployment when it is visible.
+type OperatorStatus struct {
+	Status        StatusResult `json:"status"`
+	Message       string       `json:"message,omitempty"`
+	Deployment    string       `json:"deployment,omitempty"`
+	ReadyReplicas int32        `json:"readyReplicas,omitempty"`
+	Replicas      int32        `json:"replicas,omitempty"`
+	Version       string       `json:"version,omitempty"`
+}
+
+// KleymAPIStatus records the Kleym API CRD versions used by status output.
+type KleymAPIStatus struct {
+	Status                   StatusResult `json:"status"`
+	Message                  string       `json:"message,omitempty"`
+	InferenceIdentityBinding string       `json:"inferenceIdentityBinding,omitempty"`
+}
+
+// SPIRECRDStatus records SPIRE CRD availability.
+type SPIRECRDStatus struct {
+	Status          StatusResult `json:"status"`
+	Message         string       `json:"message,omitempty"`
+	ClusterSPIFFEID string       `json:"clusterSPIFFEID,omitempty"`
+}
+
+// GAIEStatus records Gateway API Inference Extension CRD availability.
+type GAIEStatus struct {
+	Status             StatusResult `json:"status"`
+	Message            string       `json:"message,omitempty"`
+	InferencePool      string       `json:"inferencePool,omitempty"`
+	InferenceObjective string       `json:"inferenceObjective,omitempty"`
+}
+
+// StatusConfig records visible operator identity configuration.
+type StatusConfig struct {
+	TrustDomain                   string `json:"trustDomain,omitempty"`
+	ClusterSPIFFEIDClassName      string `json:"clusterSPIFFEIDClassName,omitempty"`
+	ClusterSPIFFEIDClassNameKnown bool   `json:"clusterSPIFFEIDClassNameKnown,omitempty"`
+}
+
+// StatusSummary records aggregate binding counts.
+type StatusSummary struct {
+	Bindings BindingStatusSummary `json:"bindings"`
+}
+
+// BindingStatusSummary counts bindings by visible health state.
+type BindingStatusSummary struct {
+	OK         int                     `json:"ok"`
+	Warning    int                     `json:"warning"`
+	Error      int                     `json:"error"`
+	Total      int                     `json:"total"`
+	Conditions BindingConditionSummary `json:"conditions"`
+}
+
+// BindingConditionSummary counts true binding conditions by type.
+type BindingConditionSummary struct {
+	Ready          int `json:"ready"`
+	Conflict       int `json:"conflict"`
+	InvalidRef     int `json:"invalidRef"`
+	UnsafeSelector int `json:"unsafeSelector"`
+	RenderFailure  int `json:"renderFailure"`
+}
+
+// NewStatusReport returns the stable report scaffold from docs/spec/cli.md.
+func NewStatusReport() StatusReport {
+	return normalizeStatusReport(StatusReport{})
+}
+
+func normalizeStatusReport(report StatusReport) StatusReport {
+	if report.SchemaVersion == "" {
+		report.SchemaVersion = StatusReportSchemaVersion
+	}
+	if report.Kind == "" {
+		report.Kind = StatusReportKind
+	}
+	if report.Status == "" {
+		report.Status = StatusResultUnknown
+	}
+	if report.Findings == nil {
+		report.Findings = []BindingInspectionFinding{}
+	}
+	for i := range report.Findings {
+		if report.Findings[i].AffectedRefs == nil {
+			report.Findings[i].AffectedRefs = []BindingInspectionTargetRef{}
+		}
+	}
+	return report
+}
+
+// WriteStatusReport selects the cluster status output format.
+func WriteStatusReport(w io.Writer, output string, report StatusReport) error {
+	switch output {
+	case outputText:
+		return writeStatusReportText(w, report)
+	case outputJSON:
+		return writeStatusReportJSON(w, report)
+	default:
+		return fmt.Errorf("invalid status output %q", output)
+	}
+}
+
+func writeStatusReportJSON(w io.Writer, report StatusReport) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(normalizeStatusReport(report))
+}
+
+func writeStatusReportText(w io.Writer, report StatusReport) error {
+	report = normalizeStatusReport(report)
+
+	var builder strings.Builder
+	appendTextLine(&builder, "Kleym")
+	appendTextLine(&builder, "  CLI: %s", textString(report.CLIVersion))
+	appendTextLine(&builder, "  Operator: %s", availabilityStatus(report.Components.Operator.Status))
+	appendTextLine(&builder, "    Deployment: %s", textString(report.Components.Operator.Deployment))
+	appendTextLine(&builder, "    Ready: %d/%d", report.Components.Operator.ReadyReplicas, report.Components.Operator.Replicas)
+	appendTextLine(&builder, "    Version: %s", textString(report.Components.Operator.Version))
+	appendTextLine(&builder, "  Config:")
+	appendTextLine(&builder, "    trustDomain: %s", textConfigValue(report.Config.TrustDomain))
+	appendTextLine(&builder, "    clusterSPIFFEIDClass: %s", textClassName(report.Config.ClusterSPIFFEIDClassName, report.Config.ClusterSPIFFEIDClassNameKnown))
+	appendTextLine(&builder, "  API:")
+	appendTextLine(&builder, "    InferenceIdentityBinding: %s", textString(report.Components.KleymCRDs.InferenceIdentityBinding))
+
+	appendTextLine(&builder, "")
+	appendTextLine(&builder, "Bindings")
+	appendTextLine(&builder, "  Total: %d", report.Summary.Bindings.Total)
+	appendTextLine(&builder, "  Conditions:")
+	appendTextLine(&builder, "    Ready: %d", report.Summary.Bindings.Conditions.Ready)
+	appendTextLine(&builder, "    Conflict: %d", report.Summary.Bindings.Conditions.Conflict)
+	appendTextLine(&builder, "    InvalidRef: %d", report.Summary.Bindings.Conditions.InvalidRef)
+	appendTextLine(&builder, "    UnsafeSelector: %d", report.Summary.Bindings.Conditions.UnsafeSelector)
+	appendTextLine(&builder, "    RenderFailure: %d", report.Summary.Bindings.Conditions.RenderFailure)
+
+	appendTextLine(&builder, "")
+	appendTextLine(&builder, "Dependencies")
+	appendTextLine(&builder, "  GAIE: %s", availabilityStatus(report.Components.GAIECRDs.Status))
+	appendTextLine(&builder, "    InferencePool: %s", textString(report.Components.GAIECRDs.InferencePool))
+	appendTextLine(&builder, "    InferenceObjective: %s", textString(report.Components.GAIECRDs.InferenceObjective))
+	appendTextLine(&builder, "  SPIRE: %s", availabilityStatus(report.Components.SPIRECRDs.Status))
+	appendTextLine(&builder, "    ClusterSPIFFEID: %s", textString(report.Components.SPIRECRDs.ClusterSPIFFEID))
+
+	if len(report.Findings) > 0 {
+		appendTextLine(&builder, "")
+		appendTextFindings(&builder, report.Findings)
+	}
+
+	_, err := io.WriteString(w, builder.String())
+	return err
+}
+
+func availabilityStatus(status StatusResult) string {
+	switch status {
+	case "":
+		return "unknown"
+	case StatusResultOK:
+		return "Available"
+	case StatusResultWarning:
+		return "Warning"
+	case StatusResultError:
+		return "Unavailable"
+	default:
+		return string(status)
+	}
+}
+
+func textConfigValue(value string) string {
+	if value == "" {
+		return "unknown"
+	}
+	return value
+}
+
+func textClassName(className string, known bool) string {
+	if !known {
+		return "unknown"
+	}
+	if className == "" {
+		return "classless"
+	}
+	return className
+}

--- a/internal/inspection/status_test.go
+++ b/internal/inspection/status_test.go
@@ -1,0 +1,254 @@
+package inspection
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kleymv1alpha1 "github.com/sonda-red/kleym/api/v1alpha1"
+	"github.com/sonda-red/kleym/internal/gaie"
+	"github.com/sonda-red/kleym/internal/spirecm"
+)
+
+func TestStatusHealthyInstallation(t *testing.T) {
+	binding := testStatusBinding("binding-a", metav1.ConditionTrue, metav1.ConditionFalse)
+	inspector := newTestStatusInspector(t, newReadyOperatorDeployment(), binding)
+
+	report, err := inspector.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status returned error: %v", err)
+	}
+
+	if report.Status != StatusResultOK ||
+		report.Components.Operator.Status != StatusResultOK ||
+		report.Components.SPIRECRDs.Status != StatusResultOK ||
+		report.Summary.Bindings.OK != 1 ||
+		report.Summary.Bindings.Error != 0 ||
+		report.Summary.Bindings.Total != 1 ||
+		report.Summary.Bindings.Conditions.Ready != 1 {
+		t.Fatalf("unexpected healthy report: %#v", report)
+	}
+	if report.Components.Operator.Deployment != "kleym-system/kleym-operator" ||
+		report.Components.Operator.ReadyReplicas != 1 ||
+		report.Components.Operator.Replicas != 1 ||
+		report.Components.Operator.Version != "v0.3.0" {
+		t.Fatalf("operator = %#v, want deployment, ready replicas, and version", report.Components.Operator)
+	}
+	if report.Config.TrustDomain != "example.org" ||
+		report.Config.ClusterSPIFFEIDClassName != "kleym" ||
+		!report.Config.ClusterSPIFFEIDClassNameKnown {
+		t.Fatalf("config = %#v, want operator config", report.Config)
+	}
+	if report.Components.GAIECRDs.InferencePool != "v1,v1alpha2" ||
+		report.Components.GAIECRDs.InferenceObjective != "v1alpha2,v1" {
+		t.Fatalf("gaie = %#v, want served versions", report.Components.GAIECRDs)
+	}
+}
+
+func TestStatusMissingSPIRECRD(t *testing.T) {
+	binding := testStatusBinding("binding-a", metav1.ConditionFalse, metav1.ConditionUnknown)
+	binding.Status.Conditions[0].Reason = "ClusterSPIFFEIDCRDMissing"
+	binding.Status.Conditions[0].Message = "ClusterSPIFFEID CRD is not installed"
+	noSPIRE := removeStatusGVK(defaultStatusGVKs(), spirecm.ClusterSPIFFEIDGVK())
+	inspector := newTestStatusInspectorWithGVKs(t, noSPIRE, newReadyOperatorDeployment(), binding)
+
+	report, err := inspector.Status(context.Background())
+	if !errors.Is(err, ErrStatusReportErrorFindings) {
+		t.Fatalf("Status error = %v, want error findings", err)
+	}
+
+	if report.Components.SPIRECRDs.Status != StatusResultError ||
+		report.Components.SPIRECRDs.Message != "missing ClusterSPIFFEID" {
+		t.Fatalf("spire component = %#v, want missing ClusterSPIFFEID", report.Components.SPIRECRDs)
+	}
+	assertFinding(t, report.Findings, findingCRDMissing, BindingInspectionFindingSeverityError, "ClusterSPIFFEIDCRDMissing")
+	if report.Summary.Bindings.Error != 1 {
+		t.Fatalf("binding errors = %d, want 1", report.Summary.Bindings.Error)
+	}
+}
+
+func TestStatusBindingCollisionCondition(t *testing.T) {
+	binding := testStatusBinding("binding-a", metav1.ConditionFalse, metav1.ConditionTrue)
+	binding.Status.Conditions[0].Reason = "IdentityCollision"
+	binding.Status.Conditions[0].Message = "identity collision with bindings peer-a"
+	binding.Status.Conditions[1].Reason = "IdentityCollision"
+	binding.Status.Conditions[1].Message = "identity collision with bindings peer-a"
+	inspector := newTestStatusInspector(t, newReadyOperatorDeployment(), binding)
+
+	report, err := inspector.Status(context.Background())
+	if !errors.Is(err, ErrStatusReportErrorFindings) {
+		t.Fatalf("Status error = %v, want error findings", err)
+	}
+
+	if report.Summary.Bindings.Conditions.Conflict != 1 ||
+		report.Summary.Bindings.Error != 1 {
+		t.Fatalf("binding summary = %#v, want one conflict and one error", report.Summary.Bindings)
+	}
+}
+
+func TestStatusNoBindings(t *testing.T) {
+	inspector := newTestStatusInspector(t, newReadyOperatorDeployment())
+
+	report, err := inspector.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status returned error: %v", err)
+	}
+
+	if report.Status != StatusResultOK ||
+		report.Summary.Bindings.OK != 0 ||
+		report.Summary.Bindings.Total != 0 {
+		t.Fatalf("unexpected no-bindings report: %#v", report)
+	}
+	if report.Config.TrustDomain != "example.org" ||
+		report.Config.ClusterSPIFFEIDClassName != "kleym" ||
+		!report.Config.ClusterSPIFFEIDClassNameKnown {
+		t.Fatalf("config = %#v, want operator args fallback", report.Config)
+	}
+}
+
+func TestStatusBindingConfigFallbackReportsMixedValues(t *testing.T) {
+	bindingA := testStatusBinding("binding-a", metav1.ConditionTrue, metav1.ConditionFalse)
+	bindingB := testStatusBinding("binding-b", metav1.ConditionTrue, metav1.ConditionFalse)
+	bindingB.Status.TrustDomain = "other.example.org"
+	bindingB.Status.ClusterSPIFFEIDClassName = "other"
+	operator := newReadyOperatorDeployment()
+	operator.Spec.Template.Spec.Containers[0].Args = []string{}
+	inspector := newTestStatusInspector(t, operator, bindingA, bindingB)
+
+	report, err := inspector.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status returned error: %v", err)
+	}
+
+	if report.Config.TrustDomain != "mixed" ||
+		report.Config.ClusterSPIFFEIDClassName != "mixed" ||
+		!report.Config.ClusterSPIFFEIDClassNameKnown {
+		t.Fatalf("config = %#v, want mixed binding fallback", report.Config)
+	}
+}
+
+func testStatusBinding(
+	name string,
+	readyStatus metav1.ConditionStatus,
+	conflictStatus metav1.ConditionStatus,
+) *kleymv1alpha1.InferenceIdentityBinding {
+	binding := testInspectionBinding()
+	binding.Name = name
+	binding.Status.TrustDomain = "example.org"
+	binding.Status.ClusterSPIFFEIDClassName = "kleym"
+	binding.Status.Conditions = []metav1.Condition{
+		{
+			Type:               conditionTypeReady,
+			Status:             readyStatus,
+			Reason:             "Reconciled",
+			Message:            "Binding reconciled",
+			LastTransitionTime: metav1.Now(),
+		},
+		{
+			Type:               conditionTypeConflict,
+			Status:             conflictStatus,
+			Reason:             "Resolved",
+			Message:            "No identity collision detected",
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+	binding.Status.RenderedSelectors = []kleymv1alpha1.RenderedSelectorStatus{{
+		SpiffeID: "spiffe://kleym.sonda.red/ns/tenant-a/objective/objective-a",
+		Selectors: []string{
+			"k8s:ns:tenant-a",
+			"k8s:sa:model-sa",
+			"k8s:pod-label:app:model-server",
+			"k8s:container-name:model-server",
+		},
+	}}
+	return binding
+}
+
+func newReadyOperatorDeployment() *appsv1.Deployment {
+	replicas := int32(1)
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "kleym-system",
+			Name:      "kleym-operator",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      operatorLabelName,
+				"app.kubernetes.io/component": operatorLabelComponent,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  operatorLabelComponent,
+						Image: "ghcr.io/sonda-red/kleym-operator:v0.3.0",
+						Args: []string{
+							"--trust-domain=example.org",
+							"--clusterspiffeid-class-name=kleym",
+						},
+					}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: 1},
+	}
+}
+
+func newTestStatusInspector(t *testing.T, objects ...client.Object) *statusInspector {
+	return newTestStatusInspectorWithGVKs(t, defaultStatusGVKs(), objects...)
+}
+
+func newTestStatusInspectorWithGVKs(
+	t *testing.T,
+	available []schema.GroupVersionKind,
+	objects ...client.Object,
+) *statusInspector {
+	t.Helper()
+
+	scheme := newBindingInspectionScheme()
+	_ = appsv1.AddToScheme(scheme)
+	baseClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+	return &statusInspector{
+		client: baseClient,
+		mapper: newInspectionTestRESTMapper(
+			defaultStatusGVKs(),
+			available,
+		),
+		now: func() time.Time {
+			return time.Date(2026, 5, 18, 10, 11, 12, 0, time.UTC)
+		},
+	}
+}
+
+func defaultStatusGVKs() []schema.GroupVersionKind {
+	return append(
+		[]schema.GroupVersionKind{
+			kleymv1alpha1.GroupVersion.WithKind("InferenceIdentityBinding"),
+			spirecm.ClusterSPIFFEIDGVK(),
+		},
+		append(gaie.InferencePoolGVKs(), gaie.InferenceObjectiveGVKs()...)...,
+	)
+}
+
+func removeStatusGVK(gvks []schema.GroupVersionKind, removed schema.GroupVersionKind) []schema.GroupVersionKind {
+	filtered := make([]schema.GroupVersionKind, 0, len(gvks))
+	for _, gvk := range gvks {
+		if gvk != removed {
+			filtered = append(filtered, gvk)
+		}
+	}
+	return filtered
+}
+
+var _ StatusInspector = &statusInspector{}


### PR DESCRIPTION
## Summary

- Add `kleym status` as a read-only cluster overview command with text and JSON output.
- Report Kleym/operator/API/dependency status, visible identity config, and binding condition counts.
- Document the new command surface, report shape, findings, access needs, and exit behavior.

## What I Changed And Why

- Added a Kubernetes-backed status inspector and a thin Cobra command adapter.
- Kept status flags limited to `-o/--output`, `--context`, `--kubeconfig`, and `--timeout`; inspect-only flags remain under `inspect`.
- Added deterministic config reporting: operator args win when visible, binding status is only used as fallback, and mixed binding config reports `mixed` instead of depending on list order.
- Chose a grouped text output (`Kleym`, `Bindings`, `Dependencies`) instead of the ticket's flat example. During review the flat labels (`Kleym`, `Kleym Operator`, `GAIE resources`) were hard to scan and ambiguous. The grouped structure gives the same operational signal with clearer ownership: CLI/operator/config/API under `Kleym`, binding health under `Bindings`, and external CRDs under `Dependencies`.
- Removed status-level matched-pod and collision summaries from the final status surface. `Conflict` is now represented as a binding condition count, and detailed matched-pod evaluation stays in `inspect binding`. This keeps `status` lightweight and avoids extra pod reads/RBAC edge cases while preserving the collision signal requested by the ticket.

## Related Issue

- Fixes #199

## Scope Check

- This PR follows the issue's read-only status command scope and keeps namespace filtering out of scope.
- It intentionally does not compare live managed `ClusterSPIFFEID` output, recompute peer collisions, query SPIRE Server, install/repair resources, or claim SVID issuance/workload attestation/identity consumption.
- It intentionally uses grouped text output rather than the ticket's flat sample because the grouped output proved more readable and avoids stale/ambiguous component labels.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because this is read-only CLI behavior and does not change reconciliation or API semantics.
- CLI Spec (`docs/spec/cli.md`): updated for `kleym status`, supported flags, report shape, behavior, and exit-code coverage.
- Other docs: updated CLI usage, results, inspection report reference, finding IDs, and exit-code reference.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `env GOCACHE=/tmp/kgw/go-build go test ./internal/cli ./internal/inspection`
- Tests not run and why:
  - `make test` and `make lint` were not run in this session; focused package tests covered the changed CLI and inspection code.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or write paths.
- It reads Kubernetes resources only and does not mutate cluster state.
- It reports trust-domain and `ClusterSPIFFEID` class configuration from visible operator args or binding status, but does not alter trust boundaries or expose secrets.