### PR TITLE
test(controller): pin condition taxonomy reasons

### DIFF
--- a/internal/controller/inferenceidentitybinding_status_test.go
+++ b/internal/controller/inferenceidentitybinding_status_test.go
@@ -69,3 +69,32 @@ func TestInitializeConditionsEnsuresCanonicalSetForCurrentGeneration(t *testing.
 		t.Fatalf("stale Conflict condition was not removed: %#v", conflict)
 	}
 }
+
+func TestInitializeConditionsSetsUnevaluatedConditionsToInitializing(t *testing.T) {
+	t.Parallel()
+
+	status := kleymv1alpha1.InferenceIdentityBindingStatus{}
+
+	initializeConditions(&status, 3)
+
+	for _, conditionType := range []string{
+		conditionTypeReady,
+		conditionTypeInvalidRef,
+		conditionTypeUnsafeSelector,
+		conditionTypeRenderFailure,
+	} {
+		condition := meta.FindStatusCondition(status.Conditions, conditionType)
+		if condition == nil {
+			t.Fatalf("expected condition %q to be present", conditionType)
+		}
+		if condition.Status != metav1.ConditionUnknown {
+			t.Fatalf("condition %q status = %q, want %q", conditionType, condition.Status, metav1.ConditionUnknown)
+		}
+		if condition.Reason != conditionReasonInitializing {
+			t.Fatalf("condition %q reason = %q, want %q", conditionType, condition.Reason, conditionReasonInitializing)
+		}
+		if condition.ObservedGeneration != 3 {
+			t.Fatalf("condition %q observedGeneration = %d, want 3", conditionType, condition.ObservedGeneration)
+		}
+	}
+}

--- a/internal/controller/inferenceidentitybinding_taxonomy_test.go
+++ b/internal/controller/inferenceidentitybinding_taxonomy_test.go
@@ -60,12 +60,22 @@ func TestReconcileConditionTaxonomyFailures(t *testing.T) {
 
 	cases := map[string]struct {
 		binding       *kleymv1alpha1.InferenceIdentityBinding
+		config        *OperatorConfig
 		objects       []client.Object
 		wrapClient    func(client.Client) client.Client
 		wantResult    ctrl.Result
 		wantCondition string
 		wantReason    string
 	}{
+		"invalid-pool-ref": {
+			binding: func() *kleymv1alpha1.InferenceIdentityBinding {
+				binding := newPoolOnlyBinding("binding-invalid-pool-ref-taxonomy", "")
+				binding.Spec.PoolRef.Name = " "
+				return binding
+			}(),
+			wantCondition: conditionTypeInvalidRef,
+			wantReason:    conditionReasonInvalidPoolRef,
+		},
 		"missing-pool": {
 			binding:       newPoolOnlyBinding("binding-missing-pool-taxonomy", ""),
 			wantCondition: conditionTypeInvalidRef,
@@ -84,6 +94,13 @@ func TestReconcileConditionTaxonomyFailures(t *testing.T) {
 			objects:       []client.Object{newTestPool()},
 			wantCondition: conditionTypeRenderFailure,
 			wantReason:    identity.ReasonInvalidServiceAccountName,
+		},
+		"missing-trust-domain": {
+			binding:       newPoolOnlyBinding("binding-missing-trust-domain-taxonomy", ""),
+			config:        &OperatorConfig{},
+			objects:       []client.Object{newTestPool()},
+			wantCondition: conditionTypeRenderFailure,
+			wantReason:    identity.ReasonMissingTrustDomain,
 		},
 		"missing-inferencepool-crd": {
 			binding: newPoolOnlyBinding("binding-missing-pool-crd-taxonomy", ""),
@@ -130,8 +147,12 @@ func TestReconcileConditionTaxonomyFailures(t *testing.T) {
 			if tc.wrapClient != nil {
 				k8sClient = tc.wrapClient(baseClient)
 			}
+			config := testOperatorConfig()
+			if tc.config != nil {
+				config = *tc.config
+			}
 			reconciler := &InferenceIdentityBindingReconciler{
-				Config: testOperatorConfig(),
+				Config: config,
 				Client: k8sClient,
 				Scheme: scheme,
 			}
@@ -153,6 +174,38 @@ func TestReconcileConditionTaxonomyFailures(t *testing.T) {
 			}
 			if len(current.Status.RenderedSelectors) != 0 {
 				t.Fatalf("renderedSelectors = %d, want cleared on failure", len(current.Status.RenderedSelectors))
+			}
+		})
+	}
+}
+
+func TestConditionTaxonomyAllowedReasonStrings(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		got  string
+		want string
+	}{
+		"ready-reconciled":             {got: conditionReasonReconciled, want: "Reconciled"},
+		"inactive-resolved":            {got: conditionReasonResolved, want: "Resolved"},
+		"unevaluated-initializing":     {got: conditionReasonInitializing, want: "Initializing"},
+		"invalid-pool-ref":             {got: conditionReasonInvalidPoolRef, want: "InvalidPoolRef"},
+		"target-pool-not-found":        {got: gaie.ReasonTargetPoolNotFound, want: "TargetPoolNotFound"},
+		"inferencepool-crd-missing":    {got: gaie.ReasonInferencePoolCRDMissing, want: "InferencePoolCRDMissing"},
+		"invalid-pool-selector":        {got: identity.ReasonInvalidPoolSelector, want: "InvalidPoolSelector"},
+		"unsafe-selector":              {got: identity.ReasonUnsafeSelector, want: "UnsafeSelector"},
+		"missing-trust-domain":         {got: identity.ReasonMissingTrustDomain, want: "MissingTrustDomain"},
+		"invalid-service-account-name": {got: identity.ReasonInvalidServiceAccountName, want: "InvalidServiceAccountName"},
+		"invalid-spiffe-id":            {got: identity.ReasonInvalidSPIFFEID, want: "InvalidSPIFFEID"},
+		"clusterspiffeid-crd-missing":  {got: conditionReasonClusterSPIFFEIDCRDMissing, want: "ClusterSPIFFEIDCRDMissing"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.got != tc.want {
+				t.Fatalf("reason = %q, want %q", tc.got, tc.want)
 			}
 		})
 	}
@@ -182,6 +235,9 @@ func assertPrimaryFailureCondition(
 	primary := assertConditionStatusOnBinding(t, binding, conditionType, metav1.ConditionTrue, reason)
 	if primary.Message == "" {
 		t.Fatalf("primary condition message is empty for reason %q", reason)
+	}
+	if ready.Message != primary.Message {
+		t.Fatalf("Ready message = %q, want primary failure message %q", ready.Message, primary.Message)
 	}
 
 	for _, candidate := range []string{conditionTypeInvalidRef, conditionTypeUnsafeSelector, conditionTypeRenderFailure} {

--- a/internal/gaie/resolver_test.go
+++ b/internal/gaie/resolver_test.go
@@ -98,6 +98,28 @@ func TestResolveInferencePoolPropagatesUnexpectedReaderError(t *testing.T) {
 	}
 }
 
+func TestConditionTaxonomyReasonStrings(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		got  string
+		want string
+	}{
+		"inferencepool-crd-missing": {got: ReasonInferencePoolCRDMissing, want: "InferencePoolCRDMissing"},
+		"target-pool-not-found":     {got: ReasonTargetPoolNotFound, want: "TargetPoolNotFound"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.got != tc.want {
+				t.Fatalf("reason = %q, want %q", tc.got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDeriveSelectorsFromPoolKeepsFlatStringMapCompatibility(t *testing.T) {
 	t.Parallel()
 

--- a/internal/identity/render_test.go
+++ b/internal/identity/render_test.go
@@ -86,6 +86,50 @@ func TestPlanIdentityRejectsMissingTrustDomain(t *testing.T) {
 	}
 }
 
+func TestPlanIdentityRejectsUnsafeSelector(t *testing.T) {
+	t.Parallel()
+
+	input := testPlanInput(testBinding(), "pool-a")
+	input.PoolDerivedSelectors = append(input.PoolDerivedSelectors, "k8s:ns:other")
+
+	_, err := PlanIdentity(input)
+	if err == nil {
+		t.Fatalf("expected unsafe selector error, got nil")
+	}
+	var stateErr *StateError
+	if !errors.As(err, &stateErr) {
+		t.Fatalf("expected StateError, got %T", err)
+	}
+	if stateErr.ConditionType != ConditionTypeUnsafeSelector || stateErr.Reason != "UnsafeSelector" {
+		t.Fatalf("condition/reason = %q/%q, want %q/UnsafeSelector", stateErr.ConditionType, stateErr.Reason, ConditionTypeUnsafeSelector)
+	}
+}
+
+func TestConditionTaxonomyReasonStrings(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		got  string
+		want string
+	}{
+		"missing-trust-domain":         {got: ReasonMissingTrustDomain, want: "MissingTrustDomain"},
+		"invalid-service-account-name": {got: ReasonInvalidServiceAccountName, want: "InvalidServiceAccountName"},
+		"unsafe-selector":              {got: ReasonUnsafeSelector, want: "UnsafeSelector"},
+		"invalid-spiffe-id":            {got: ReasonInvalidSPIFFEID, want: "InvalidSPIFFEID"},
+		"invalid-pool-selector":        {got: ReasonInvalidPoolSelector, want: "InvalidPoolSelector"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.got != tc.want {
+				t.Fatalf("reason = %q, want %q", tc.got, tc.want)
+			}
+		})
+	}
+}
+
 func testBinding() *kleymv1alpha1.InferenceIdentityBinding {
 	return &kleymv1alpha1.InferenceIdentityBinding{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

- Add focused taxonomy tests that pin the current `InferenceIdentityBinding` condition reason strings.
- Cover initialization and `Ready=False` primary-failure reason/message mirroring.
- Add narrow package-level coverage for GAIE and identity-owned reason constants.

## What I Changed And Why

- Expanded controller taxonomy coverage for `InvalidPoolRef` and `MissingTrustDomain` reconcile paths so those documented reasons are exercised through status reconciliation.
- Added an initialization test proving unevaluated canonical conditions start as `Unknown/Initializing` for the current generation.
- Added literal reason-string tests in controller, GAIE resolver, and identity rendering packages so contract reason strings fail loudly on accidental drift.
- Added identity-layer unsafe-selector coverage because that reason is owned below full reconcile.

## Related Issue

- Closes #252

## Scope Check

- This PR is limited to condition-taxonomy test coverage.
- It does not change production behavior, generated manifests, CLI behavior, or documentation.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because the documented taxonomy did not change.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI behavior and output did not change.
- Other docs: not needed because this is test-only coverage for the existing contract.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `make test` — passed.
  - `make lint` — passed, 0 issues.
  - `git diff --check` — passed.
- Tests not run and why: `make test-e2e-chainsaw` was not run because this is unit/envtest coverage for the existing status taxonomy and does not change cluster behavior.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or secret handling.
- It changes tests only and does not alter runtime trust boundaries.