### PR TITLE
docs: clarify current inference identity model

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,10 +1,18 @@
 ---
 title: Concepts
 weight: 10
-description: "Kleym concepts for Gateway API Inference Extension InferencePool inputs, pool identity, and selector safety."
+description: "Kleym concepts for inference workload identity, Gateway API Inference Extension InferencePool inputs, pool identity, and selector safety."
 aliases:
   - /operator/concepts/
 ---
+
+## Inference Workload Identity
+
+Kleym uses inference workload identity to mean identity registration derived from a Kubernetes inference serving boundary, not from a pod alone. In the current contract, that serving boundary is a Gateway API Inference Extension (GAIE) `InferencePool` referenced by an `InferenceIdentityBinding`.
+
+The binding namespace and required service account constrain which workloads may match. Selectors from the referenced pool provide workload provenance. `kleym-operator` combines those facts to render one deterministic pool SPIFFE ID and reconcile a managed SPIRE Controller Manager `ClusterSPIFFEID`.
+
+This stops at identity registration. Kleym does not deploy inference workloads, route traffic, configure gateways, evaluate request policy, issue credentials, or prove runtime SVID use. The authoritative behavior is defined in the [Operator Spec](/spec/operator/).
 
 ## GAIE Resources
 


### PR DESCRIPTION
## Summary

- Fold the inference workload identity explanation into the existing Concepts page.
- Keep the wording anchored to the current pool-only Kleym contract.
- Avoid adding a standalone canonical route or alias for the broader term.

## What I Changed And Why

- Added a short `Inference Workload Identity` section to `docs/concepts.md`.
- Described the current implemented model: `InferenceIdentityBinding` + GAIE `InferencePool` + namespace/service account/selector boundary → deterministic SPIFFE ID → managed `ClusterSPIFFEID`.
- Pointed readers to the Operator Spec for the authoritative behavior.
- Updated the Concepts page description so rendered metadata reflects the added section.

## Related Issue

- Closes #229

## Scope Check

- Follows the re-scoped issue direction by keeping the explanation in `docs/concepts.md`.
- Does not add `/concepts/inference-workload-identity/` or `/inference-workload-identity/`.
- Does not present `InferenceObjective`, objective-backed identity, SVID config, gateway policy, request authorization, runtime proof, or future source families as current behavior.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not changed because the existing spec already defines the current pool-only identity registration contract.
- CLI Spec (`docs/spec/cli.md`): not needed because this is docs-only concept wording and does not change CLI behavior.
- Other docs: updated `docs/concepts.md`.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none for this docs clarification. Future SVID consumption/validation design remains separate in #236 if still wanted.

## Verification

- Commands run:
  - `git diff --check`
  - `make docs-build`
  - Rendered output inspection: confirmed `public/concepts/index.html` contains the updated description, section heading, Operator Spec link, canonical concepts URL, and JSON-LD; confirmed `public/sitemap.xml` includes `https://kleym.sonda.red/concepts/`; confirmed no generated standalone `/concepts/inference-workload-identity/` or `/inference-workload-identity/` route exists.
- Tests not run and why: Go/controller tests were not run because this PR only changes docs prose.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or runtime trust boundaries.
- It preserves the existing Kleym boundary wording: identity registration only, no credential issuance or request-time enforcement.