### PR TITLE
docs(operator): stabilize rendered selector contract

### DIFF
--- a/docs/design/selector-safety.md
+++ b/docs/design/selector-safety.md
@@ -11,6 +11,10 @@ aliases:
 The controller writes identities for workloads that match the referenced pool,
 binding namespace, and required service account selectors.
 
+The authoritative rendered selector contract lives in
+[Operator Spec](/spec/operator/#rendered-selector-contract). This design note
+explains the safety rationale and must not broaden that contract.
+
 ## Current Safety Layers
 
 The current implementation requires:
@@ -36,9 +40,10 @@ It rejects:
 
 - empty selectors
 - empty label keys or values
+- non-string label values
 - label keys or values that do not satisfy Kubernetes label syntax
 - label values with leading or trailing whitespace
-- `matchExpressions`
+- any `matchExpressions` field
 - pool selectors that cannot be decoded into a stable label map
 
 The controller renders pool labels directly into SPIRE workload selectors, so it
@@ -49,3 +54,5 @@ did not specify. `matchExpressions` are not rendered.
 
 Users provide only `serviceAccountName`. Kleym renders the namespace and
 service-account selectors internally and derives pool selectors from `poolRef`.
+The final selector set is de-duplicated and sorted before it is reported in
+status or written to managed `ClusterSPIFFEID` output.

--- a/docs/reference/gaie-compatibility.md
+++ b/docs/reference/gaie-compatibility.md
@@ -22,9 +22,9 @@ GVK examples:
 `spec.selector.matchLabels` or a flat selector map that can be normalized into
 `matchLabels`.
 
-`kleym-operator` rejects empty selectors, invalid label keys or values, values with leading
-or trailing whitespace, non-empty `matchExpressions`, and selector shapes that
-cannot be decoded into a stable label map.
+`kleym-operator` rejects empty selectors, invalid label keys or values, non-string
+values, values with leading or trailing whitespace, any `matchExpressions` field,
+and selector shapes that cannot be decoded into a stable label map.
 
 ## Discovery Behavior
 

--- a/docs/reference/resources.md
+++ b/docs/reference/resources.md
@@ -17,12 +17,16 @@ resources in `spire.spiffe.io`.
 | Field | Rendered value |
 | --- | --- |
 | `spec.spiffeIDTemplate` | Fully rendered SPIFFE ID. |
-| `spec.podSelector` | Validated selector derived from the referenced pool. |
-| `spec.workloadSelectorTemplates` | Rendered namespace and service-account safety selectors plus pool-derived selectors. |
+| `spec.podSelector` | Validated pool selector from the referenced pool, normalized to `matchLabels` when the compatibility flat string-map form is used. |
+| `spec.workloadSelectorTemplates` | Canonical selector set: internally rendered namespace and service-account selectors plus pool-derived `k8s:pod-label` selectors, de-duplicated and sorted. |
 | `spec.className` | Rendered only when `kleym-operator` is configured with `--clusterspiffeid-class-name`. When omitted, SPIRE Controller Manager must watch classless resources. |
 | `spec.fallback` | `false` for all managed identities. |
 | `spec.hint` | Originating binding reference in the form `<namespace>/<binding-name>`. |
 | JWT-SVID-related fields | Not rendered today. Requires a user story and SPIRE Controller Manager/SPIRE version gate. |
+
+Selector provenance and unsupported pool selector inputs are defined by the
+[Operator Spec](/spec/operator/#rendered-selector-contract). Managed resources
+do not add selector sources beyond that contract.
 
 Managed `ClusterSPIFFEID` objects are labeled with:
 

--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -51,6 +51,50 @@ When `--clusterspiffeid-class-name` is empty, SPIRE Controller Manager must be c
 
 Field details live in [API Reference][api-reference]. Condition details live in [Conditions Reference][conditions-reference].
 
+## Rendered Selector Contract
+
+The current selector contract is pool-only. A binding accepts only
+`spec.poolRef` and `spec.serviceAccountName`; it does not accept user-supplied
+selector lists or selector source modes.
+
+Every rendered identity selector set is assembled from these sources:
+
+1. Mandatory namespace selector rendered internally from the binding namespace:
+   `k8s:ns:<binding namespace>`.
+2. Mandatory service-account selector rendered internally from
+   `spec.serviceAccountName`: `k8s:sa:<serviceAccountName>`.
+3. Pool-derived selectors rendered from the referenced `InferencePool`
+   `spec.selector.matchLabels`.
+
+The only pool selector compatibility form is an existing flat string map under
+`spec.selector`; Kleym normalizes it to `matchLabels` before rendering. Pool
+labels render directly to `k8s:pod-label:<key>:<value>` workload selectors.
+
+Unsupported pool selector input is refused, including:
+
+- missing or empty `spec.selector`
+- empty `matchLabels`
+- empty or malformed label keys
+- empty, malformed, or non-string label values
+- label values with leading or trailing whitespace
+- any `matchExpressions` field, including an empty array
+- selector shapes that cannot be decoded into deterministic string
+  `matchLabels`
+
+Rendered selector sets are canonical. Kleym removes duplicate selector strings
+and sorts the remaining strings lexicographically before writing
+`status.renderedSelectors`, managed `ClusterSPIFFEID`
+`spec.workloadSelectorTemplates`, or any future rendered selector fingerprint.
+The canonical set preserves provenance by selector form: namespace and
+service-account selectors are binding-derived, and `k8s:pod-label` selectors are
+pool-derived.
+
+Malformed or unsupported pool selector input fails reconciliation with
+`UnsafeSelector=True` reason `InvalidPoolSelector`. A rendered selector set that
+would omit or escape the mandatory namespace or service-account boundary fails
+with `UnsafeSelector=True` reason `UnsafeSelector`. Selector failures produce no
+managed output and clear `computedSpiffeIDs` plus `renderedSelectors` in status.
+
 ## Required Behavior
 
 1. Discover the supported GAIE pool GVK served by the cluster and watch it.

--- a/internal/controller/inferenceidentitybinding_status_test.go
+++ b/internal/controller/inferenceidentitybinding_status_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"slices"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -96,5 +97,28 @@ func TestInitializeConditionsSetsUnevaluatedConditionsToInitializing(t *testing.
 		if condition.ObservedGeneration != 3 {
 			t.Fatalf("condition %q observedGeneration = %d, want 3", conditionType, condition.ObservedGeneration)
 		}
+	}
+}
+
+func TestApplySuccessStatusRecordsRenderedSelectors(t *testing.T) {
+	t.Parallel()
+
+	status := kleymv1alpha1.InferenceIdentityBindingStatus{}
+	wantSelectors := []string{
+		"k8s:ns:default",
+		"k8s:pod-label:app:model-server",
+		"k8s:sa:inference-sa",
+	}
+
+	applySuccessStatus(&status, 4, []renderedIdentity{{
+		SpiffeID:  "spiffe://example.org/ns/default/pool/pool-a",
+		Selectors: wantSelectors,
+	}})
+
+	if len(status.RenderedSelectors) != 1 {
+		t.Fatalf("renderedSelectors = %d, want 1", len(status.RenderedSelectors))
+	}
+	if !slices.Equal(status.RenderedSelectors[0].Selectors, wantSelectors) {
+		t.Fatalf("selectors = %v, want %v", status.RenderedSelectors[0].Selectors, wantSelectors)
 	}
 }

--- a/internal/gaie/resolver.go
+++ b/internal/gaie/resolver.go
@@ -101,8 +101,17 @@ func DeriveSelectorsFromPool(pool *unstructured.Unstructured) (map[string]any, [
 		return nil, nil, fmt.Errorf("pool spec.selector must be set")
 	}
 
+	if _, hasExpressions := selectorMap["matchExpressions"]; hasExpressions {
+		return nil, nil, fmt.Errorf("pool spec.selector.matchExpressions are not supported")
+	}
+
 	var matchLabels map[string]any
 	if rawMatchLabels, hasMatchLabels := selectorMap["matchLabels"]; hasMatchLabels {
+		for key := range selectorMap {
+			if key != "matchLabels" {
+				return nil, nil, fmt.Errorf("pool spec.selector.%s is not supported", key)
+			}
+		}
 		typedMatchLabels, ok := rawMatchLabels.(map[string]any)
 		if !ok {
 			return nil, nil, fmt.Errorf("pool spec.selector.matchLabels must be an object")
@@ -121,10 +130,6 @@ func DeriveSelectorsFromPool(pool *unstructured.Unstructured) (map[string]any, [
 		}
 		matchLabels = selectorMap
 		selectorMap = map[string]any{"matchLabels": matchLabels}
-	}
-
-	if _, hasExpressions := selectorMap["matchExpressions"]; hasExpressions {
-		return nil, nil, fmt.Errorf("pool spec.selector.matchExpressions are not supported")
 	}
 
 	if len(matchLabels) == 0 {

--- a/internal/gaie/resolver.go
+++ b/internal/gaie/resolver.go
@@ -123,14 +123,8 @@ func DeriveSelectorsFromPool(pool *unstructured.Unstructured) (map[string]any, [
 		selectorMap = map[string]any{"matchLabels": matchLabels}
 	}
 
-	if rawExpressions, hasExpressions := selectorMap["matchExpressions"]; hasExpressions {
-		expressions, ok := rawExpressions.([]any)
-		if !ok {
-			return nil, nil, fmt.Errorf("pool spec.selector.matchExpressions must be an array")
-		}
-		if len(expressions) > 0 {
-			return nil, nil, fmt.Errorf("pool spec.selector.matchExpressions are not supported")
-		}
+	if _, hasExpressions := selectorMap["matchExpressions"]; hasExpressions {
+		return nil, nil, fmt.Errorf("pool spec.selector.matchExpressions are not supported")
 	}
 
 	if len(matchLabels) == 0 {

--- a/internal/gaie/resolver_test.go
+++ b/internal/gaie/resolver_test.go
@@ -195,6 +195,60 @@ func TestDeriveSelectorsFromPoolRejectsInvalidMatchLabels(t *testing.T) {
 	}
 }
 
+func TestDeriveSelectorsFromPoolRejectsUnsupportedSelectorShapes(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		selector any
+		wantErr  string
+	}{
+		"empty-selector": {
+			selector: map[string]any{},
+			wantErr:  "pool spec.selector must be set",
+		},
+		"empty-match-labels": {
+			selector: map[string]any{"matchLabels": map[string]any{}},
+			wantErr:  "pool spec.selector.matchLabels must not be empty",
+		},
+		"match-expressions": {
+			selector: map[string]any{
+				"matchLabels":      map[string]any{"app": "model-server"},
+				"matchExpressions": []any{},
+			},
+			wantErr: "pool spec.selector.matchExpressions are not supported",
+		},
+		"flat-non-string-value": {
+			selector: map[string]any{"app": float64(1)},
+			wantErr:  "pool selector must use matchLabels for deterministic rendering",
+		},
+		"non-map-match-labels": {
+			selector: map[string]any{"matchLabels": []any{"app=model-server"}},
+			wantErr:  "pool spec.selector.matchLabels must be an object",
+		},
+		"non-decodable-selector": {
+			selector: []any{"app=model-server"},
+			wantErr:  "failed to decode pool spec.selector",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			pool := testPool("pool-unsupported-selector")
+			pool.Object["spec"] = map[string]any{"selector": tc.selector}
+
+			_, _, err := DeriveSelectorsFromPool(pool)
+			if err == nil {
+				t.Fatalf("expected unsupported selector error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %q, want to contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
 func registerUnstructuredGVK(scheme *runtime.Scheme, gvk schema.GroupVersionKind) {
 	scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
 	scheme.AddKnownTypeWithName(gvk.GroupVersion().WithKind(gvk.Kind+"List"), &unstructured.UnstructuredList{})

--- a/internal/gaie/resolver_test.go
+++ b/internal/gaie/resolver_test.go
@@ -217,6 +217,24 @@ func TestDeriveSelectorsFromPoolRejectsUnsupportedSelectorShapes(t *testing.T) {
 			},
 			wantErr: "pool spec.selector.matchExpressions are not supported",
 		},
+		"match-expressions-without-match-labels": {
+			selector: map[string]any{"matchExpressions": []any{}},
+			wantErr:  "pool spec.selector.matchExpressions are not supported",
+		},
+		"match-labels-with-flat-selector-field": {
+			selector: map[string]any{
+				"matchLabels": map[string]any{"app": "model-server"},
+				"app":         "other-server",
+			},
+			wantErr: "pool spec.selector.app is not supported",
+		},
+		"match-labels-with-unknown-object-field": {
+			selector: map[string]any{
+				"matchLabels": map[string]any{"app": "model-server"},
+				"matchFields": []any{},
+			},
+			wantErr: "pool spec.selector.matchFields is not supported",
+		},
 		"flat-non-string-value": {
 			selector: map[string]any{"app": float64(1)},
 			wantErr:  "pool selector must use matchLabels for deterministic rendering",

--- a/internal/identity/render_test.go
+++ b/internal/identity/render_test.go
@@ -2,6 +2,7 @@ package identity
 
 import (
 	"errors"
+	"slices"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,6 +64,35 @@ func TestPlanIdentityUsesPoolSPIFFEID(t *testing.T) {
 		if !containsString(identity.Selectors, expectedSelector) {
 			t.Fatalf("expected selector %q, selectors: %v", expectedSelector, identity.Selectors)
 		}
+	}
+}
+
+func TestPlanIdentityCanonicalizesRenderedSelectors(t *testing.T) {
+	t.Parallel()
+
+	input := testPlanInput(testBinding(), "pool-a")
+	input.PoolDerivedSelectors = []string{
+		"k8s:pod-label:z:last",
+		"k8s:pod-label:app:model-server",
+		"k8s:pod-label:app:model-server",
+		"k8s:sa:inference-sa",
+		"k8s:pod-label:team:ml",
+	}
+
+	identity, err := PlanIdentity(input)
+	if err != nil {
+		t.Fatalf("PlanIdentity returned error: %v", err)
+	}
+
+	wantSelectors := []string{
+		"k8s:ns:default",
+		"k8s:pod-label:app:model-server",
+		"k8s:pod-label:team:ml",
+		"k8s:pod-label:z:last",
+		"k8s:sa:inference-sa",
+	}
+	if !slices.Equal(identity.Selectors, wantSelectors) {
+		t.Fatalf("selectors = %v, want %v", identity.Selectors, wantSelectors)
 	}
 }
 

--- a/internal/spirecm/clusterspiffeid_test.go
+++ b/internal/spirecm/clusterspiffeid_test.go
@@ -1,6 +1,7 @@
 package spirecm
 
 import (
+	"slices"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -34,6 +35,52 @@ func TestDesiredClusterSPIFFEIDIncludesHintAndFallback(t *testing.T) {
 	}
 	if spec["fallback"] != false {
 		t.Fatalf("fallback = %v, want false", spec["fallback"])
+	}
+}
+
+func TestDesiredClusterSPIFFEIDUsesCanonicalSelectorTemplates(t *testing.T) {
+	t.Parallel()
+
+	binding := &kleymv1alpha1.InferenceIdentityBinding{}
+	binding.Name = "binding-a"
+	binding.Namespace = "default"
+	binding.Spec.ServiceAccountName = "inference-sa"
+	plan, err := identity.PlanIdentity(identity.PlanInput{
+		Binding:     binding,
+		TrustDomain: "example.org",
+		PoolName:    "pool-a",
+		PodSelector: map[string]any{"matchLabels": map[string]any{"app": "model-server"}},
+		PoolDerivedSelectors: []string{
+			"k8s:pod-label:team:ml",
+			"k8s:pod-label:app:model-server",
+			"k8s:pod-label:app:model-server",
+		},
+	})
+	if err != nil {
+		t.Fatalf("PlanIdentity returned error: %v", err)
+	}
+
+	desired := DesiredClusterSPIFFEID(binding, plan, "")
+	gotSelectors, found, err := unstructured.NestedStringSlice(
+		desired.Object,
+		"spec",
+		"workloadSelectorTemplates",
+	)
+	if err != nil {
+		t.Fatalf("failed to inspect workloadSelectorTemplates: %v", err)
+	}
+	if !found {
+		t.Fatal("workloadSelectorTemplates missing")
+	}
+
+	wantSelectors := []string{
+		"k8s:ns:default",
+		"k8s:pod-label:app:model-server",
+		"k8s:pod-label:team:ml",
+		"k8s:sa:inference-sa",
+	}
+	if !slices.Equal(gotSelectors, wantSelectors) {
+		t.Fatalf("workloadSelectorTemplates = %v, want %v", gotSelectors, wantSelectors)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Define the pool-only rendered selector contract in the operator spec.
- Align selector-safety, GAIE compatibility, and managed-resource references with that contract.
- Add focused tests for selector canonicalization and unsupported pool selector input.

## What I Changed And Why

- Added an authoritative `Rendered Selector Contract` section to `docs/spec/operator.md` covering selector sources, mandatory selectors, pool-derived selectors, unsupported input, canonical ordering/de-duplication, provenance, and failure behavior.
- Updated related docs so they point back to the operator spec instead of carrying looser selector wording.
- Tightened pool selector derivation so any `matchExpressions` field is rejected rather than ignored, matching the documented matchLabels-only rendering contract.
- Added focused tests that prove canonical selector ordering/de-duplication reaches identity plans, binding status, and managed `ClusterSPIFFEID` workload selector templates.

## Related Issue

- Closes #213

## Scope Check

- This PR follows #213 by stabilizing the current pool-only selector contract for `InferenceIdentityBinding`.
- Left out of scope: SPIFFE ID shape changes, public API changes, new selector sources, source-family abstractions, and objective-era behavior.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): updated with the authoritative rendered selector contract.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI command behavior and output shape do not change.
- Other docs: updated `docs/design/selector-safety.md`, `docs/reference/resources.md`, and `docs/reference/gaie-compatibility.md` to stay aligned with the operator spec.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `git diff --check`
  - `go test ./internal/identity ./internal/gaie ./internal/spirecm`
  - `go test ./internal/controller -run 'TestApplySuccessStatusRecordsRenderedSelectors|TestRenderIdentityMapsInvalidPoolSelectorToUnsafeSelector|TestRenderIdentityPassesValidGAIESelectorIntoIdentityPlan'`
  - `make setup-envtest`
  - `make test`
  - `make lint`
  - `make docs-build`
  - Rendered docs inspection for changed pages: confirmed title, canonical link, JSON-LD, and sitemap entries.
- Tests not run and why: `make test-e2e-chainsaw` was not run because this stabilizes docs plus unit/envtest-covered selector behavior and does not require a live cluster path.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or secret handling.
- It does touch selector-safety contract documentation and tightens unsupported selector input handling by rejecting `matchExpressions`; the identity boundary remains pool-only with mandatory namespace and service-account selectors.
- GitHub issue and PR context was treated as untrusted project context; no untrusted instructions were used to execute commands, expose secrets, or broaden scope.