### PR TITLE
docs: format llms resources as links

### DIFF
--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -8,15 +8,15 @@ Kleym stops at identity registration. It does not deploy inference workloads, ro
 
 ## Canonical Sections
 
-- Documentation home: https://kleym.sonda.red/
-- Install: https://kleym.sonda.red/install/
-- Concepts: https://kleym.sonda.red/concepts/
-- Architecture: https://kleym.sonda.red/architecture/
-- Examples: https://kleym.sonda.red/examples/
-- API reference: https://kleym.sonda.red/reference/api/
-- Operator spec: https://kleym.sonda.red/spec/operator/
-- CLI spec: https://kleym.sonda.red/spec/cli/
-- Source repository: https://github.com/sonda-red/kleym
+- [Documentation home](https://kleym.sonda.red/)
+- [Install](https://kleym.sonda.red/install/)
+- [Concepts](https://kleym.sonda.red/concepts/)
+- [Architecture](https://kleym.sonda.red/architecture/)
+- [Examples](https://kleym.sonda.red/examples/)
+- [API reference](https://kleym.sonda.red/reference/api/)
+- [Operator spec](https://kleym.sonda.red/spec/operator/)
+- [CLI spec](https://kleym.sonda.red/spec/cli/)
+- [Source repository](https://github.com/sonda-red/kleym)
 
 ## Main Topics
 
@@ -31,16 +31,16 @@ Kleym stops at identity registration. It does not deploy inference workloads, ro
 
 ## Key Resources
 
-- https://kleym.sonda.red/concepts/ - GAIE inputs, identity modes, container-name boundaries, and selector safety.
-- https://kleym.sonda.red/architecture/ - End-to-end control flow from `InferenceIdentityBinding` to SPIRE registration state.
-- https://kleym.sonda.red/reference/api/ - `InferenceIdentityBinding` API fields and validation rules.
-- https://kleym.sonda.red/reference/resources/ - Managed `ClusterSPIFFEID` output shape.
-- https://kleym.sonda.red/design/selector-safety/ - Selector safety rationale and failure behavior.
-- https://kleym.sonda.red/design/collision-detection/ - Identity collision model and conflict handling.
-- https://kleym.sonda.red/cli/usage/ - Read-only CLI status and binding inspection usage.
+- [Concepts](https://kleym.sonda.red/concepts/) - GAIE inputs, identity modes, container-name boundaries, and selector safety.
+- [Architecture](https://kleym.sonda.red/architecture/) - End-to-end control flow from `InferenceIdentityBinding` to SPIRE registration state.
+- [API reference](https://kleym.sonda.red/reference/api/) - `InferenceIdentityBinding` API fields and validation rules.
+- [Managed resources](https://kleym.sonda.red/reference/resources/) - Managed `ClusterSPIFFEID` output shape.
+- [Selector safety](https://kleym.sonda.red/design/selector-safety/) - Selector safety rationale and failure behavior.
+- [Collision detection](https://kleym.sonda.red/design/collision-detection/) - Identity collision model and conflict handling.
+- [CLI usage](https://kleym.sonda.red/cli/usage/) - Read-only CLI status and binding inspection usage.
 
 ## Related Sonda Red Links
 
-- Personal lab: https://sonda.red/
-- Notes archive: https://sonda.red/notes/
-- About Kalin Daskalov: https://sonda.red/about/
+- [Personal lab](https://sonda.red/)
+- [Notes archive](https://sonda.red/notes/)
+- [About Kalin Daskalov](https://sonda.red/about/)


### PR DESCRIPTION
## Summary

- Format Kleym `llms.txt` resource URLs as explicit Markdown links.

## What I Changed And Why

- Converted bare canonical section, key resource, and related Sonda Red URLs in `docs/static/llms.txt` to `[label](url)` Markdown links.
- This keeps the file human-readable while matching the PageSpeed/Lighthouse `llms.txt` recommendation that the file contain discoverable links.

## Related Issue

- Not ticket-driven.

## Scope Check

- This PR is intentionally limited to `docs/static/llms.txt` formatting.
- It does not touch Hextra accessibility behavior, theme templates, operator behavior, CLI behavior, CRDs, generated manifests, CI, or release automation.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because operator behavior and API contracts are unchanged.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI behavior and output contracts are unchanged.
- Other docs: updated `docs/static/llms.txt` because it is the public metadata file being fixed.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `make docs-build`
  - Markdown link/H1 check against `/home/scribe/Code/repos/sonda-red/kleym/public/llms.txt`
- Tests not run and why: Go unit/e2e tests were not run because this only changes a static metadata text file.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or runtime trust boundaries.
- It changes public static documentation metadata only; no untrusted input receives write access, secrets, or shell execution.