### PR TITLE
docs: improve docs SEO discovery metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,23 @@ Keep the search tight. Read the directly relevant discussion and any immediately
 - For every change, explicitly assess whether docs updates are needed and state the result in your handoff (`updated: <files>` or `not needed: <reason>`).
 - If uncertainty affects scope, safety, API shape, or behavior, stop and report the gap instead of filling it with plausible code.
 
+## Docs SEO Handling
+
+When creating or substantially changing a documentation page under `docs/`, explicitly check whether the existing SEO patterns need to change.
+
+At minimum, review:
+
+- front matter `title`, `linkTitle`, `summary`, `description`, `images`, `aliases`, and `cascade`
+- whether the page title and description are specific enough for search results without sounding like vendor copy
+- whether `layouts/_partials/custom/head-end.html` still emits appropriate `TechArticle`, `SoftwareSourceCode`, breadcrumb, author, and article tag JSON-LD for the new docs page shape
+- whether `layouts/sitemap.xml` still includes the right canonical docs pages and image entries
+- whether `layouts/robots.txt` still points at the canonical XML sitemap
+- whether new or moved docs pages need aliases rather than search-visible duplicate content
+
+Do not add one-off SEO templates, generated assets, or custom routing for a single docs page by default. Prefer improving shared Hugo templates or front matter only when the new page exposes a real gap in the existing discovery patterns.
+
+Before handoff for docs work, build the docs site when practical and inspect the rendered page head plus `public/sitemap.xml` for the changed page.
+
 ## Code Style Baseline
 
 - Prefer simple, readable Go over clever patterns. If a stdlib function exists, use it.

--- a/layouts/_partials/custom/head-end.html
+++ b/layouts/_partials/custom/head-end.html
@@ -1,5 +1,6 @@
 {{- $description := partial "utils/page-description.html" . | plainify | htmlUnescape -}}
 {{- $language := site.Params.locale | default site.Language.Lang | default "en" -}}
+{{- $ogLocale := replace $language "-" "_" -}}
 {{- $personID := "https://sonda.red/#person-kalin-daskalov" -}}
 {{- $websiteID := printf "%s#website" site.BaseURL -}}
 {{- $softwareID := printf "%s#software-source-code" site.BaseURL -}}
@@ -18,6 +19,16 @@
 {{- end -}}
 
 <link rel="alternate" type="application/rss+xml" title="{{ site.Title }} docs" href="{{ "index.xml" | absURL }}" />
+<link rel="sitemap" type="application/xml" title="{{ site.Title }} sitemap" href="{{ "sitemap.xml" | absURL }}" />
+<meta name="author" content="Kalin Daskalov" />
+<meta property="og:locale" content="{{ $ogLocale }}" />
+{{- if and .IsPage (not .IsHome) }}
+<meta property="article:author" content="Kalin Daskalov" />
+<meta property="article:tag" content="Kleym" />
+<meta property="article:tag" content="Kubernetes" />
+<meta property="article:tag" content="SPIFFE" />
+<meta property="article:tag" content="workload identity" />
+{{- end }}
 
 {{- $person := dict
   "@type" "Person"
@@ -26,6 +37,7 @@
   "url" "https://sonda.red/about/"
   "image" "https://sonda.red/images/about/kalin-daskalov.jpg"
   "sameAs" (slice "https://github.com/sonda-red" "https://linkedin.com/in/daskalovk")
+  "knowsAbout" (slice "Kubernetes" "workload identity" "SPIFFE" "SPIRE" "Gateway API Inference Extension" "Kubernetes operators" "inference systems")
 -}}
 {{- $software := dict
   "@type" "SoftwareSourceCode"
@@ -39,6 +51,7 @@
   "programmingLanguage" "Go"
   "runtimePlatform" "Kubernetes"
   "applicationCategory" "DeveloperApplication"
+  "softwareRequirements" (slice "Kubernetes" "SPIRE Controller Manager" "Gateway API Inference Extension")
   "author" (dict "@id" $personID)
   "publisher" (dict "@id" $personID)
   "keywords" site.Params.keywords
@@ -77,6 +90,10 @@
 {{- $graph := slice $person $software $website -}}
 {{- if and .IsPage (not .IsHome) -}}
   {{- $articleID := printf "%s#techarticle" .Permalink -}}
+  {{- $minutes := div (add .WordCount 199) 200 -}}
+  {{- if lt $minutes 1 -}}
+    {{- $minutes = 1 -}}
+  {{- end -}}
   {{- $article := dict
     "@type" "TechArticle"
     "@id" $articleID
@@ -89,6 +106,11 @@
     "publisher" (dict "@id" $personID)
     "about" (dict "@id" $softwareID)
     "inLanguage" $language
+    "keywords" site.Params.keywords
+    "isAccessibleForFree" true
+    "proficiencyLevel" "Intermediate"
+    "wordCount" .WordCount
+    "timeRequired" (printf "PT%dM" $minutes)
   -}}
   {{- with .Parent -}}
     {{- if ne .RelPermalink "/" -}}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,0 +1,22 @@
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+{{- $pages := where site.Pages "Kind" "in" (slice "home" "section" "page") -}}
+{{- range sort $pages "Permalink" -}}
+  {{- if not .Params.noindex }}
+  <url>
+    <loc>{{ .Permalink }}</loc>
+    {{- if not .Lastmod.IsZero }}
+    <lastmod>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" }}</lastmod>
+    {{- end }}
+    {{- with .Params.images }}
+      {{- range . }}
+    <image:image>
+      <image:loc>{{ . | absURL }}</image:loc>
+    </image:image>
+      {{- end }}
+    {{- end }}
+  </url>
+  {{- end }}
+{{- end }}
+</urlset>


### PR DESCRIPTION
## Summary

- Add richer discoverability metadata for the Kleym docs site.
- Add a custom XML sitemap template for canonical docs pages and image entries.
- Document the docs SEO review checklist in `AGENTS.md` for future documentation changes.

## What I Changed And Why

- Extended `layouts/_partials/custom/head-end.html` with sitemap discovery, author and locale metadata, docs article tags, richer `TechArticle` JSON-LD, and stronger `SoftwareSourceCode` context.
- Added `layouts/sitemap.xml` so the generated sitemap focuses on canonical home, section, and docs page URLs instead of relying only on default output behavior.
- Added `AGENTS.md` guidance so future docs additions check whether front matter, JSON-LD, sitemap behavior, robots, and aliases need to change.

## Related Issue

- Not ticket-driven.

## Scope Check

- This PR stays scoped to documentation-site SEO metadata and agent workflow guidance.
- It does not change operator behavior, CLI behavior, CRDs, generated manifests, release automation, or runtime configuration.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because operator behavior and API contracts are unchanged.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI behavior and output contracts are unchanged.
- Other docs: updated `AGENTS.md` with docs SEO handling guidance.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `make docs-build`
  - `xmllint --noout /home/scribe/Code/repos/sonda-red/kleym/public/sitemap.xml`
  - `node -e '...parse rendered JSON-LD...'` for `/home/scribe/Code/repos/sonda-red/kleym/public/reference/api/index.html`
- Tests not run and why: Go unit/e2e tests were not run because this only changes Hugo metadata templates, sitemap output, and agent instructions.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or runtime trust boundaries.
- It adds public metadata and sitemap output only; no untrusted input is granted write access, secrets, or shell execution.