### PR TITLE
docs(config): align projects menu target

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -42,7 +42,7 @@ menu:
       weight: 1
     - name: Projects
       identifier: projects
-      url: /projects/
+      url: "https://sonda.red/projects/"
       weight: 2
     - name: Notes
       url: "https://sonda.red/notes/"


### PR DESCRIPTION
## Summary

- Align the Kleym docs `Projects` menu configuration with the canonical Sonda Red projects page.

## What I Changed And Why

- Changed `hugo.yaml` so the `Projects` parent menu entry points to `https://sonda.red/projects/` instead of the local `/projects/` path.
- Hextra renders this parent entry as a dropdown/section label because it has the `kleym` child item, so this is configuration hygiene rather than a new rendered public link.

## Related Issue

- No related issue; requested directly in chat.

## Scope Check

- This PR keeps the change to the Projects menu target only.
- Backlink/SEO expansion, README links, `llms.txt` changes, and extra docs cross-links were intentionally left out of scope.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because operator behavior and API contracts are unchanged.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI behavior is unchanged.
- Other docs: not needed because this only adjusts Hugo navigation configuration.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `make docs-build`
  - `rg -n "sonda\\.red/projects|kleym\\.sonda\\.red/projects|Projects" public/index.html public/sitemap.xml`
- Tests not run and why: Go tests were not run because this PR only changes docs navigation configuration.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.