### PR TITLE
feat(operator): add env fallbacks for identity config

### DIFF
--- a/cmd/kleym-operator/main.go
+++ b/cmd/kleym-operator/main.go
@@ -85,13 +85,22 @@ func main() {
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+	explicitConfigFields := controller.OperatorConfigExplicitFields{}
+	flag.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "trust-domain":
+			explicitConfigFields.TrustDomain = true
+		case "clusterspiffeid-class-name":
+			explicitConfigFields.ClusterSPIFFEIDClassName = true
+		}
+	})
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	operatorConfig := controller.OperatorConfig{
 		TrustDomain:              trustDomain,
 		ClusterSPIFFEIDClassName: clusterSPIFFEIDClassName,
-	}
+	}.WithEnvFallback(os.LookupEnv, explicitConfigFields)
 	if err := operatorConfig.Validate(); err != nil {
 		setupLog.Error(err, "invalid operator configuration")
 		os.Exit(1)

--- a/docs/install.md
+++ b/docs/install.md
@@ -39,6 +39,12 @@ operator identity settings when your local SPIRE install uses different values:
 make run TRUST_DOMAIN=example.org CLUSTERSPIFFEID_CLASS_NAME=kleym
 ```
 
+For direct binary or Deployment usage, `--trust-domain` can fall back to
+`KLEYM_TRUST_DOMAIN` and `--clusterspiffeid-class-name` can fall back to
+`KLEYM_CLUSTERSPIFFEID_CLASS_NAME`. Explicit flags take precedence over
+environment variables. Environment values are read once at startup and are not
+reloaded.
+
 Build the operator binary:
 
 ```sh

--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -17,12 +17,21 @@ Dependency facts live in [Dependencies][dependencies]. Supported GAIE inputs liv
 
 ## Operator Configuration
 
-`kleym-operator` requires install-level identity configuration at startup:
+`kleym-operator` requires install-level identity configuration at startup.
+Command-line flags are the canonical configuration surface. Environment
+variables are startup-only fallbacks when the matching flag is omitted; they are
+not watched or reloaded after process start.
 
-| Flag | Required | Behavior |
-| --- | --- | --- |
-| `--trust-domain=<value>` | yes | Sets the SPIRE Server trust domain used when rendering every SPIFFE ID. The value must not include `spiffe://`, must not contain `/`, and must not include leading or trailing whitespace. |
-| `--clusterspiffeid-class-name=<value>` | no | Sets `spec.className` on every managed `ClusterSPIFFEID`. When empty, Kleym omits `spec.className` and keeps classless output. |
+| Flag | Environment fallback | Required | Behavior |
+| --- | --- | --- | --- |
+| `--trust-domain=<value>` | `KLEYM_TRUST_DOMAIN` | yes | Sets the SPIRE Server trust domain used when rendering every SPIFFE ID. The value must not include `spiffe://`, must not contain `/`, and must not include leading or trailing whitespace. |
+| `--clusterspiffeid-class-name=<value>` | `KLEYM_CLUSTERSPIFFEID_CLASS_NAME` | no | Sets `spec.className` on every managed `ClusterSPIFFEID`. When empty, Kleym omits `spec.className` and keeps classless output. |
+
+Explicit flags take precedence over environment variables, including explicit
+empty values. Missing trust domain from both `--trust-domain` and
+`KLEYM_TRUST_DOMAIN` fails startup with
+`trustDomain must be configured before Kleym can render SPIFFE IDs`. Values
+loaded from environment variables use the same validation rules as flag values.
 
 `trustDomain` and `ClusterSPIFFEID` class are deployment concerns, not per-binding inference identity intent. They are not fields in `InferenceIdentityBinding.spec`.
 

--- a/internal/controller/operator_config.go
+++ b/internal/controller/operator_config.go
@@ -22,10 +22,41 @@ import (
 
 const trustDomainRequiredMessage = "trustDomain must be configured before Kleym can render SPIFFE IDs"
 
+const (
+	// EnvTrustDomain is the startup-only fallback for --trust-domain.
+	EnvTrustDomain = "KLEYM_TRUST_DOMAIN"
+	// EnvClusterSPIFFEIDClassName is the startup-only fallback for --clusterspiffeid-class-name.
+	EnvClusterSPIFFEIDClassName = "KLEYM_CLUSTERSPIFFEID_CLASS_NAME"
+)
+
 // OperatorConfig carries install-level settings that affect all reconciled identities.
 type OperatorConfig struct {
 	TrustDomain              string
 	ClusterSPIFFEIDClassName string
+}
+
+// OperatorConfigExplicitFields records startup flags that must override env fallbacks.
+type OperatorConfigExplicitFields struct {
+	TrustDomain              bool
+	ClusterSPIFFEIDClassName bool
+}
+
+// WithEnvFallback returns config with env values filled only for omitted startup flags.
+func (c OperatorConfig) WithEnvFallback(
+	lookupEnv func(string) (string, bool),
+	explicit OperatorConfigExplicitFields,
+) OperatorConfig {
+	if !explicit.TrustDomain {
+		if value, ok := lookupEnv(EnvTrustDomain); ok {
+			c.TrustDomain = value
+		}
+	}
+	if !explicit.ClusterSPIFFEIDClassName {
+		if value, ok := lookupEnv(EnvClusterSPIFFEIDClassName); ok {
+			c.ClusterSPIFFEIDClassName = value
+		}
+	}
+	return c
 }
 
 // Validate rejects ambiguous install-level identity configuration before reconciliation starts.

--- a/internal/controller/operator_config_test.go
+++ b/internal/controller/operator_config_test.go
@@ -2,6 +2,122 @@ package controller
 
 import "testing"
 
+func TestOperatorConfigWithEnvFallbackUsesEnvWhenFlagsOmitted(t *testing.T) {
+	t.Parallel()
+
+	config := (OperatorConfig{}).WithEnvFallback(
+		mapLookupEnv(map[string]string{
+			EnvTrustDomain:                 "example.org",
+			EnvClusterSPIFFEIDClassName:    "kleym",
+			"UNRELATED_OPERATOR_ENV_VALUE": "ignored",
+		}),
+		OperatorConfigExplicitFields{},
+	)
+
+	if config.TrustDomain != "example.org" {
+		t.Fatalf("TrustDomain = %q, want %q", config.TrustDomain, "example.org")
+	}
+	if config.ClusterSPIFFEIDClassName != "kleym" {
+		t.Fatalf("ClusterSPIFFEIDClassName = %q, want %q", config.ClusterSPIFFEIDClassName, "kleym")
+	}
+	if err := config.Validate(); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+}
+
+func TestOperatorConfigWithEnvFallbackKeepsExplicitFlags(t *testing.T) {
+	t.Parallel()
+
+	config := (OperatorConfig{
+		TrustDomain:              "flag.example.org",
+		ClusterSPIFFEIDClassName: "flag-class",
+	}).WithEnvFallback(
+		mapLookupEnv(map[string]string{
+			EnvTrustDomain:              "env.example.org",
+			EnvClusterSPIFFEIDClassName: "env-class",
+		}),
+		OperatorConfigExplicitFields{
+			TrustDomain:              true,
+			ClusterSPIFFEIDClassName: true,
+		},
+	)
+
+	if config.TrustDomain != "flag.example.org" {
+		t.Fatalf("TrustDomain = %q, want %q", config.TrustDomain, "flag.example.org")
+	}
+	if config.ClusterSPIFFEIDClassName != "flag-class" {
+		t.Fatalf("ClusterSPIFFEIDClassName = %q, want %q", config.ClusterSPIFFEIDClassName, "flag-class")
+	}
+}
+
+func TestOperatorConfigWithEnvFallbackKeepsExplicitEmptyClassName(t *testing.T) {
+	t.Parallel()
+
+	config := (OperatorConfig{
+		TrustDomain: "example.org",
+	}).WithEnvFallback(
+		mapLookupEnv(map[string]string{
+			EnvClusterSPIFFEIDClassName: "env-class",
+		}),
+		OperatorConfigExplicitFields{
+			ClusterSPIFFEIDClassName: true,
+		},
+	)
+
+	if config.ClusterSPIFFEIDClassName != "" {
+		t.Fatalf("ClusterSPIFFEIDClassName = %q, want empty", config.ClusterSPIFFEIDClassName)
+	}
+	if err := config.Validate(); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+}
+
+func TestOperatorConfigWithEnvFallbackKeepsExplicitEmptyTrustDomain(t *testing.T) {
+	t.Parallel()
+
+	config := (OperatorConfig{}).WithEnvFallback(
+		mapLookupEnv(map[string]string{
+			EnvTrustDomain: "env.example.org",
+		}),
+		OperatorConfigExplicitFields{
+			TrustDomain: true,
+		},
+	)
+
+	err := config.Validate()
+	if err == nil {
+		t.Fatalf("expected missing trustDomain error, got nil")
+	}
+	if err.Error() != trustDomainRequiredMessage {
+		t.Fatalf("error = %q, want %q", err.Error(), trustDomainRequiredMessage)
+	}
+}
+
+func TestOperatorConfigWithEnvFallbackValidatesEnvValues(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]map[string]string{
+		"invalid-trust-domain": {
+			EnvTrustDomain: "spiffe://example.org",
+		},
+		"invalid-class-name": {
+			EnvTrustDomain:              "example.org",
+			EnvClusterSPIFFEIDClassName: " kleym",
+		},
+	}
+
+	for name, env := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			config := (OperatorConfig{}).WithEnvFallback(mapLookupEnv(env), OperatorConfigExplicitFields{})
+			if err := config.Validate(); err == nil {
+				t.Fatalf("expected validation error, got nil")
+			}
+		})
+	}
+}
+
 func TestOperatorConfigValidateRequiresTrustDomain(t *testing.T) {
 	t.Parallel()
 
@@ -11,6 +127,13 @@ func TestOperatorConfigValidateRequiresTrustDomain(t *testing.T) {
 	}
 	if err.Error() != trustDomainRequiredMessage {
 		t.Fatalf("error = %q, want %q", err.Error(), trustDomainRequiredMessage)
+	}
+}
+
+func mapLookupEnv(values map[string]string) func(string) (string, bool) {
+	return func(name string) (string, bool) {
+		value, ok := values[name]
+		return value, ok
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add startup-only environment variable fallbacks for `kleym-operator` identity configuration.
- Document flag/env precedence and validation behavior for operator installs.
- Add focused controller config tests for fallback, precedence, missing trust domain, and invalid env values.

## What I Changed And Why

- Wired `KLEYM_TRUST_DOMAIN` and `KLEYM_CLUSTERSPIFFEID_CLASS_NAME` into operator startup config through `OperatorConfig.WithEnvFallback` so omitted flags can be filled from the process environment.
- Kept command-line flags as the canonical and highest-precedence source, including explicit empty flag values, because issue #204 keeps this as deployment-level startup configuration rather than live runtime configuration.
- Reused the existing `OperatorConfig.Validate` path so env-provided values follow the same trust domain and class-name validation rules as flag values.

## Related Issue

- Fixes #204

## Scope Check

- This PR follows the issue instructions by adding env fallback support only for operator startup identity config.
- Intentionally left out ConfigMap watches, live reload, identity migration behavior, API fields on `InferenceIdentityBinding`, and reconciliation behavior changes.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): updated with env fallback names, startup-only behavior, precedence, missing trust-domain failure, and shared validation rules.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI command behavior and inspection output are unchanged.
- Other docs: updated `docs/install.md` with direct binary/Deployment env fallback guidance.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none identified.

## Verification

- Commands run:
  - `go test ./cmd/kleym-operator ./internal/controller`
  - `make lint`
  - `make docs-build`
  - `git diff --check`
- Tests not run and why: Kind/Chainsaw e2e was not run because this change is limited to operator startup config parsing and docs, with no reconciliation behavior changes.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or repository secret handling.
- It does touch identity trust-boundary configuration by allowing deployment environments to provide the SPIFFE trust domain and ClusterSPIFFEID class at startup; flags remain highest precedence, values are fail-fast validated, and there is no live reload path or user-controlled command execution.