### PR TITLE
refactor(api)!: remove obsolete Conflict condition

### DIFF
--- a/api/v1alpha1/inferenceidentitybinding_types.go
+++ b/api/v1alpha1/inferenceidentitybinding_types.go
@@ -92,7 +92,6 @@ type InferenceIdentityBindingStatus struct {
 	//
 	// Known condition types:
 	//   - "Ready"
-	//   - "Conflict"
 	//   - "InvalidRef"
 	//   - "UnsafeSelector"
 	//   - "RenderFailure"

--- a/config/crd/bases/kleym.sonda.red_inferenceidentitybindings.yaml
+++ b/config/crd/bases/kleym.sonda.red_inferenceidentitybindings.yaml
@@ -109,7 +109,6 @@ spec:
 
                   Known condition types:
                     - "Ready"
-                    - "Conflict"
                     - "InvalidRef"
                     - "UnsafeSelector"
                     - "RenderFailure"

--- a/docs/cli/findings.md
+++ b/docs/cli/findings.md
@@ -36,7 +36,6 @@ reasons where possible. See [Conditions](/reference/conditions/).
 | `dependency-missing` | `error` when required | Required inputs or APIs are unavailable. |
 | `unsafe-selector` | `error` | Rendered selectors fail Kleym safety rules. |
 | `render-failure` | `error` | Identity output could not be rendered. |
-| `kleym-collision` | `error` | Kleym detected a deterministic identity collision. |
 | `zero-matched-pods` | `info` | Scale-to-zero can be valid. |
 | `identity-config-undiscovered` | `warning` | Binding status does not include operator config, so inspection used CLI flags, defaults, or both. |
 | `rbac-limited` | `warning` | Inspection continued with reduced visibility. |

--- a/docs/cli/results.md
+++ b/docs/cli/results.md
@@ -33,8 +33,8 @@ were attested, or identities were consumed.
 ## Findings
 
 Findings identify issues or notable states, such as missing CRDs, unavailable
-operator replicas, invalid references, deterministic Kleym collisions, missing
-dependencies, unsupported selectors, or RBAC limits. See
+operator replicas, invalid references, missing dependencies, unsupported
+selectors, or RBAC limits. See
 [Findings](/cli/findings/) for the current finding classes.
 
 ## Exit Behavior

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,8 +18,8 @@ If code and docs disagree, fix the disagreement instead of silently choosing one
 
 ## Core Stabilization Focus
 
-Prioritize API stability, selector safety, collision behavior, managed output,
-finalizer cleanup, and read-only inspection.
+Prioritize API stability, selector safety, managed output, finalizer cleanup,
+and read-only inspection.
 
 ## Check GitHub Context First
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -97,7 +97,6 @@ Expected observation:
 
 ```text
 Ready=True Reconciled
-Conflict=False Resolved
 InvalidRef=False Resolved
 UnsafeSelector=False Resolved
 RenderFailure=False Resolved

--- a/docs/examples/basic-binding.md
+++ b/docs/examples/basic-binding.md
@@ -74,7 +74,6 @@ spec:
 The binding status should report:
 
 - `Ready=True`
-- `Conflict=False`
 - `InvalidRef=False`
 - `UnsafeSelector=False`
 - `RenderFailure=False`

--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -1,7 +1,7 @@
 ---
 title: Conditions
 weight: 20
-description: "Kleym condition reference for Ready, Conflict, InvalidRef, UnsafeSelector, RenderFailure, and related status reasons."
+description: "Kleym condition reference for Ready, InvalidRef, UnsafeSelector, RenderFailure, and related status reasons."
 aliases:
   - /operator/reference/conditions/
 ---
@@ -11,7 +11,6 @@ aliases:
 | Type | Meaning when `True` | Common reasons |
 | --- | --- | --- |
 | `Ready` | The binding reconciled successfully. | `Reconciled` |
-| `Conflict` | Reserved status condition retained for compatibility. Current pool-only reconciliation does not create identity collisions. | `IdentityCollision` on historical Objective-era bindings only |
 | `InvalidRef` | `poolRef` or a required CRD could not be resolved or validated. | `TargetPoolNotFound`, `InvalidPoolRef`, `InferencePoolCRDMissing` |
 | `UnsafeSelector` | The rendered selector set is missing required safety constraints or the pool selector cannot be rendered safely. | `UnsafeSelector`, `InvalidPoolSelector` |
 | `RenderFailure` | Rendering failed after reference resolution succeeded. | `InvalidServiceAccountName`, `InvalidSPIFFEID`, `ClusterSPIFFEIDCRDMissing`, `MissingTrustDomain` |
@@ -21,7 +20,6 @@ aliases:
 On successful reconciliation:
 
 - `Ready=True` with reason `Reconciled`
-- `Conflict=False`
 - `InvalidRef=False`
 - `UnsafeSelector=False`
 - `RenderFailure=False`
@@ -32,6 +30,3 @@ On any failure state:
 - The triggering condition is set to `True`
 - The other non-triggering conditions are set to `False` with resolution or healthy messages
 - `computedSpiffeIDs` and `renderedSelectors` are cleared
-
-`Conflict` remains in status for compatibility with existing reports. In current
-pool-only reconciliation it is normally `False` with reason `Resolved`.

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -72,9 +72,8 @@ Status text output must group the report under `Kleym`, `Bindings`, and `Depende
 3. List visible `InferenceIdentityBinding` resources across namespaces.
 4. Record visible trust domain and `ClusterSPIFFEID` class from binding status, with operator Deployment args as fallback when bindings are not available.
 5. Count bindings as `OK` when `Ready=True`, `WARNING` when readiness is missing or unknown, and `ERROR` when `Ready=False`.
-6. Count true `Ready`, `Conflict`, `InvalidRef`, `UnsafeSelector`, and `RenderFailure` binding conditions.
-7. Report `Conflict` condition visibility from binding status. The CLI must not recompute peer conflicts.
-8. Emit findings and exit according to finding severity.
+6. Count true `Ready`, `InvalidRef`, `UnsafeSelector`, and `RenderFailure` binding conditions.
+7. Emit findings and exit according to finding severity.
 
 Status does not compare live managed `ClusterSPIFFEID` output, prove SVID issuance, prove workload attestation, prove identity consumption, or perform request-time authorization checks.
 
@@ -85,7 +84,7 @@ Status does not compare live managed `ClusterSPIFFEID` output, prove SVID issuan
 3. Record config values and sources. If binding status lacks operator config, add a warning finding.
 4. Render identity and deterministic `ClusterSPIFFEID` output with shared Kleym logic.
 5. Read pods when permitted and report pods or containers matching rendered Kubernetes-observable selectors.
-6. Preserve current binding conditions. Conflict state comes from the inspected binding's `Conflict` condition, not peer re-analysis.
+6. Preserve current binding conditions.
 7. Emit the report and exit according to finding severity.
 
 Matched pods are not proof of SVID issuance, workload attestation, identity consumption, or request-time authorization.

--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -45,7 +45,7 @@ When `--clusterspiffeid-class-name` is empty, SPIRE Controller Manager must be c
 1. `poolRef` references one [`InferencePool`][gaie-inferencepool]. The pool is the required workload anchor and selector provenance source.
 2. `serviceAccountName` is required. Kleym renders safety selectors internally as `k8s:ns:<binding namespace>` and `k8s:sa:<serviceAccountName>`.
 3. SPIFFE IDs are always deterministic under the configured trust domain: `spiffe://<trustDomain>/ns/<namespace>/pool/<pool-name>`.
-4. Status records `trustDomain`, `clusterSPIFFEIDClassName`, `computedSpiffeIDs`, `renderedSelectors`, and conditions. Conditions include `Ready`, `Conflict`, `InvalidRef`, `UnsafeSelector`, and `RenderFailure`.
+4. Status records `trustDomain`, `clusterSPIFFEIDClassName`, `computedSpiffeIDs`, `renderedSelectors`, and conditions. Conditions include `Ready`, `InvalidRef`, `UnsafeSelector`, and `RenderFailure`.
 5. `trustDomain` and `clusterSPIFFEIDClassName` record the operator config values used for the latest status update. They are observation data for read-only inspection compatibility; they do not make trust domain or class name per-binding spec intent.
 6. The CRD exposes printer columns for `POOL`, `READY`, `REASON`, and `SPIFFE ID` so `kubectl get inferenceidentitybindings.kleym.sonda.red -A` is the primary binding list view.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,7 +33,6 @@ If reconciliation fails, `Ready=False` and the triggering condition becomes `Tru
 | `InvalidRef` | `InferencePoolCRDMissing` | The GAIE `InferencePool` CRD is not installed in the cluster. | Install the required GAIE CRDs before reconciling bindings. |
 | `UnsafeSelector` | `InvalidPoolSelector` | The pool selector cannot be normalized into a rendered selector set, or its label keys or values are malformed. | Use a deterministic `matchLabels`-style selector with valid Kubernetes label keys and values. Do not rely on whitespace trimming. |
 | `UnsafeSelector` | `UnsafeSelector` | The rendered selector set is missing namespace or service account safety constraints, or would widen beyond the tenant boundary. | Ensure `serviceAccountName` and the pool-derived selector stay within the intended workload boundary. |
-| `Conflict` | `IdentityCollision` | Historical Objective-era collision state. Current pool-only reconciliation should leave `Conflict=False`. | Confirm you are running the current CRD and controller. |
 | `RenderFailure` | `InvalidServiceAccountName` | `spec.serviceAccountName` is empty or not a valid Kubernetes service account name. | Set `serviceAccountName` to the exact workload service account. |
 | `RenderFailure` | `InvalidSPIFFEID` | The computed SPIFFE ID is not valid. | Check the referenced namespace and pool names. |
 | `RenderFailure` | `MissingTrustDomain` | The operator has no trust domain configured. | Configure `--trust-domain` or `KLEYM_TRUST_DOMAIN` before starting the operator. |

--- a/internal/controller/inferenceidentitybinding_controller.go
+++ b/internal/controller/inferenceidentitybinding_controller.go
@@ -43,12 +43,9 @@ const (
 	inferenceIdentityBindingFinalizer = "kleym.sonda.red/inferenceidentitybinding-finalizer"
 
 	conditionTypeReady          = "Ready"
-	conditionTypeConflict       = "Conflict"
 	conditionTypeInvalidRef     = "InvalidRef"
 	conditionTypeUnsafeSelector = "UnsafeSelector"
 	conditionTypeRenderFailure  = "RenderFailure"
-
-	noIdentityCollisionMessage = "No identity collision detected"
 
 	fieldIndexPoolRefName          = "spec.poolRef.name"
 	infraNotReadyRequeueAfter      = 30 * time.Second

--- a/internal/controller/inferenceidentitybinding_envtest_test.go
+++ b/internal/controller/inferenceidentitybinding_envtest_test.go
@@ -25,7 +25,6 @@ var _ = Describe("InferenceIdentityBinding Envtest Coverage", func() {
 		conditionTypeInvalidRef,
 		conditionTypeUnsafeSelector,
 		conditionTypeRenderFailure,
-		conditionTypeConflict,
 	}
 
 	newName := func(prefix string) string {

--- a/internal/controller/inferenceidentitybinding_metrics.go
+++ b/internal/controller/inferenceidentitybinding_metrics.go
@@ -35,10 +35,10 @@ const (
 	metricLabelCondition              = "condition"
 	metricLabelReason                 = "reason"
 	metricReasonInitializing          = "Initializing"
+	metricReasonUnclassifiedFailure   = "UnclassifiedFailure"
 )
 
 var failureOutcomeConditionOrder = []string{
-	conditionTypeConflict,
 	conditionTypeInvalidRef,
 	conditionTypeUnsafeSelector,
 	conditionTypeRenderFailure,
@@ -213,6 +213,13 @@ func deriveBindingOutcomeLabels(
 				reason:    condition.Reason,
 			}, true
 		}
+	}
+
+	if ready != nil && ready.Status == metav1.ConditionFalse {
+		return bindingOutcomeLabels{
+			condition: conditionTypeReady,
+			reason:    metricReasonUnclassifiedFailure,
+		}, true
 	}
 
 	return bindingOutcomeLabels{}, false

--- a/internal/controller/inferenceidentitybinding_metrics_test.go
+++ b/internal/controller/inferenceidentitybinding_metrics_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	dto "github.com/prometheus/client_model/go"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -74,22 +76,27 @@ func TestDeriveBindingOutcomeLabelsFailure(t *testing.T) {
 	}
 }
 
-func TestDeriveBindingOutcomeLabelsCollision(t *testing.T) {
+func TestDeriveBindingOutcomeLabelsLegacyReadyFalseFallback(t *testing.T) {
 	t.Parallel()
 
-	binding := newPoolOnlyBinding("binding-collision", "")
-	initializeConditions(&binding.Status, 1)
-	applyCollisionStatus(&binding.Status, binding.Generation, true, "identity collision with bindings default/peer")
+	binding := newPoolOnlyBinding("binding-legacy-failure", "")
+	binding.Status.Conditions = []metav1.Condition{{
+		Type:               conditionTypeReady,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: binding.Generation,
+		Reason:             "LegacyRemovedReason",
+		Message:            "stale obsolete condition reason from older controller",
+	}}
 
-	labels, ok := deriveBindingOutcomeLabels(binding, false)
+	labels, ok := deriveBindingOutcomeLabels(binding, true)
 	if !ok {
-		t.Fatal("expected outcome labels")
+		t.Fatal("expected fallback outcome labels")
 	}
-	if labels.condition != conditionTypeConflict {
-		t.Fatalf("condition = %q, want %q", labels.condition, conditionTypeConflict)
+	if labels.condition != conditionTypeReady {
+		t.Fatalf("condition = %q, want %q", labels.condition, conditionTypeReady)
 	}
-	if labels.reason != "IdentityCollision" {
-		t.Fatalf("reason = %q, want %q", labels.reason, "IdentityCollision")
+	if labels.reason != metricReasonUnclassifiedFailure {
+		t.Fatalf("reason = %q, want %q", labels.reason, metricReasonUnclassifiedFailure)
 	}
 }
 
@@ -127,6 +134,46 @@ func TestReconcileRecordsSuccessfulTerminalOutcomeAfterStatusPatch(t *testing.T)
 	outcome := recorder.outcomes[0]
 	if outcome.condition != conditionTypeReady || outcome.reason != "Reconciled" {
 		t.Fatalf("unexpected outcome: %+v", outcome)
+	}
+}
+
+func TestReconcileRemovesStaleConflictCondition(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newControllerTestScheme(t)
+
+	binding := newPoolOnlyBinding("binding-stale-conflict", "")
+	binding.Status.Conditions = []metav1.Condition{{
+		Type:               "Conflict",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: binding.Generation,
+		Reason:             "Obsolete",
+		Message:            "stale obsolete condition from older controller",
+	}}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+		WithObjects(newTestPool(), binding).
+		Build()
+
+	reconciler := &InferenceIdentityBindingReconciler{
+		Config: testOperatorConfig(),
+		Client: k8sClient,
+		Scheme: scheme,
+	}
+	key := types.NamespacedName{Namespace: testNamespace, Name: binding.Name}
+
+	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	fetched := &kleymv1alpha1.InferenceIdentityBinding{}
+	if err := k8sClient.Get(ctx, key, fetched); err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if condition := meta.FindStatusCondition(fetched.Status.Conditions, "Conflict"); condition != nil {
+		t.Fatalf("stale Conflict condition persisted: %#v", condition)
 	}
 }
 
@@ -175,21 +222,21 @@ func TestIdentityBindingGaugeCollectorAggregatesOutcomes(t *testing.T) {
 
 	readyA := newPoolOnlyBinding("binding-ready-a", "")
 	readyB := newPoolOnlyBinding("binding-ready-b", "")
-	collision := newPoolOnlyBinding("binding-collision", "")
+	unsafe := newPoolOnlyBinding("binding-unsafe", "")
 	initializing := newPoolOnlyBinding("binding-initializing", "")
 
 	initializeConditions(&readyA.Status, 1)
 	initializeConditions(&readyB.Status, 1)
-	initializeConditions(&collision.Status, 1)
+	initializeConditions(&unsafe.Status, 1)
 	initializeConditions(&initializing.Status, 1)
 
 	applySuccessStatus(&readyA.Status, readyA.Generation, []renderedIdentity{{SpiffeID: "spiffe://kleym.sonda.red/ns/default/pool/pool-a"}})
 	applySuccessStatus(&readyB.Status, readyB.Generation, []renderedIdentity{{SpiffeID: "spiffe://kleym.sonda.red/ns/default/pool/pool-a"}})
-	applyCollisionStatus(&collision.Status, collision.Generation, true, "identity collision with bindings default/peer")
+	applyFailureStatus(&unsafe.Status, unsafe.Generation, newStateError(conditionTypeUnsafeSelector, "UnsafeSelector", "selectors are unsafe"))
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(readyA, readyB, collision, initializing).
+		WithObjects(readyA, readyB, unsafe, initializing).
 		Build()
 
 	collector := newIdentityBindingGaugeCollector()
@@ -217,8 +264,8 @@ func TestIdentityBindingGaugeCollectorAggregatesOutcomes(t *testing.T) {
 		reason:    "Reconciled",
 	}, 2)
 	assertMetricValue(t, values, bindingOutcomeLabels{
-		condition: conditionTypeConflict,
-		reason:    "IdentityCollision",
+		condition: conditionTypeUnsafeSelector,
+		reason:    "UnsafeSelector",
 	}, 1)
 	assertMetricValue(t, values, bindingOutcomeLabels{
 		condition: conditionTypeReady,

--- a/internal/controller/inferenceidentitybinding_resolver.go
+++ b/internal/controller/inferenceidentitybinding_resolver.go
@@ -33,8 +33,7 @@ func (r *InferenceIdentityBindingReconciler) resolveInferencePool(
 func shouldCleanupManagedClusterSPIFFEIDs(conditionType string) bool {
 	return conditionType == conditionTypeInvalidRef ||
 		conditionType == conditionTypeUnsafeSelector ||
-		conditionType == conditionTypeRenderFailure ||
-		conditionType == conditionTypeConflict
+		conditionType == conditionTypeRenderFailure
 }
 
 func isInfrastructureNotReadyReason(reason string) bool {

--- a/internal/controller/inferenceidentitybinding_status.go
+++ b/internal/controller/inferenceidentitybinding_status.go
@@ -36,11 +36,12 @@ func initializeConditions(
 		message       string
 	}{
 		{conditionTypeReady, "Readiness has not been evaluated yet"},
-		{conditionTypeConflict, "Identity collision has not been evaluated yet"},
 		{conditionTypeInvalidRef, "Reference validity has not been evaluated yet"},
 		{conditionTypeUnsafeSelector, "Selector safety has not been evaluated yet"},
 		{conditionTypeRenderFailure, "Render health has not been evaluated yet"},
 	}
+
+	status.Conditions = removeCondition(status.Conditions, "Conflict")
 
 	for _, entry := range canonical {
 		conditionStatus := metav1.ConditionUnknown
@@ -90,7 +91,6 @@ func applySuccessStatus(
 	}
 
 	setCondition(status, generation, conditionTypeReady, metav1.ConditionTrue, "Reconciled", "Binding reconciled")
-	setCondition(status, generation, conditionTypeConflict, metav1.ConditionFalse, "Resolved", noIdentityCollisionMessage)
 	setCondition(status, generation, conditionTypeInvalidRef, metav1.ConditionFalse, "Resolved", "References are valid")
 	setCondition(status, generation, conditionTypeUnsafeSelector, metav1.ConditionFalse, "Resolved", "Selectors are safe")
 	setCondition(status, generation, conditionTypeRenderFailure, metav1.ConditionFalse, "Resolved", "Rendering is healthy")
@@ -110,38 +110,12 @@ func applyFailureStatus(
 	if stateErr.conditionType != conditionTypeInvalidRef {
 		setCondition(status, generation, conditionTypeInvalidRef, metav1.ConditionFalse, "Resolved", "References are valid")
 	}
-	if stateErr.conditionType != conditionTypeConflict {
-		setCondition(status, generation, conditionTypeConflict, metav1.ConditionFalse, "Resolved", noIdentityCollisionMessage)
-	}
 	if stateErr.conditionType != conditionTypeUnsafeSelector {
 		setCondition(status, generation, conditionTypeUnsafeSelector, metav1.ConditionFalse, "Resolved", "Selectors are safe")
 	}
 	if stateErr.conditionType != conditionTypeRenderFailure {
 		setCondition(status, generation, conditionTypeRenderFailure, metav1.ConditionFalse, "Resolved", "Rendering is healthy")
 	}
-}
-
-func applyCollisionStatus(
-	status *kleymv1alpha1.InferenceIdentityBindingStatus,
-	generation int64,
-	hasCollision bool,
-	message string,
-) {
-	if hasCollision {
-		status.ComputedSpiffeIDs = nil
-		status.RenderedSelectors = nil
-		setCondition(status, generation, conditionTypeReady, metav1.ConditionFalse, "IdentityCollision", message)
-		setCondition(status, generation, conditionTypeConflict, metav1.ConditionTrue, "IdentityCollision", message)
-		setCondition(status, generation, conditionTypeInvalidRef, metav1.ConditionFalse, "Resolved", "References are valid")
-		setCondition(status, generation, conditionTypeUnsafeSelector, metav1.ConditionFalse, "Resolved", "Selectors are safe")
-		setCondition(status, generation, conditionTypeRenderFailure, metav1.ConditionFalse, "Resolved", "Rendering is healthy")
-		return
-	}
-
-	if strings.TrimSpace(message) == "" {
-		message = noIdentityCollisionMessage
-	}
-	setCondition(status, generation, conditionTypeConflict, metav1.ConditionFalse, "Resolved", message)
 }
 
 func (r *InferenceIdentityBindingReconciler) patchStatusFromBase(
@@ -170,4 +144,15 @@ func setCondition(
 		Reason:             reason,
 		Message:            message,
 	})
+}
+
+func removeCondition(conditions []metav1.Condition, conditionType string) []metav1.Condition {
+	filtered := conditions[:0]
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			continue
+		}
+		filtered = append(filtered, condition)
+	}
+	return filtered
 }

--- a/internal/controller/inferenceidentitybinding_status_test.go
+++ b/internal/controller/inferenceidentitybinding_status_test.go
@@ -21,6 +21,13 @@ func TestInitializeConditionsEnsuresCanonicalSetForCurrentGeneration(t *testing.
 				Reason:             "Reconciled",
 				Message:            "Binding reconciled",
 			},
+			{
+				Type:               "Conflict",
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 2,
+				Reason:             "Obsolete",
+				Message:            "stale obsolete condition from older controller",
+			},
 		},
 	}
 
@@ -28,7 +35,6 @@ func TestInitializeConditionsEnsuresCanonicalSetForCurrentGeneration(t *testing.
 
 	canonicalConditionTypes := []string{
 		conditionTypeReady,
-		conditionTypeConflict,
 		conditionTypeInvalidRef,
 		conditionTypeUnsafeSelector,
 		conditionTypeRenderFailure,
@@ -58,14 +64,8 @@ func TestInitializeConditionsEnsuresCanonicalSetForCurrentGeneration(t *testing.
 		t.Fatalf("ready message = %q, want %q", ready.Message, "Binding reconciled")
 	}
 
-	conflict := meta.FindStatusCondition(status.Conditions, conditionTypeConflict)
-	if conflict == nil {
-		t.Fatalf("expected condition %q to be present", conditionTypeConflict)
-	}
-	if conflict.Status != metav1.ConditionUnknown {
-		t.Fatalf("conflict status = %q, want %q", conflict.Status, metav1.ConditionUnknown)
-	}
-	if conflict.Reason != "Initializing" {
-		t.Fatalf("conflict reason = %q, want %q", conflict.Reason, "Initializing")
+	conflict := meta.FindStatusCondition(status.Conditions, "Conflict")
+	if conflict != nil {
+		t.Fatalf("stale Conflict condition was not removed: %#v", conflict)
 	}
 }

--- a/internal/inspection/inspection.go
+++ b/internal/inspection/inspection.go
@@ -33,7 +33,6 @@ const (
 	findingDependencyMissing     = "dependency-missing"
 	findingUnsafeSelector        = "unsafe-selector"
 	findingRenderFailure         = "render-failure"
-	findingKleymCollision        = "kleym-collision"
 	findingZeroMatchedPods       = "zero-matched-pods"
 	findingUnsupportedSelector   = "unsupported-selector"
 	findingRBACLimited           = "rbac-limited"
@@ -42,7 +41,6 @@ const (
 	reasonUnsupportedSelector    = "UnsupportedSelector"
 	reasonRBACLimited            = "Forbidden"
 	reasonIdentityConfigMissing  = "IdentityConfigUndiscovered"
-	conditionTypeConflict        = "Conflict"
 	podResourceName              = "pods"
 )
 
@@ -269,7 +267,6 @@ func (i *bindingInspector) InspectBinding(ctx context.Context, namespace string,
 	report.Capabilities.Binding = BindingInspectionCapabilityFull
 	report.Capabilities.PeerBindings = BindingInspectionCapabilityPartial
 	report.BindingRef = bindingInspectionBindingRef(binding)
-	i.addCollisionFinding(binding, &report)
 	identityConfig := i.resolveIdentityConfig(binding, &report)
 
 	rendered, renderedReady := i.inspectRenderedIdentity(ctx, binding, availablePoolGVKs, identityConfig, &report)
@@ -660,29 +657,6 @@ func podSelectorMatchLabels(selector map[string]any) (map[string]string, error) 
 		labels[key] = text
 	}
 	return labels, nil
-}
-
-func (i *bindingInspector) addCollisionFinding(
-	binding *kleymv1alpha1.InferenceIdentityBinding,
-	report *BindingInspectionReport,
-) {
-	condition := meta.FindStatusCondition(binding.Status.Conditions, conditionTypeConflict)
-	if condition == nil || condition.Status != metav1.ConditionTrue {
-		return
-	}
-	report.Findings = append(report.Findings, BindingInspectionFinding{
-		ID:       findingKleymCollision,
-		Severity: BindingInspectionFindingSeverityError,
-		Reason:   condition.Reason,
-		Message:  condition.Message,
-		AffectedRefs: []BindingInspectionTargetRef{{
-			Namespace: binding.Namespace,
-			Name:      binding.Name,
-			Group:     kleymv1alpha1.GroupVersion.Group,
-			Version:   kleymv1alpha1.GroupVersion.Version,
-			Kind:      "InferenceIdentityBinding",
-		}},
-	})
 }
 
 // zeroMatchedPodsFinding records that readable pods did not match the rendered identity selectors.

--- a/internal/inspection/inspection_test.go
+++ b/internal/inspection/inspection_test.go
@@ -391,25 +391,6 @@ func TestInspectBindingDoesNotRequireClusterSPIFFEIDCRD(t *testing.T) {
 	assertNoFinding(t, report.Findings, findingDependencyMissing)
 }
 
-func TestInspectBindingCollisionConditionFinding(t *testing.T) {
-	binding := testInspectionBinding()
-	binding.Status.Conditions = []metav1.Condition{{
-		Type:    conditionTypeConflict,
-		Status:  metav1.ConditionTrue,
-		Reason:  "IdentityCollision",
-		Message: "identity collision with bindings peer-a",
-	}}
-	pool := testInspectionPool("pool-a")
-	inspector := newTestBindingInspector(t, nil, binding, pool)
-
-	report, err := inspector.InspectBinding(context.Background(), "tenant-a", "binding-a")
-	if !errors.Is(err, ErrBindingInspectionErrorFindings) {
-		t.Fatalf("InspectBinding error = %v, want error findings", err)
-	}
-
-	assertFinding(t, report.Findings, findingKleymCollision, BindingInspectionFindingSeverityError, "IdentityCollision")
-}
-
 func newTestBindingInspector(t *testing.T, listErr error, objects ...client.Object) *bindingInspector {
 	return newTestBindingInspectorWithListErrors(t, listErr, nil, objects...)
 }

--- a/internal/inspection/report.go
+++ b/internal/inspection/report.go
@@ -395,7 +395,7 @@ func textConditionNeedsDetail(condition metav1.Condition) bool {
 	switch condition.Type {
 	case "Ready", "Resolved", "Rendered":
 		return condition.Status != metav1.ConditionTrue
-	case "Conflict", "InvalidRef", "UnsafeSelector", "RenderFailure":
+	case "InvalidRef", "UnsafeSelector", "RenderFailure":
 		return condition.Status == metav1.ConditionTrue
 	default:
 		return condition.Status != metav1.ConditionTrue

--- a/internal/inspection/report_test.go
+++ b/internal/inspection/report_test.go
@@ -410,9 +410,9 @@ func TestWriteBindingInspectionReportTextConditionDetails(t *testing.T) {
 				Reason:  "RenderFailed",
 				Message: "failed to render ClusterSPIFFEID because serviceAccountName is invalid",
 			}, {
-				Type:   "Conflict",
+				Type:   "InvalidRef",
 				Status: metav1.ConditionFalse,
-				Reason: "NoIdentityCollision",
+				Reason: "Resolved",
 			}},
 		},
 	}
@@ -426,14 +426,14 @@ func TestWriteBindingInspectionReportTextConditionDetails(t *testing.T) {
 		"Ready=False",
 		"Reason: RenderFailed",
 		"Message: failed to render ClusterSPIFFEID because serviceAccountName is invalid",
-		"Conflict=False",
+		"InvalidRef=False",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("text output missing %q\n%s", want, text)
 		}
 	}
-	if strings.Contains(text, "Reason: NoIdentityCollision") {
-		t.Fatalf("healthy Conflict=False condition should stay compact:\n%s", text)
+	if strings.Contains(text, "Reason: Resolved") {
+		t.Fatalf("healthy InvalidRef=False condition should stay compact:\n%s", text)
 	}
 }
 

--- a/internal/inspection/status.go
+++ b/internal/inspection/status.go
@@ -363,9 +363,6 @@ func addBindingConditionCounts(
 	if conditionIsTrue(binding, conditionTypeReady) {
 		summary.Ready++
 	}
-	if conditionIsTrue(binding, conditionTypeConflict) {
-		summary.Conflict++
-	}
 	if conditionIsTrue(binding, conditionTypeInvalidRef) {
 		summary.InvalidRef++
 	}

--- a/internal/inspection/status_report.go
+++ b/internal/inspection/status_report.go
@@ -109,7 +109,6 @@ type BindingStatusSummary struct {
 // BindingConditionSummary counts true binding conditions by type.
 type BindingConditionSummary struct {
 	Ready          int `json:"ready"`
-	Conflict       int `json:"conflict"`
 	InvalidRef     int `json:"invalidRef"`
 	UnsafeSelector int `json:"unsafeSelector"`
 	RenderFailure  int `json:"renderFailure"`
@@ -180,7 +179,6 @@ func writeStatusReportText(w io.Writer, report StatusReport) error {
 	appendTextLine(&builder, "  Total: %d", report.Summary.Bindings.Total)
 	appendTextLine(&builder, "  Conditions:")
 	appendTextLine(&builder, "    Ready: %d", report.Summary.Bindings.Conditions.Ready)
-	appendTextLine(&builder, "    Conflict: %d", report.Summary.Bindings.Conditions.Conflict)
 	appendTextLine(&builder, "    InvalidRef: %d", report.Summary.Bindings.Conditions.InvalidRef)
 	appendTextLine(&builder, "    UnsafeSelector: %d", report.Summary.Bindings.Conditions.UnsafeSelector)
 	appendTextLine(&builder, "    RenderFailure: %d", report.Summary.Bindings.Conditions.RenderFailure)

--- a/internal/inspection/status_test.go
+++ b/internal/inspection/status_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestStatusHealthyInstallation(t *testing.T) {
-	binding := testStatusBinding("binding-a", metav1.ConditionTrue, metav1.ConditionFalse)
+	binding := testStatusBinding("binding-a", metav1.ConditionTrue)
 	inspector := newTestStatusInspector(t, newReadyOperatorDeployment(), binding)
 
 	report, err := inspector.Status(context.Background())
@@ -53,7 +53,7 @@ func TestStatusHealthyInstallation(t *testing.T) {
 }
 
 func TestStatusMissingSPIRECRD(t *testing.T) {
-	binding := testStatusBinding("binding-a", metav1.ConditionFalse, metav1.ConditionUnknown)
+	binding := testStatusBinding("binding-a", metav1.ConditionFalse)
 	binding.Status.Conditions[0].Reason = "ClusterSPIFFEIDCRDMissing"
 	binding.Status.Conditions[0].Message = "ClusterSPIFFEID CRD is not installed"
 	noSPIRE := removeStatusGVK(defaultStatusGVKs(), spirecm.ClusterSPIFFEIDGVK())
@@ -71,25 +71,6 @@ func TestStatusMissingSPIRECRD(t *testing.T) {
 	assertFinding(t, report.Findings, findingCRDMissing, BindingInspectionFindingSeverityError, "ClusterSPIFFEIDCRDMissing")
 	if report.Summary.Bindings.Error != 1 {
 		t.Fatalf("binding errors = %d, want 1", report.Summary.Bindings.Error)
-	}
-}
-
-func TestStatusBindingCollisionCondition(t *testing.T) {
-	binding := testStatusBinding("binding-a", metav1.ConditionFalse, metav1.ConditionTrue)
-	binding.Status.Conditions[0].Reason = "IdentityCollision"
-	binding.Status.Conditions[0].Message = "identity collision with bindings peer-a"
-	binding.Status.Conditions[1].Reason = "IdentityCollision"
-	binding.Status.Conditions[1].Message = "identity collision with bindings peer-a"
-	inspector := newTestStatusInspector(t, newReadyOperatorDeployment(), binding)
-
-	report, err := inspector.Status(context.Background())
-	if !errors.Is(err, ErrStatusReportErrorFindings) {
-		t.Fatalf("Status error = %v, want error findings", err)
-	}
-
-	if report.Summary.Bindings.Conditions.Conflict != 1 ||
-		report.Summary.Bindings.Error != 1 {
-		t.Fatalf("binding summary = %#v, want one conflict and one error", report.Summary.Bindings)
 	}
 }
 
@@ -114,8 +95,8 @@ func TestStatusNoBindings(t *testing.T) {
 }
 
 func TestStatusBindingConfigFallbackReportsMixedValues(t *testing.T) {
-	bindingA := testStatusBinding("binding-a", metav1.ConditionTrue, metav1.ConditionFalse)
-	bindingB := testStatusBinding("binding-b", metav1.ConditionTrue, metav1.ConditionFalse)
+	bindingA := testStatusBinding("binding-a", metav1.ConditionTrue)
+	bindingB := testStatusBinding("binding-b", metav1.ConditionTrue)
 	bindingB.Status.TrustDomain = "other.example.org"
 	bindingB.Status.ClusterSPIFFEIDClassName = "other"
 	operator := newReadyOperatorDeployment()
@@ -137,28 +118,18 @@ func TestStatusBindingConfigFallbackReportsMixedValues(t *testing.T) {
 func testStatusBinding(
 	name string,
 	readyStatus metav1.ConditionStatus,
-	conflictStatus metav1.ConditionStatus,
 ) *kleymv1alpha1.InferenceIdentityBinding {
 	binding := testInspectionBinding()
 	binding.Name = name
 	binding.Status.TrustDomain = "example.org"
 	binding.Status.ClusterSPIFFEIDClassName = "kleym"
-	binding.Status.Conditions = []metav1.Condition{
-		{
-			Type:               conditionTypeReady,
-			Status:             readyStatus,
-			Reason:             "Reconciled",
-			Message:            "Binding reconciled",
-			LastTransitionTime: metav1.Now(),
-		},
-		{
-			Type:               conditionTypeConflict,
-			Status:             conflictStatus,
-			Reason:             "Resolved",
-			Message:            "No identity collision detected",
-			LastTransitionTime: metav1.Now(),
-		},
-	}
+	binding.Status.Conditions = []metav1.Condition{{
+		Type:               conditionTypeReady,
+		Status:             readyStatus,
+		Reason:             "Reconciled",
+		Message:            "Binding reconciled",
+		LastTransitionTime: metav1.Now(),
+	}}
 	binding.Status.RenderedSelectors = []kleymv1alpha1.RenderedSelectorStatus{{
 		SpiffeID: "spiffe://kleym.sonda.red/ns/tenant-a/pool/pool-a",
 		Selectors: []string{

--- a/test/chainsaw/binding-reconciliation/binding-ready.yaml
+++ b/test/chainsaw/binding-reconciliation/binding-ready.yaml
@@ -18,9 +18,6 @@ status:
     - type: Ready
       status: "True"
       reason: Reconciled
-    - type: Conflict
-      status: "False"
-      reason: Resolved
     - type: InvalidRef
       status: "False"
       reason: Resolved

--- a/test/chainsaw/binding-reconciliation/pool-binding-ready.yaml
+++ b/test/chainsaw/binding-reconciliation/pool-binding-ready.yaml
@@ -18,9 +18,6 @@ status:
     - type: Ready
       status: "True"
       reason: Reconciled
-    - type: Conflict
-      status: "False"
-      reason: Resolved
     - type: InvalidRef
       status: "False"
       reason: Resolved


### PR DESCRIPTION
## Summary

- Remove the obsolete `Conflict` / `IdentityCollision` condition path from the current pool-only `InferenceIdentityBinding` status contract.
- Update controller status handling, metrics, CLI status/inspect reporting, generated CRD comments, docs, and tests to use the current condition taxonomy only.
- Drop conflict-specific CLI findings/counters while preserving stale-condition cleanup during reconciliation.

## What I Changed And Why

- Removed `Conflict` from canonical status initialization and generated API/CRD condition docs.
- Removed no-op collision status helpers and conflict-specific terminal/gauge metric assertions.
- Added stale `Conflict` cleanup in condition initialization so reconciled legacy objects do not keep the historical condition.
- Removed conflict-specific `kleym status` JSON/text counters and `kleym inspect` collision findings because the pool-only contract has no current collision state.
- Updated docs, examples, and Chainsaw expected status to describe `Ready`, `InvalidRef`, `UnsafeSelector`, and `RenderFailure` as the current operator conditions.

## Related Issue

- Closes #247

## Scope Check

- Follows #247 by removing only obsolete `Conflict` / `IdentityCollision` behavior.
- Left out any new diff/collision reporting, objective-era behavior, identity rendering changes, selector semantics changes, and runtime evidence behavior.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): updated to remove `Conflict` from the current status taxonomy.
- CLI Spec (`docs/spec/cli.md`): updated to remove conflict counters/findings from status/inspect behavior.
- Other docs: updated conditions reference, troubleshooting, CLI findings/results, demo, basic example, and contributing wording.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `make manifests` — passed
  - `make generate` — passed
  - `go test ./internal/controller ./internal/inspection ./internal/cli` — passed
  - `make test` — passed
  - `make lint` — passed, 0 issues
  - `make docs-build` — passed
  - `git diff --check` — passed
- Tests not run and why:
  - `make test-e2e-chainsaw` — not run; this change updates expected Chainsaw status snippets but does not introduce live-cluster behavior beyond condition removal covered by controller/envtest/unit checks.

## Security Review

- Does not touch GitHub Actions, CI, release automation, credentials, or secret handling.
- Touches identity/status contract and CLI reporting, but does not change SPIFFE ID rendering, selector derivation, managed `ClusterSPIFFEID` reconciliation, finalizer cleanup, or runtime authorization behavior.

BREAKING CHANGE: `InferenceIdentityBinding` status and `kleym status` JSON no longer expose the obsolete `Conflict` condition or conflict counter.