### PR TITLE
refactor(controller): normalize condition taxonomy

### DIFF
--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -8,14 +8,14 @@ aliases:
 
 ## Core Condition Contract
 
-`InferenceIdentityBinding` uses only the following current pool-only condition types:
+`InferenceIdentityBinding` uses the following current pool-only condition types:
 
 - `Ready`
 - `InvalidRef`
 - `UnsafeSelector`
 - `RenderFailure`
 
-These conditions describe operator reconciliation state only. They are not runtime evidence, SVID issuance, workload attestation, model loading, GPU usage, or request authorization signals. Future `InferenceSVIDConfig` behavior must define its own condition taxonomy instead of extending these binding reasons.
+These conditions describe reference resolution, selector safety, identity rendering, managed-output application, and reconciliation readiness.
 
 ## Allowed Reasons
 

--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -1,32 +1,52 @@
 ---
 title: Conditions
 weight: 20
-description: "Kleym condition reference for Ready, InvalidRef, UnsafeSelector, RenderFailure, and related status reasons."
+description: "Stable Kleym condition taxonomy and allowed reasons for the pool-only InferenceIdentityBinding operator contract."
 aliases:
   - /operator/reference/conditions/
 ---
 
-## Condition Types
+## Core Condition Contract
 
-| Type | Meaning when `True` | Common reasons |
+`InferenceIdentityBinding` uses only the following current pool-only condition types:
+
+- `Ready`
+- `InvalidRef`
+- `UnsafeSelector`
+- `RenderFailure`
+
+These conditions describe operator reconciliation state only. They are not runtime evidence, SVID issuance, workload attestation, model loading, GPU usage, or request authorization signals. Future `InferenceSVIDConfig` behavior must define its own condition taxonomy instead of extending these binding reasons.
+
+## Allowed Reasons
+
+| Type | Meaning when `True` | Allowed `True` reasons |
 | --- | --- | --- |
 | `Ready` | The binding reconciled successfully. | `Reconciled` |
-| `InvalidRef` | `poolRef` or a required CRD could not be resolved or validated. | `TargetPoolNotFound`, `InvalidPoolRef`, `InferencePoolCRDMissing` |
-| `UnsafeSelector` | The rendered selector set is missing required safety constraints or the pool selector cannot be rendered safely. | `UnsafeSelector`, `InvalidPoolSelector` |
-| `RenderFailure` | Rendering failed after reference resolution succeeded. | `InvalidServiceAccountName`, `InvalidSPIFFEID`, `ClusterSPIFFEIDCRDMissing`, `MissingTrustDomain` |
+| `InvalidRef` | `poolRef` or the required GAIE pool CRD could not be resolved or validated. | `InvalidPoolRef`, `TargetPoolNotFound`, `InferencePoolCRDMissing` |
+| `UnsafeSelector` | The rendered selector set is missing required safety constraints or the pool selector cannot be rendered safely. | `InvalidPoolSelector`, `UnsafeSelector` |
+| `RenderFailure` | Rendering or managed-output application failed after reference resolution succeeded. | `MissingTrustDomain`, `InvalidServiceAccountName`, `InvalidSPIFFEID`, `ClusterSPIFFEIDCRDMissing` |
 
-## Current Status Behavior
+`Ready=False` uses the same reason and message as the single active failure condition. Failure conditions use `Resolved` when `False`; all conditions may use `Initializing` while a generation has not been evaluated.
+
+## Status Behavior
 
 On successful reconciliation:
 
 - `Ready=True` with reason `Reconciled`
-- `InvalidRef=False`
-- `UnsafeSelector=False`
-- `RenderFailure=False`
+- `InvalidRef=False` with reason `Resolved`
+- `UnsafeSelector=False` with reason `Resolved`
+- `RenderFailure=False` with reason `Resolved`
 
 On any failure state:
 
-- `Ready=False`
-- The triggering condition is set to `True`
+- `Ready=False` with the primary failure reason and message
+- Exactly one of `InvalidRef`, `UnsafeSelector`, or `RenderFailure` is set to `True` with the same reason and message
 - The other non-triggering conditions are set to `False` with resolution or healthy messages
 - `computedSpiffeIDs` and `renderedSelectors` are cleared
+
+Dependency-unavailable states are classified as follows:
+
+- Missing GAIE `InferencePool` CRD: `InvalidRef=True`, reason `InferencePoolCRDMissing`
+- Missing SPIRE Controller Manager `ClusterSPIFFEID` CRD during reconcile: `RenderFailure=True`, reason `ClusterSPIFFEIDCRDMissing`
+
+`ClusterSPIFFEIDCRDMissing` retries automatically on the controller's infrastructure retry timer. `InferencePoolCRDMissing` can appear during resolution, but the operator also fails startup if no supported GAIE pool GVK is served during controller setup.

--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -66,7 +66,7 @@ Selector rationale is expanded in [Selector Safety][selector-safety].
 
 ## Condition Taxonomy
 
-`InferenceIdentityBinding.status.conditions` is a stable machine-readable contract for the current pool-only operator. It does not describe runtime evidence, SVID issuance, workload attestation, model loading, GPU usage, request authorization, or future `InferenceSVIDConfig` lifecycle state.
+`InferenceIdentityBinding.status.conditions` is a stable machine-readable contract for reference resolution, selector safety, identity rendering, managed-output application, and reconciliation readiness.
 
 Allowed condition types and reasons:
 

--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -45,7 +45,7 @@ When `--clusterspiffeid-class-name` is empty, SPIRE Controller Manager must be c
 1. `poolRef` references one [`InferencePool`][gaie-inferencepool]. The pool is the required workload anchor and selector provenance source.
 2. `serviceAccountName` is required. Kleym renders safety selectors internally as `k8s:ns:<binding namespace>` and `k8s:sa:<serviceAccountName>`.
 3. SPIFFE IDs are always deterministic under the configured trust domain: `spiffe://<trustDomain>/ns/<namespace>/pool/<pool-name>`.
-4. Status records `trustDomain`, `clusterSPIFFEIDClassName`, `computedSpiffeIDs`, `renderedSelectors`, and conditions. Conditions include `Ready`, `InvalidRef`, `UnsafeSelector`, and `RenderFailure`.
+4. Status records `trustDomain`, `clusterSPIFFEIDClassName`, `computedSpiffeIDs`, `renderedSelectors`, and conditions. The current pool-only condition taxonomy is limited to `Ready`, `InvalidRef`, `UnsafeSelector`, and `RenderFailure`.
 5. `trustDomain` and `clusterSPIFFEIDClassName` record the operator config values used for the latest status update. They are observation data for read-only inspection compatibility; they do not make trust domain or class name per-binding spec intent.
 6. The CRD exposes printer columns for `POOL`, `READY`, `REASON`, and `SPIFFE ID` so `kubectl get inferenceidentitybindings.kleym.sonda.red -A` is the primary binding list view.
 
@@ -63,6 +63,32 @@ Field details live in [API Reference][api-reference]. Condition details live in 
 8. On deletion, delete managed `ClusterSPIFFEID` children first and keep the binding finalizer until a follow-up list confirms no managed children remain.
 
 Selector rationale is expanded in [Selector Safety][selector-safety].
+
+## Condition Taxonomy
+
+`InferenceIdentityBinding.status.conditions` is a stable machine-readable contract for the current pool-only operator. It does not describe runtime evidence, SVID issuance, workload attestation, model loading, GPU usage, request authorization, or future `InferenceSVIDConfig` lifecycle state.
+
+Allowed condition types and reasons:
+
+| Condition | Status | Allowed reasons |
+| --- | --- | --- |
+| `Ready` | `True` | `Reconciled` |
+| `Ready` | `False` | The same primary failure reason used by the active failure condition. |
+| `Ready` | `Unknown` | `Initializing` |
+| `InvalidRef` | `True` | `InvalidPoolRef`, `TargetPoolNotFound`, `InferencePoolCRDMissing` |
+| `UnsafeSelector` | `True` | `InvalidPoolSelector`, `UnsafeSelector` |
+| `RenderFailure` | `True` | `MissingTrustDomain`, `InvalidServiceAccountName`, `InvalidSPIFFEID`, `ClusterSPIFFEIDCRDMissing` |
+| `InvalidRef`, `UnsafeSelector`, `RenderFailure` | `False` | `Resolved` |
+| `InvalidRef`, `UnsafeSelector`, `RenderFailure` | `Unknown` | `Initializing` |
+
+On success, `Ready=True` uses `Reconciled`, every failure condition is `False` with `Resolved`, and rendered identity status is populated.
+
+On failure, `Ready=False` uses the same reason and message as the one active failure condition. Exactly one of `InvalidRef`, `UnsafeSelector`, or `RenderFailure` is `True`, and `computedSpiffeIDs` plus `renderedSelectors` are cleared.
+
+Dependency-unavailable states use the same taxonomy:
+
+- Missing GAIE `InferencePool` CRD during pool discovery or pool resolution is `InvalidRef=True` with reason `InferencePoolCRDMissing`. Startup discovery fails when no supported GAIE pool GVK is served.
+- Missing SPIRE Controller Manager `ClusterSPIFFEID` CRD during reconcile is `RenderFailure=True` with reason `ClusterSPIFFEIDCRDMissing` and the reconcile retries on a timer.
 
 ## Safety Invariants
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,12 +1,14 @@
 ---
 title: Troubleshooting
 weight: 60
-description: "Troubleshooting guide for Kleym binding conditions, missing dependency CRDs, unsafe selectors, and inspection output."
+description: "Troubleshooting guide for Kleym binding condition reasons, missing dependency CRDs, unsafe selectors, and inspection output."
 aliases:
   - /operator/troubleshooting/
 ---
 
 For the full condition set, read [Conditions](/reference/conditions/).
+
+Binding conditions report operator reconciliation state only. They do not prove SVID issuance, workload attestation, model loading, GPU use, request authorization, or future runtime-evidence state.
 
 ## Start Here
 
@@ -23,6 +25,7 @@ In normal operation:
 - all failure conditions are `False` with reason `Resolved`
 
 If reconciliation fails, `Ready=False` and the triggering condition becomes `True`.
+`Ready=False` carries the same reason and message as the single active failure condition.
 
 ## Condition And Reason Map
 
@@ -72,3 +75,5 @@ Reference docs:
 
 After startup succeeds, missing managed-output CRDs or infrastructure-not-ready states keep retrying automatically on a timer, so they can recover after installation without waiting for unrelated watch events.
 If you install the GAIE CRD after `kleym-operator` startup failed, restart the controller so startup-time GVK discovery can register the watch.
+
+If the `ClusterSPIFFEID` CRD is missing during reconcile, the binding reports `RenderFailure=True` with reason `ClusterSPIFFEIDCRDMissing` and retries automatically. If the `InferencePool` CRD is missing during pool resolution, the binding reports `InvalidRef=True` with reason `InferencePoolCRDMissing`; if it was missing during startup, restart the operator after installing the CRD.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,8 +8,6 @@ aliases:
 
 For the full condition set, read [Conditions](/reference/conditions/).
 
-Binding conditions report operator reconciliation state only. They do not prove SVID issuance, workload attestation, model loading, GPU use, request authorization, or future runtime-evidence state.
-
 ## Start Here
 
 Inspect the binding status and recent events:

--- a/internal/controller/inferenceidentitybinding_controller.go
+++ b/internal/controller/inferenceidentitybinding_controller.go
@@ -47,6 +47,12 @@ const (
 	conditionTypeUnsafeSelector = "UnsafeSelector"
 	conditionTypeRenderFailure  = "RenderFailure"
 
+	conditionReasonReconciled                = "Reconciled"
+	conditionReasonResolved                  = "Resolved"
+	conditionReasonInitializing              = "Initializing"
+	conditionReasonInvalidPoolRef            = "InvalidPoolRef"
+	conditionReasonClusterSPIFFEIDCRDMissing = "ClusterSPIFFEIDCRDMissing"
+
 	fieldIndexPoolRefName          = "spec.poolRef.name"
 	infraNotReadyRequeueAfter      = 30 * time.Second
 	deleteVerificationRequeueAfter = 2 * time.Second
@@ -203,7 +209,7 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(
 	// Phase 5: Apply — reconcile ClusterSPIFFEID resources.
 	if err := r.reconcileClusterSPIFFEIDs(ctx, binding, desiredState.identities); err != nil {
 		if meta.IsNoMatchError(err) {
-			stateErr := newStateError(conditionTypeRenderFailure, "ClusterSPIFFEIDCRDMissing", "ClusterSPIFFEID CRD is not installed")
+			stateErr := newClusterSPIFFEIDCRDMissingStateError()
 			if err := r.applyStateError(ctx, binding, stateErr); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -235,7 +241,7 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(
 	logger.Info(
 		"applied success status",
 		logKeyCondition, conditionTypeReady,
-		logKeyReason, "Reconciled",
+		logKeyReason, conditionReasonReconciled,
 	)
 
 	primaryIdentity := desiredState.identities[0]
@@ -244,7 +250,7 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(
 		primaryIdentity,
 		r.Config.ClusterSPIFFEIDClassName,
 	).GetName()
-	r.recordEventf(binding, corev1.EventTypeNormal, "Reconciled", "reconciled ClusterSPIFFEID %q", primaryClusterSPIFFEIDName)
+	r.recordEventf(binding, corev1.EventTypeNormal, conditionReasonReconciled, "reconciled ClusterSPIFFEID %q", primaryClusterSPIFFEIDName)
 	logger.Info(
 		"reconciled successfully",
 		logKeyClusterSPIFFEID, primaryClusterSPIFFEIDName,
@@ -376,7 +382,7 @@ func (r *InferenceIdentityBindingReconciler) computeDesiredState(
 
 	poolRef, err := gaie.BindingPoolRef(binding)
 	if err != nil {
-		return desiredBindingState{}, newStateError(conditionTypeInvalidRef, "InvalidPoolRef", err.Error())
+		return desiredBindingState{}, newStateError(conditionTypeInvalidRef, conditionReasonInvalidPoolRef, err.Error())
 	}
 	logger.Info(
 		"resolved binding poolRef",

--- a/internal/controller/inferenceidentitybinding_render.go
+++ b/internal/controller/inferenceidentitybinding_render.go
@@ -33,7 +33,7 @@ func (r *InferenceIdentityBindingReconciler) renderIdentity(
 	if err != nil {
 		return identity.RenderedIdentity{}, &identity.StateError{
 			ConditionType: identity.ConditionTypeUnsafeSelector,
-			Reason:        "InvalidPoolSelector",
+			Reason:        identity.ReasonInvalidPoolSelector,
 			Message:       err.Error(),
 		}
 	}

--- a/internal/controller/inferenceidentitybinding_resolver.go
+++ b/internal/controller/inferenceidentitybinding_resolver.go
@@ -37,6 +37,16 @@ func shouldCleanupManagedClusterSPIFFEIDs(conditionType string) bool {
 }
 
 func isInfrastructureNotReadyReason(reason string) bool {
-	return reason == "InferencePoolCRDMissing" ||
-		reason == "ClusterSPIFFEIDCRDMissing"
+	return reason == gaie.ReasonInferencePoolCRDMissing ||
+		reason == conditionReasonClusterSPIFFEIDCRDMissing
+}
+
+// newClusterSPIFFEIDCRDMissingStateError keeps the managed-output dependency
+// failure mapped to the RenderFailure taxonomy from docs/spec/operator.md.
+func newClusterSPIFFEIDCRDMissingStateError() *reconcileStateError {
+	return newStateError(
+		conditionTypeRenderFailure,
+		conditionReasonClusterSPIFFEIDCRDMissing,
+		"ClusterSPIFFEID CRD is not installed",
+	)
 }

--- a/internal/controller/inferenceidentitybinding_status.go
+++ b/internal/controller/inferenceidentitybinding_status.go
@@ -45,7 +45,7 @@ func initializeConditions(
 
 	for _, entry := range canonical {
 		conditionStatus := metav1.ConditionUnknown
-		reason := "Initializing"
+		reason := conditionReasonInitializing
 		message := entry.message
 
 		existing := meta.FindStatusCondition(status.Conditions, entry.conditionType)
@@ -90,10 +90,10 @@ func applySuccessStatus(
 		})
 	}
 
-	setCondition(status, generation, conditionTypeReady, metav1.ConditionTrue, "Reconciled", "Binding reconciled")
-	setCondition(status, generation, conditionTypeInvalidRef, metav1.ConditionFalse, "Resolved", "References are valid")
-	setCondition(status, generation, conditionTypeUnsafeSelector, metav1.ConditionFalse, "Resolved", "Selectors are safe")
-	setCondition(status, generation, conditionTypeRenderFailure, metav1.ConditionFalse, "Resolved", "Rendering is healthy")
+	setCondition(status, generation, conditionTypeReady, metav1.ConditionTrue, conditionReasonReconciled, "Binding reconciled")
+	setCondition(status, generation, conditionTypeInvalidRef, metav1.ConditionFalse, conditionReasonResolved, "References are valid")
+	setCondition(status, generation, conditionTypeUnsafeSelector, metav1.ConditionFalse, conditionReasonResolved, "Selectors are safe")
+	setCondition(status, generation, conditionTypeRenderFailure, metav1.ConditionFalse, conditionReasonResolved, "Rendering is healthy")
 }
 
 func applyFailureStatus(
@@ -108,13 +108,13 @@ func applyFailureStatus(
 	setCondition(status, generation, stateErr.conditionType, metav1.ConditionTrue, stateErr.reason, stateErr.message)
 
 	if stateErr.conditionType != conditionTypeInvalidRef {
-		setCondition(status, generation, conditionTypeInvalidRef, metav1.ConditionFalse, "Resolved", "References are valid")
+		setCondition(status, generation, conditionTypeInvalidRef, metav1.ConditionFalse, conditionReasonResolved, "References are valid")
 	}
 	if stateErr.conditionType != conditionTypeUnsafeSelector {
-		setCondition(status, generation, conditionTypeUnsafeSelector, metav1.ConditionFalse, "Resolved", "Selectors are safe")
+		setCondition(status, generation, conditionTypeUnsafeSelector, metav1.ConditionFalse, conditionReasonResolved, "Selectors are safe")
 	}
 	if stateErr.conditionType != conditionTypeRenderFailure {
-		setCondition(status, generation, conditionTypeRenderFailure, metav1.ConditionFalse, "Resolved", "Rendering is healthy")
+		setCondition(status, generation, conditionTypeRenderFailure, metav1.ConditionFalse, conditionReasonResolved, "Rendering is healthy")
 	}
 }
 

--- a/internal/controller/inferenceidentitybinding_taxonomy_test.go
+++ b/internal/controller/inferenceidentitybinding_taxonomy_test.go
@@ -1,0 +1,282 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kleymv1alpha1 "github.com/sonda-red/kleym/api/v1alpha1"
+	"github.com/sonda-red/kleym/internal/gaie"
+	"github.com/sonda-red/kleym/internal/identity"
+)
+
+func TestReconcileConditionTaxonomySuccess(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newControllerTestScheme(t)
+	binding := newPoolOnlyBinding("binding-taxonomy-success", "")
+	reconciler := &InferenceIdentityBindingReconciler{
+		Config: testOperatorConfig(),
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+			WithObjects(newTestPool(), binding).
+			Build(),
+		Scheme: scheme,
+	}
+
+	result, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: binding.Name},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("result = %#v, want empty result", result)
+	}
+
+	current := fetchBinding(t, ctx, reconciler.Client, binding.Name)
+	assertSuccessConditionSet(t, current)
+	if len(current.Status.ComputedSpiffeIDs) != 1 {
+		t.Fatalf("computedSpiffeIDs = %d, want 1", len(current.Status.ComputedSpiffeIDs))
+	}
+	if len(current.Status.RenderedSelectors) != 1 {
+		t.Fatalf("renderedSelectors = %d, want 1", len(current.Status.RenderedSelectors))
+	}
+}
+
+func TestReconcileConditionTaxonomyFailures(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		binding       *kleymv1alpha1.InferenceIdentityBinding
+		objects       []client.Object
+		wrapClient    func(client.Client) client.Client
+		wantResult    ctrl.Result
+		wantCondition string
+		wantReason    string
+	}{
+		"missing-pool": {
+			binding:       newPoolOnlyBinding("binding-missing-pool-taxonomy", ""),
+			wantCondition: conditionTypeInvalidRef,
+			wantReason:    gaie.ReasonTargetPoolNotFound,
+		},
+		"invalid-pool-selector": {
+			binding: newPoolOnlyBinding("binding-invalid-selector-taxonomy", ""),
+			objects: []client.Object{
+				testPoolWithSelector("pool-a", map[string]any{"matchLabels": map[string]any{"app": []any{"model-server"}}}),
+			},
+			wantCondition: conditionTypeUnsafeSelector,
+			wantReason:    identity.ReasonInvalidPoolSelector,
+		},
+		"invalid-service-account": {
+			binding:       newPoolBindingWithServiceAccount("binding-invalid-sa-taxonomy", "Invalid_ServiceAccount"),
+			objects:       []client.Object{newTestPool()},
+			wantCondition: conditionTypeRenderFailure,
+			wantReason:    identity.ReasonInvalidServiceAccountName,
+		},
+		"missing-inferencepool-crd": {
+			binding: newPoolOnlyBinding("binding-missing-pool-crd-taxonomy", ""),
+			wrapClient: func(base client.Client) client.Client {
+				return noMatchClient{
+					Client:        base,
+					getNoMatchGVK: inferencePoolGVKs[0],
+				}
+			},
+			wantResult:    ctrl.Result{RequeueAfter: infraNotReadyRequeueAfter},
+			wantCondition: conditionTypeInvalidRef,
+			wantReason:    gaie.ReasonInferencePoolCRDMissing,
+		},
+		"missing-clusterspiffeid-crd": {
+			binding: newPoolOnlyBinding("binding-missing-clusterspiffeid-crd-taxonomy", ""),
+			objects: []client.Object{
+				newTestPool(),
+			},
+			wrapClient: func(base client.Client) client.Client {
+				return noMatchClient{
+					Client:         base,
+					listNoMatchGVK: clusterSPIFFEIDGVK.GroupVersion().WithKind(clusterSPIFFEIDGVK.Kind + "List"),
+				}
+			},
+			wantResult:    ctrl.Result{RequeueAfter: infraNotReadyRequeueAfter},
+			wantCondition: conditionTypeRenderFailure,
+			wantReason:    conditionReasonClusterSPIFFEIDCRDMissing,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			scheme := newControllerTestScheme(t)
+			objects := append([]client.Object{tc.binding}, tc.objects...)
+			baseClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+				WithObjects(objects...).
+				Build()
+			k8sClient := client.Client(baseClient)
+			if tc.wrapClient != nil {
+				k8sClient = tc.wrapClient(baseClient)
+			}
+			reconciler := &InferenceIdentityBindingReconciler{
+				Config: testOperatorConfig(),
+				Client: k8sClient,
+				Scheme: scheme,
+			}
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: tc.binding.Name},
+			})
+			if err != nil {
+				t.Fatalf("Reconcile returned error: %v", err)
+			}
+			if result != tc.wantResult {
+				t.Fatalf("result = %#v, want %#v", result, tc.wantResult)
+			}
+
+			current := fetchBinding(t, ctx, k8sClient, tc.binding.Name)
+			assertPrimaryFailureCondition(t, current, tc.wantCondition, tc.wantReason)
+			if len(current.Status.ComputedSpiffeIDs) != 0 {
+				t.Fatalf("computedSpiffeIDs = %d, want cleared on failure", len(current.Status.ComputedSpiffeIDs))
+			}
+			if len(current.Status.RenderedSelectors) != 0 {
+				t.Fatalf("renderedSelectors = %d, want cleared on failure", len(current.Status.RenderedSelectors))
+			}
+		})
+	}
+}
+
+func assertSuccessConditionSet(t *testing.T, binding *kleymv1alpha1.InferenceIdentityBinding) {
+	t.Helper()
+
+	assertConditionStatusOnBinding(t, binding, conditionTypeReady, metav1.ConditionTrue, conditionReasonReconciled)
+	assertConditionStatusOnBinding(t, binding, conditionTypeInvalidRef, metav1.ConditionFalse, conditionReasonResolved)
+	assertConditionStatusOnBinding(t, binding, conditionTypeUnsafeSelector, metav1.ConditionFalse, conditionReasonResolved)
+	assertConditionStatusOnBinding(t, binding, conditionTypeRenderFailure, metav1.ConditionFalse, conditionReasonResolved)
+}
+
+func assertPrimaryFailureCondition(
+	t *testing.T,
+	binding *kleymv1alpha1.InferenceIdentityBinding,
+	conditionType string,
+	reason string,
+) {
+	t.Helper()
+
+	ready := assertConditionStatusOnBinding(t, binding, conditionTypeReady, metav1.ConditionFalse, reason)
+	if ready.Message == "" {
+		t.Fatalf("Ready condition message is empty for reason %q", reason)
+	}
+	primary := assertConditionStatusOnBinding(t, binding, conditionType, metav1.ConditionTrue, reason)
+	if primary.Message == "" {
+		t.Fatalf("primary condition message is empty for reason %q", reason)
+	}
+
+	for _, candidate := range []string{conditionTypeInvalidRef, conditionTypeUnsafeSelector, conditionTypeRenderFailure} {
+		condition := meta.FindStatusCondition(binding.Status.Conditions, candidate)
+		if condition == nil {
+			t.Fatalf("missing condition %q", candidate)
+		}
+		if candidate == conditionType {
+			continue
+		}
+		if condition.Status != metav1.ConditionFalse || condition.Reason != conditionReasonResolved {
+			t.Fatalf("condition %q = %s/%s, want False/%s", candidate, condition.Status, condition.Reason, conditionReasonResolved)
+		}
+	}
+}
+
+func assertConditionStatusOnBinding(
+	t *testing.T,
+	binding *kleymv1alpha1.InferenceIdentityBinding,
+	conditionType string,
+	expectedStatus metav1.ConditionStatus,
+	expectedReason string,
+) *metav1.Condition {
+	t.Helper()
+
+	condition := meta.FindStatusCondition(binding.Status.Conditions, conditionType)
+	if condition == nil {
+		t.Fatalf("expected condition %q on %s/%s", conditionType, binding.Namespace, binding.Name)
+	}
+	if condition.Status != expectedStatus {
+		t.Fatalf("condition %q status = %q, want %q", conditionType, condition.Status, expectedStatus)
+	}
+	if condition.Reason != expectedReason {
+		t.Fatalf("condition %q reason = %q, want %q", conditionType, condition.Reason, expectedReason)
+	}
+	if condition.ObservedGeneration != binding.Generation {
+		t.Fatalf("condition %q observedGeneration = %d, want %d", conditionType, condition.ObservedGeneration, binding.Generation)
+	}
+	return condition
+}
+
+func fetchBinding(
+	t *testing.T,
+	ctx context.Context,
+	k8sClient client.Client,
+	name string,
+) *kleymv1alpha1.InferenceIdentityBinding {
+	t.Helper()
+
+	binding := &kleymv1alpha1.InferenceIdentityBinding{}
+	key := types.NamespacedName{Namespace: testNamespace, Name: name}
+	if err := k8sClient.Get(ctx, key, binding); err != nil {
+		t.Fatalf("failed to fetch %s: %v", key, err)
+	}
+	return binding
+}
+
+func testPoolWithSelector(name string, selector map[string]any) *unstructured.Unstructured {
+	pool := newTestPool()
+	pool.SetName(name)
+	pool.Object["spec"] = map[string]any{"selector": selector}
+	return pool
+}
+
+type noMatchClient struct {
+	client.Client
+	getNoMatchGVK  schema.GroupVersionKind
+	listNoMatchGVK schema.GroupVersionKind
+}
+
+func (c noMatchClient) Get(
+	ctx context.Context,
+	key types.NamespacedName,
+	obj client.Object,
+	opts ...client.GetOption,
+) error {
+	if c.getNoMatchGVK != (schema.GroupVersionKind{}) && obj.GetObjectKind().GroupVersionKind() == c.getNoMatchGVK {
+		return &meta.NoKindMatchError{
+			GroupKind:        c.getNoMatchGVK.GroupKind(),
+			SearchedVersions: []string{c.getNoMatchGVK.Version},
+		}
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func (c noMatchClient) List(
+	ctx context.Context,
+	list client.ObjectList,
+	opts ...client.ListOption,
+) error {
+	if c.listNoMatchGVK != (schema.GroupVersionKind{}) && list.GetObjectKind().GroupVersionKind() == c.listNoMatchGVK {
+		return &meta.NoKindMatchError{
+			GroupKind:        c.listNoMatchGVK.GroupKind(),
+			SearchedVersions: []string{c.listNoMatchGVK.Version},
+		}
+	}
+	return c.Client.List(ctx, list, opts...)
+}

--- a/internal/gaie/resolver.go
+++ b/internal/gaie/resolver.go
@@ -52,13 +52,13 @@ func ResolveInferencePool(
 	if crdMissing {
 		return nil, newStateError(
 			ConditionTypeInvalidRef,
-			"InferencePoolCRDMissing",
+			ReasonInferencePoolCRDMissing,
 			"InferencePool CRD is not installed",
 		)
 	}
 	return nil, newStateError(
 		ConditionTypeInvalidRef,
-		"TargetPoolNotFound",
+		ReasonTargetPoolNotFound,
 		fmt.Sprintf("poolRef %q was not found", poolRef.Name),
 	)
 }

--- a/internal/gaie/types.go
+++ b/internal/gaie/types.go
@@ -25,6 +25,11 @@ import (
 const (
 	// ConditionTypeInvalidRef matches the controller status condition for invalid input references.
 	ConditionTypeInvalidRef = "InvalidRef"
+
+	// ReasonInferencePoolCRDMissing reports that the GAIE InferencePool CRD is unavailable.
+	ReasonInferencePoolCRDMissing = "InferencePoolCRDMissing"
+	// ReasonTargetPoolNotFound reports that the referenced InferencePool object does not exist.
+	ReasonTargetPoolNotFound = "TargetPoolNotFound"
 )
 
 // StateError carries condition metadata for shared GAIE computation errors.

--- a/internal/identity/render.go
+++ b/internal/identity/render.go
@@ -29,7 +29,7 @@ func PlanIdentity(input PlanInput) (Plan, error) {
 	if strings.TrimSpace(input.TrustDomain) == "" {
 		return Plan{}, newStateError(
 			ConditionTypeRenderFailure,
-			"MissingTrustDomain",
+			ReasonMissingTrustDomain,
 			"trustDomain must be configured before Kleym can render SPIFFE IDs",
 		)
 	}
@@ -44,7 +44,7 @@ func PlanIdentity(input PlanInput) (Plan, error) {
 	if err != nil {
 		return Plan{}, newStateError(
 			ConditionTypeRenderFailure,
-			"InvalidServiceAccountName",
+			ReasonInvalidServiceAccountName,
 			err.Error(),
 		)
 	}
@@ -54,7 +54,7 @@ func PlanIdentity(input PlanInput) (Plan, error) {
 	if err := validateRenderedSafetySelectors(binding.Namespace, selectors); err != nil {
 		return Plan{}, newStateError(
 			ConditionTypeUnsafeSelector,
-			"UnsafeSelector",
+			ReasonUnsafeSelector,
 			err.Error(),
 		)
 	}
@@ -63,7 +63,7 @@ func PlanIdentity(input PlanInput) (Plan, error) {
 	if !strings.HasPrefix(spiffeID, "spiffe://") {
 		return Plan{}, newStateError(
 			ConditionTypeRenderFailure,
-			"InvalidSPIFFEID",
+			ReasonInvalidSPIFFEID,
 			fmt.Sprintf("computed SPIFFE ID %q must start with spiffe://", spiffeID),
 		)
 	}

--- a/internal/identity/types.go
+++ b/internal/identity/types.go
@@ -30,6 +30,17 @@ const (
 	ConditionTypeUnsafeSelector = "UnsafeSelector"
 	// ConditionTypeRenderFailure matches the controller status condition for render failures.
 	ConditionTypeRenderFailure = "RenderFailure"
+
+	// ReasonMissingTrustDomain reports missing operator identity configuration.
+	ReasonMissingTrustDomain = "MissingTrustDomain"
+	// ReasonInvalidServiceAccountName reports an invalid binding service account boundary.
+	ReasonInvalidServiceAccountName = "InvalidServiceAccountName"
+	// ReasonUnsafeSelector reports a rendered selector set that violates safety invariants.
+	ReasonUnsafeSelector = "UnsafeSelector"
+	// ReasonInvalidSPIFFEID reports a computed SPIFFE ID that fails validation.
+	ReasonInvalidSPIFFEID = "InvalidSPIFFEID"
+	// ReasonInvalidPoolSelector reports a GAIE pool selector that cannot be rendered safely.
+	ReasonInvalidPoolSelector = "InvalidPoolSelector"
 )
 
 // StateError carries condition metadata for shared identity computation errors.

--- a/internal/inspection/inspection.go
+++ b/internal/inspection/inspection.go
@@ -332,7 +332,7 @@ func (i *bindingInspector) inspectRenderedIdentity(
 		report.Capabilities.GAIEResources = BindingInspectionCapabilityFull
 		i.addFindingForError(report, &identity.StateError{
 			ConditionType: identity.ConditionTypeUnsafeSelector,
-			Reason:        "InvalidPoolSelector",
+			Reason:        identity.ReasonInvalidPoolSelector,
 			Message:       err.Error(),
 		}, *report.Resolved.PoolRef, "")
 		return identity.RenderedIdentity{}, false


### PR DESCRIPTION
## Summary

- Define the current `InferenceIdentityBinding` condition taxonomy as a stable status contract.
- Centralize condition reason strings used by controller, GAIE, identity rendering, and inspection paths.
- Add controller coverage for success, invalid ref, unsafe selector, render failure, and dependency-unavailable paths.

## What I Changed And Why

- Updated `docs/spec/operator.md`, `docs/reference/conditions.md`, and `docs/troubleshooting.md` with the allowed condition types, reason strings, and dependency-unavailable classification.
- Replaced scattered status reason string literals with named constants where those values are part of the contract.
- Added `internal/controller/inferenceidentitybinding_taxonomy_test.go` to cover primary failure selection, `Ready=False` reason/message mirroring, dependency-unavailable classification, and resolved inactive failure conditions.

## Related Issue

- Closes #215

## Scope Check

- This PR normalizes the current binding status taxonomy for `Ready`, `InvalidRef`, `UnsafeSelector`, and `RenderFailure`.
- It keeps condition behavior aligned with the current operator spec and troubleshooting/reference docs.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): updated with the condition taxonomy, allowed reasons, and dependency-unavailable classification.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI command behavior and output schema did not change.
- Other docs: updated `docs/reference/conditions.md` and `docs/troubleshooting.md`; inspected rendered conditions page metadata and sitemap after `make docs-build`.

## Follow-Up Work

- Proposed follow-up issue(s), if any: #252 adds exhaustive tests for every allowed reason string.

## Verification

- Commands run:
  - `make test`
  - `make lint`
  - `make docs-build`
  - `git diff --check`
  - inspected `public/reference/conditions/index.html` head metadata and `public/sitemap.xml`
- Tests not run and why: `make test-e2e-chainsaw` was not run because this change is covered by unit/envtest and docs build checks.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or secret handling.
- It updates the operator status contract and dependency-failure classification.