### PR TITLE
fix(controller): handle unparseable collision messages

### DIFF
--- a/docs/design/collision-detection.md
+++ b/docs/design/collision-detection.md
@@ -29,6 +29,14 @@ Bindings with the same fingerprint are treated as colliding.
 
 To recover peer bindings across reconciliations, the controller stores peer names in the `Conflict` condition message. This avoids introducing an API status field dedicated to a rare collision path while still allowing deterministic peer recovery. If the message cannot be parsed, the controller falls back to scanning all `PerObjective` bindings in the namespace.
 
+The parseable `Conflict=True` message format is compatibility-sensitive:
+
+```text
+identity collision with bindings <peer-name>[, <peer-name>...]: PerObjective bindings must not share the same pod selector and container name
+```
+
+The peer list excludes the current binding and is rendered in sorted order. Future wording changes must either preserve this parseable structure or intentionally update the parser, tests, and condition reference together. This is status recovery data, not a new user-authored API field.
+
 ## Current Outcome
 
 When a collision is detected:

--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -38,6 +38,18 @@ On a detected per-objective collision:
 - `Ready=False`
 - Managed `ClusterSPIFFEID` resources for the colliding bindings are deleted until the collision is resolved
 
+For `Conflict=True` with reason `IdentityCollision`, the controller writes peer
+binding names in the condition message so later reconciliations can refresh
+previously colliding peers without scanning the whole namespace. The parseable
+message format is compatibility-sensitive:
+
+```text
+identity collision with bindings <peer-name>[, <peer-name>...]: PerObjective bindings must not share the same pod selector and container name
+```
+
+If the message cannot be parsed, the controller falls back to scanning all
+`PerObjective` bindings in the namespace and continues reconciliation.
+
 ## Collision Scope
 
 `Conflict` is only used for `PerObjective` bindings. `PoolOnly` bindings do not participate in the current collision-detection path.

--- a/internal/controller/inferenceidentitybinding_collision.go
+++ b/internal/controller/inferenceidentitybinding_collision.go
@@ -339,7 +339,9 @@ func isFieldLookupUnsupported(err error) bool {
 // regeneration, and migration logic for a condition that is rare in practice.
 // The message-based approach is self-healing — if the message format is
 // unrecognizable, the caller falls back to scanning all PerObjective bindings
-// in the namespace on the next reconcile.
+// in the namespace on the next reconcile. The generated message format is
+// compatibility-sensitive; update the parser tests and condition reference
+// before changing identityCollisionMessagePrefix or identityCollisionMessageSuffix.
 func collisionPeerBindingNames(conditions []metav1.Condition) []string {
 	conflictCondition := meta.FindStatusCondition(conditions, conditionTypeConflict)
 	if conflictCondition == nil || conflictCondition.Status != metav1.ConditionTrue {

--- a/internal/controller/inferenceidentitybinding_collision_test.go
+++ b/internal/controller/inferenceidentitybinding_collision_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -177,6 +178,72 @@ func TestReconcilePerObjectiveCollisionResolutionRefreshesPeersOnSingleReconcile
 	assertConditionStatus(t, ctx, reconciler.Client, "binding-b", conditionTypeConflict, metav1.ConditionFalse, "Resolved")
 }
 
+func TestReconcilePerObjectiveCollisionResolutionFallsBackForUnparseablePeerMessage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newCollisionTestScheme(t)
+	objects := []client.Object{
+		newTestPool(),
+		newTestObjective("objective-a"),
+		newTestObjective("objective-b"),
+		newPerObjectiveBinding("binding-a", "objective-a"),
+		newPerObjectiveBinding("binding-b", "objective-b"),
+	}
+
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+			WithObjects(objects...).
+			Build(),
+		Scheme: scheme,
+	}
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: "binding-a"},
+	})
+	if err != nil {
+		t.Fatalf("initial Reconcile returned error: %v", err)
+	}
+	assertConditionStatus(t, ctx, reconciler.Client, "binding-a", conditionTypeConflict, metav1.ConditionTrue, "IdentityCollision")
+	assertConditionStatus(t, ctx, reconciler.Client, "binding-b", conditionTypeConflict, metav1.ConditionTrue, "IdentityCollision")
+
+	bindingB := &kleymv1alpha1.InferenceIdentityBinding{}
+	if err := reconciler.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "binding-b"}, bindingB); err != nil {
+		t.Fatalf("failed to get binding-b: %v", err)
+	}
+	setCondition(
+		&bindingB.Status,
+		bindingB.Generation,
+		conditionTypeConflict,
+		metav1.ConditionTrue,
+		"IdentityCollision",
+		"collision details written by an older or edited controller",
+	)
+	if err := reconciler.Status().Update(ctx, bindingB); err != nil {
+		t.Fatalf("failed to update binding-b status: %v", err)
+	}
+
+	if err := reconciler.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "binding-b"}, bindingB); err != nil {
+		t.Fatalf("failed to refetch binding-b: %v", err)
+	}
+	bindingB.Spec.ContainerName = "sidecar"
+	if err := reconciler.Update(ctx, bindingB); err != nil {
+		t.Fatalf("failed to update binding-b: %v", err)
+	}
+
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: "binding-b"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile binding-b returned error: %v", err)
+	}
+
+	assertConditionStatus(t, ctx, reconciler.Client, "binding-a", conditionTypeConflict, metav1.ConditionFalse, "Resolved")
+	assertConditionStatus(t, ctx, reconciler.Client, "binding-b", conditionTypeConflict, metav1.ConditionFalse, "Resolved")
+}
+
 func TestPoolOnlyBindingsAreNotSubjectToPerObjectiveCollisionRule(t *testing.T) {
 	t.Parallel()
 
@@ -296,6 +363,108 @@ func TestPerObjectiveBindingsWithDifferentEffectiveSelectorsDoNotCollide(t *test
 	assertConditionStatus(t, ctx, reconciler.Client, "binding-b", conditionTypeConflict, metav1.ConditionFalse, "Resolved")
 	assertConditionStatus(t, ctx, reconciler.Client, "binding-a", conditionTypeReady, metav1.ConditionTrue, "Reconciled")
 	assertClusterSPIFFEIDCount(t, ctx, reconciler.Client, 1)
+}
+
+func TestIdentityCollisionMessageCompatibilityFormat(t *testing.T) {
+	t.Parallel()
+
+	got := identityCollisionMessage("binding-a", []string{"binding-c", "binding-a", "binding-b"})
+	want := "identity collision with bindings binding-b, binding-c: PerObjective bindings must not share the same pod selector and container name"
+	if got != want {
+		t.Fatalf("identityCollisionMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestCollisionPeerBindingNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		condition *metav1.Condition
+		want      []string
+	}{
+		{
+			name: "parseable conflict message",
+			condition: &metav1.Condition{
+				Type:    conditionTypeConflict,
+				Status:  metav1.ConditionTrue,
+				Reason:  "IdentityCollision",
+				Message: identityCollisionMessage("binding-a", []string{"binding-c", "binding-a", "binding-b"}),
+			},
+			want: []string{"binding-b", "binding-c"},
+		},
+		{
+			name: "deduplicates and sorts parseable peer names",
+			condition: &metav1.Condition{
+				Type:    conditionTypeConflict,
+				Status:  metav1.ConditionTrue,
+				Reason:  "IdentityCollision",
+				Message: identityCollisionMessagePrefix + "binding-c, binding-b, binding-c" + identityCollisionMessageSuffix,
+			},
+			want: []string{"binding-b", "binding-c"},
+		},
+		{
+			name: "ignores resolved conflict",
+			condition: &metav1.Condition{
+				Type:    conditionTypeConflict,
+				Status:  metav1.ConditionFalse,
+				Reason:  "Resolved",
+				Message: identityCollisionMessage("binding-a", []string{"binding-b"}),
+			},
+		},
+		{
+			name: "ignores unparseable prefix",
+			condition: &metav1.Condition{
+				Type:    conditionTypeConflict,
+				Status:  metav1.ConditionTrue,
+				Reason:  "IdentityCollision",
+				Message: "collision with binding binding-b" + identityCollisionMessageSuffix,
+			},
+		},
+		{
+			name: "ignores unparseable suffix",
+			condition: &metav1.Condition{
+				Type:    conditionTypeConflict,
+				Status:  metav1.ConditionTrue,
+				Reason:  "IdentityCollision",
+				Message: identityCollisionMessagePrefix + "binding-b; update containerName",
+			},
+		},
+		{
+			name: "ignores empty peer list",
+			condition: &metav1.Condition{
+				Type:    conditionTypeConflict,
+				Status:  metav1.ConditionTrue,
+				Reason:  "IdentityCollision",
+				Message: identityCollisionMessagePrefix + identityCollisionMessageSuffix,
+			},
+		},
+		{
+			name: "ignores other condition type",
+			condition: &metav1.Condition{
+				Type:    conditionTypeReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Reconciled",
+				Message: identityCollisionMessage("binding-a", []string{"binding-b"}),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var conditions []metav1.Condition
+			if tt.condition != nil {
+				conditions = append(conditions, *tt.condition)
+			}
+
+			got := collisionPeerBindingNames(conditions)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("collisionPeerBindingNames() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func newCollisionTestScheme(t *testing.T) *runtime.Scheme {


### PR DESCRIPTION
## Summary

- Document the compatibility-sensitive collision peer message format.
- Add focused tests for collision peer parsing, message format stability, and unparseable-message fallback behavior.

## What I Changed And Why

- Added docs to make the `Conflict=True` peer-list message format explicit because collision recovery currently uses that message as lightweight status recovery data.
- Added parser tests around `collisionPeerBindingNames()` so future prose changes do not accidentally alter recovery behavior.
- Added a reconciliation test proving unparseable peer messages fall back to scanning `PerObjective` bindings and still clear peer conflict state.
- Added an implementation comment near the parser to point future edits at the tests and condition reference.

## Related Issue

- Fixes #221

## Scope Check

- This PR follows the issue direction by preserving the existing message-derived recovery design while documenting and testing it as compatibility-sensitive.
- Intentionally left out a structured `status.collisionPeers` field because that would expand the CRD/status API for a rare recovery path with an existing safe fallback.
- Did not change SPIFFE ID shape, selector semantics, collision fingerprint semantics, runtime evidence, attestor behavior, or collision detection architecture.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because the operator collision contract remains unchanged; the detailed recovery trade-off belongs in the design and conditions references.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI condition interpretation is unchanged.
- Other docs: updated `docs/design/collision-detection.md` and `docs/reference/conditions.md`.

## Follow-Up Work

- Proposed follow-up issue(s), if any: consider structured collision peer status in a future API cleanup if peer data becomes user-facing or fallback scans become operationally expensive.

## Verification

- Commands run:
  - `make test`
  - `make lint`
  - `make docs-build`
  - `git diff --check`
- Tests not run and why: `make test-e2e-chainsaw` was not run because this change is covered by controller unit/envtest behavior and docs; it does not change live-cluster reconciliation semantics beyond documented recovery behavior.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.
- GitHub issue text was treated as untrusted input; no untrusted instructions were executed, and the change stays scoped to collision recovery docs/tests.