### PR TITLE
docs(cli): remove stale objective diff assumptions

### DIFF
--- a/docs/cli/findings.md
+++ b/docs/cli/findings.md
@@ -32,7 +32,7 @@ reasons where possible. See [Conditions](/reference/conditions/).
 | `operator-unavailable` | `error` | The Kleym operator Deployment is not discoverable or has no ready replicas. |
 | `crd-missing` | `error` | A CRD required for status evaluation is not installed. |
 | `binding-unhealthy` | `error` | A visible binding reports `Ready=False`. |
-| `invalid-ref` | `error` | A referenced pool or objective is missing or invalid. |
+| `invalid-ref` | `error` | The referenced pool is missing or invalid. |
 | `dependency-missing` | `error` when required | Required inputs or APIs are unavailable. |
 | `unsafe-selector` | `error` | Rendered selectors fail Kleym safety rules. |
 | `render-failure` | `error` | Identity output could not be rendered. |

--- a/internal/controller/inferenceidentitybinding_delete_test.go
+++ b/internal/controller/inferenceidentitybinding_delete_test.go
@@ -21,7 +21,7 @@ func TestReconcileDeleteWaitsForManagedClusterSPIFFEIDsToDisappear(t *testing.T)
 	t.Parallel()
 
 	ctx := context.Background()
-	scheme := newCollisionTestScheme(t)
+	scheme := newControllerTestScheme(t)
 
 	binding := newPoolOnlyBinding("binding-delete", "")
 	controllerutil.AddFinalizer(binding, inferenceIdentityBindingFinalizer)
@@ -111,7 +111,7 @@ func TestReconcileCorrectsClusterSPIFFEIDDriftOnResync(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	scheme := newCollisionTestScheme(t)
+	scheme := newControllerTestScheme(t)
 
 	binding := newPoolOnlyBinding("binding-drift", "")
 
@@ -154,7 +154,7 @@ func TestReconcileCorrectsClusterSPIFFEIDDriftOnResync(t *testing.T) {
 	labels["drifted"] = "true"
 	drifted.SetLabels(labels)
 	drifted.Object["spec"] = map[string]any{
-		"spiffeIDTemplate":          "spiffe://drifted.example/ns/default/obj/objective-a",
+		"spiffeIDTemplate":          "spiffe://drifted.example/ns/default/pool/pool-a",
 		"podSelector":               map[string]any{"matchLabels": map[string]any{"app": "drifted"}},
 		"workloadSelectorTemplates": []any{"k8s:ns:default", "k8s:sa:drifted"},
 	}
@@ -200,7 +200,7 @@ func newManagedClusterSPIFFEIDForBinding(
 	managed.SetName(name)
 	managed.SetLabels(spirecm.ManagedClusterSPIFFEIDLabels(binding))
 	managed.Object["spec"] = map[string]any{
-		"spiffeIDTemplate": "spiffe://example.test/ns/default/obj/example",
+		"spiffeIDTemplate": "spiffe://example.test/ns/default/pool/example",
 	}
 	return managed
 }

--- a/internal/controller/inferenceidentitybinding_logging_test.go
+++ b/internal/controller/inferenceidentitybinding_logging_test.go
@@ -24,8 +24,8 @@ func TestReconcileLogsStructuredSuccessPath(t *testing.T) {
 	logger, logs := newRecordingLogger()
 	ctx = logf.IntoContext(ctx, logger)
 
-	scheme := newCollisionTestScheme(t)
-	binding := newPoolOnlyBinding("binding-log-success", "objective-a")
+	scheme := newControllerTestScheme(t)
+	binding := newPoolOnlyBinding("binding-log-success", "pool-a")
 	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -73,7 +73,7 @@ func TestReconcileLogsFailureStatus(t *testing.T) {
 	logger, logs := newRecordingLogger()
 	ctx = logf.IntoContext(ctx, logger)
 
-	scheme := newCollisionTestScheme(t)
+	scheme := newControllerTestScheme(t)
 	binding := newPoolOnlyBinding("binding-log-failure", "")
 	binding.Spec.PoolRef.Name = "missing-pool"
 	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
@@ -112,8 +112,8 @@ func TestReconcileClusterSPIFFEIDsLogsApplyDecisions(t *testing.T) {
 	logger, logs := newRecordingLogger()
 	ctx = logf.IntoContext(ctx, logger)
 
-	scheme := newCollisionTestScheme(t)
-	binding := newPoolOnlyBinding("binding-log-apply", "objective-a")
+	scheme := newControllerTestScheme(t)
+	binding := newPoolOnlyBinding("binding-log-apply", "pool-a")
 	identity := renderedIdentity{
 		SpiffeID: "spiffe://kleym.sonda.red/ns/default/pool/pool-a",
 		Selectors: []string{

--- a/internal/controller/inferenceidentitybinding_metrics_test.go
+++ b/internal/controller/inferenceidentitybinding_metrics_test.go
@@ -97,7 +97,7 @@ func TestReconcileRecordsSuccessfulTerminalOutcomeAfterStatusPatch(t *testing.T)
 	t.Parallel()
 
 	ctx := context.Background()
-	scheme := newCollisionTestScheme(t)
+	scheme := newControllerTestScheme(t)
 
 	binding := newPoolOnlyBinding("binding-ready-metric", "")
 	k8sClient := fake.NewClientBuilder().
@@ -134,7 +134,7 @@ func TestReconcileRecordsFailureTerminalOutcomeAfterStatusPatch(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	scheme := newCollisionTestScheme(t)
+	scheme := newControllerTestScheme(t)
 
 	binding := newPoolOnlyBinding("binding-failure-metric", "")
 	binding.Spec.PoolRef.Name = "missing-pool"
@@ -171,7 +171,7 @@ func TestReconcileRecordsFailureTerminalOutcomeAfterStatusPatch(t *testing.T) {
 func TestIdentityBindingGaugeCollectorAggregatesOutcomes(t *testing.T) {
 	t.Parallel()
 
-	scheme := newCollisionTestScheme(t)
+	scheme := newControllerTestScheme(t)
 
 	readyA := newPoolOnlyBinding("binding-ready-a", "")
 	readyB := newPoolOnlyBinding("binding-ready-b", "")

--- a/internal/controller/inferenceidentitybinding_resolver_test.go
+++ b/internal/controller/inferenceidentitybinding_resolver_test.go
@@ -17,7 +17,7 @@ func TestReconcileSetsInvalidRefWhenPoolCannotBeResolved(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	scheme := newCollisionTestScheme(t)
+	scheme := newControllerTestScheme(t)
 
 	binding := newPoolOnlyBinding("binding-missing-pool", "")
 	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
@@ -44,7 +44,7 @@ func TestReconcilePoolOnlyDoesNotRequireObjective(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	scheme := newCollisionTestScheme(t)
+	scheme := newControllerTestScheme(t)
 
 	binding := newPoolOnlyBinding("binding-pool-only", "")
 	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
@@ -71,7 +71,7 @@ func TestReconcileUsesOperatorConfigForRenderedOutput(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	scheme := newCollisionTestScheme(t)
+	scheme := newControllerTestScheme(t)
 
 	binding := newPoolOnlyBinding("binding-operator-config", "")
 	reconciler := &InferenceIdentityBindingReconciler{Config: OperatorConfig{

--- a/internal/controller/inferenceidentitybinding_test_helpers_test.go
+++ b/internal/controller/inferenceidentitybinding_test_helpers_test.go
@@ -17,7 +17,7 @@ import (
 
 const testNamespace = "default"
 
-func newCollisionTestScheme(t *testing.T) *runtime.Scheme {
+func newControllerTestScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 
 	scheme := runtime.NewScheme()


### PR DESCRIPTION
## Summary

- Remove the remaining CLI finding wording that described `objective` references as current invalid-ref inputs.
- Rename stale controller test helper references from collision-era naming to neutral controller test setup.
- Replace objective-shaped fake SPIFFE IDs and ignored test arguments with pool-shaped values.
- Updated related planning issues #231/#232 and commented on closed #230 so future `kleym diff` work stays pool-only.

## What I Changed And Why

- `docs/cli/findings.md`: `invalid-ref` now describes only missing or invalid pool refs, matching the pool-only GAIE contract.
- Controller tests: removed stale objective/collision-era names from test setup and fake drift data without changing tested behavior.
- GitHub issue metadata: #231/#232 now exclude `InferenceObjective`, `objectiveRef`, `PerObjective`, and deleted objective-era proof-case dependencies.

## Related Issue

- Closes #242

## Scope Check

- Followed #242's narrowed post-#243 scope: audit CLI docs/output text, planned `kleym diff` issues, and fixtures/tests for objective-backed assumptions.
- Did not reopen operator/API removal work from #240/#243.
- Did not implement `kleym diff`; that remains deferred to #231/#232.
- Did not add new source families such as Grove, `InferencePoolImport`, HTTPRoute, or Gateway policy.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because no operator behavior changed.
- CLI Spec (`docs/spec/cli.md`): not needed because this PR only removes stale reference wording; the future diff contract is tracked in #231.
- Other docs: updated `docs/cli/findings.md` to remove stale objective wording.

## Follow-Up Work

- #231: specify the pool-only `kleym diff` MVP contract.
- #232: implement offline pool-only `kleym diff` after #231.

## Verification

- Commands run:
  - `git diff --check` — passed.
  - `make test` — passed.
  - `make docs-build` — passed.
  - `make lint` — passed with `0 issues`.
- Tests not run and why: none relevant skipped.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or runtime trust-boundary behavior.
- It only changes docs wording and test fixture names/values for the existing pool-only contract.