### PR TITLE
fix(controller): classify managed output apply failures

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -53,12 +53,14 @@ Current validation rules enforced by the CRD:
 | `renderedClusterSPIFFEID.name` | Deterministic managed `ClusterSPIFFEID` name rendered for the binding. |
 | `renderedClusterSPIFFEID.spiffeID` | Rendered SPIFFE ID written to the managed `ClusterSPIFFEID`. This matches the SPIFFE ID in `computedSpiffeIDs`. |
 | `renderedClusterSPIFFEID.selectorFingerprint` | `sha256:<hex>` fingerprint of the canonical rendered selector set. |
-| `renderedClusterSPIFFEID.observedGeneration` | Observed `metadata.generation` of the managed `ClusterSPIFFEID` when Kubernetes reports a persisted generation. Omitted when no persisted generation has been reported. API failures while listing or applying the managed resource do not advance rendered managed status from that failed attempt. |
+| `renderedClusterSPIFFEID.observedGeneration` | Observed `metadata.generation` of the managed `ClusterSPIFFEID` when Kubernetes reports a persisted generation. Omitted when no persisted generation has been reported. |
 
-On reference, selector, render, or managed-output infrastructure failure, the
-operator clears `computedSpiffeIDs`, `renderedSelectors`, and
+On reference, selector, render, managed-output infrastructure, or managed-output
+API failure, the operator clears `computedSpiffeIDs`, `renderedSelectors`, and
 `renderedClusterSPIFFEID` together so status-only clients do not read stale
-rendered output.
+rendered output. Generic managed `ClusterSPIFFEID` list, create, update, or
+delete API failures report `RenderFailure=True` with reason
+`ManagedOutputApplyFailed`.
 
 ## Kubectl Columns
 

--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -24,7 +24,7 @@ These conditions describe reference resolution, selector safety, identity render
 | `Ready` | The binding reconciled successfully. | `Reconciled` |
 | `InvalidRef` | `poolRef` or the required GAIE pool CRD could not be resolved or validated. | `InvalidPoolRef`, `TargetPoolNotFound`, `InferencePoolCRDMissing` |
 | `UnsafeSelector` | The rendered selector set is missing required safety constraints or the pool selector cannot be rendered safely. | `InvalidPoolSelector`, `UnsafeSelector` |
-| `RenderFailure` | Rendering or managed-output application failed after reference resolution succeeded. | `MissingTrustDomain`, `InvalidServiceAccountName`, `InvalidSPIFFEID`, `ClusterSPIFFEIDCRDMissing` |
+| `RenderFailure` | Rendering or managed-output application failed after reference resolution succeeded. | `MissingTrustDomain`, `InvalidServiceAccountName`, `InvalidSPIFFEID`, `ClusterSPIFFEIDCRDMissing`, `ManagedOutputApplyFailed` |
 
 `Ready=False` uses the same reason and message as the single active failure condition. Failure conditions use `Resolved` when `False`; all conditions may use `Initializing` while a generation has not been evaluated.
 
@@ -48,5 +48,6 @@ Dependency-unavailable states are classified as follows:
 
 - Missing GAIE `InferencePool` CRD: `InvalidRef=True`, reason `InferencePoolCRDMissing`
 - Missing SPIRE Controller Manager `ClusterSPIFFEID` CRD during reconcile: `RenderFailure=True`, reason `ClusterSPIFFEIDCRDMissing`
+- Generic managed `ClusterSPIFFEID` list, create, update, or delete API failure: `RenderFailure=True`, reason `ManagedOutputApplyFailed`
 
-`ClusterSPIFFEIDCRDMissing` retries automatically on the controller's infrastructure retry timer. `InferencePoolCRDMissing` can appear during resolution, but the operator also fails startup if no supported GAIE pool GVK is served during controller setup.
+`ClusterSPIFFEIDCRDMissing` retries automatically on the controller's infrastructure retry timer. `ManagedOutputApplyFailed` returns the API error so controller-runtime retries the failed reconcile. `InferencePoolCRDMissing` can appear during resolution, but the operator also fails startup if no supported GAIE pool GVK is served during controller setup.

--- a/docs/reference/resources.md
+++ b/docs/reference/resources.md
@@ -60,7 +60,12 @@ managed output after a successful reconcile:
 | `name` | Deterministic managed `ClusterSPIFFEID` name. |
 | `spiffeID` | Rendered SPIFFE ID, matching `status.computedSpiffeIDs`. |
 | `selectorFingerprint` | `sha256:<hex>` fingerprint of the canonical selector set rendered into `spec.workloadSelectorTemplates`. |
-| `observedGeneration` | Observed managed `ClusterSPIFFEID` generation when Kubernetes reports a persisted generation. Omitted when no persisted generation has been reported. API failures while listing or applying the managed resource do not advance rendered managed status from that failed attempt. |
+| `observedGeneration` | Observed managed `ClusterSPIFFEID` generation when Kubernetes reports a persisted generation. Omitted when no persisted generation has been reported. |
+
+Generic managed `ClusterSPIFFEID` list, create, update, or delete API failures
+report `RenderFailure=True` with reason `ManagedOutputApplyFailed` and clear
+`computedSpiffeIDs`, `renderedSelectors`, and `renderedClusterSPIFFEID` so
+status-only clients do not read stale rendered output.
 
 ## Other Resources Touched
 

--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -109,9 +109,11 @@ managed resource generation when it is available from Kubernetes.
 identity used for `status.computedSpiffeIDs`; it is not a second SPIFFE state.
 `observedGeneration` is omitted when Kubernetes has not reported a persisted
 generation for the managed resource. Kleym does not write `0` as a fake
-generation. If the managed resource cannot be listed or applied because the API
-request itself fails, reconciliation returns the API error and does not advance
-rendered managed status from that failed attempt.
+generation. If the managed resource cannot be listed, created, updated, or
+deleted because the API request itself fails, reconciliation reports
+`RenderFailure=True` with reason `ManagedOutputApplyFailed`, clears
+`computedSpiffeIDs`, `renderedSelectors`, and `renderedClusterSPIFFEID`, and
+returns the API error so reconciliation retries.
 
 ## Required Behavior
 
@@ -139,7 +141,7 @@ Allowed condition types and reasons:
 | `Ready` | `Unknown` | `Initializing` |
 | `InvalidRef` | `True` | `InvalidPoolRef`, `TargetPoolNotFound`, `InferencePoolCRDMissing` |
 | `UnsafeSelector` | `True` | `InvalidPoolSelector`, `UnsafeSelector` |
-| `RenderFailure` | `True` | `MissingTrustDomain`, `InvalidServiceAccountName`, `InvalidSPIFFEID`, `ClusterSPIFFEIDCRDMissing` |
+| `RenderFailure` | `True` | `MissingTrustDomain`, `InvalidServiceAccountName`, `InvalidSPIFFEID`, `ClusterSPIFFEIDCRDMissing`, `ManagedOutputApplyFailed` |
 | `InvalidRef`, `UnsafeSelector`, `RenderFailure` | `False` | `Resolved` |
 | `InvalidRef`, `UnsafeSelector`, `RenderFailure` | `Unknown` | `Initializing` |
 
@@ -151,6 +153,7 @@ Dependency-unavailable states use the same taxonomy:
 
 - Missing GAIE `InferencePool` CRD during pool discovery or pool resolution is `InvalidRef=True` with reason `InferencePoolCRDMissing`. Startup discovery fails when no supported GAIE pool GVK is served.
 - Missing SPIRE Controller Manager `ClusterSPIFFEID` CRD during reconcile is `RenderFailure=True` with reason `ClusterSPIFFEIDCRDMissing` and the reconcile retries on a timer.
+- Generic managed `ClusterSPIFFEID` list, create, update, or delete API failures are `RenderFailure=True` with reason `ManagedOutputApplyFailed`. The reconcile returns the API error for retry and clears rendered identity plus managed-resource status from the failed attempt.
 
 ## Safety Invariants
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -38,6 +38,7 @@ If reconciliation fails, `Ready=False` and the triggering condition becomes `Tru
 | `RenderFailure` | `InvalidSPIFFEID` | The computed SPIFFE ID is not valid. | Check the referenced namespace and pool names. |
 | `RenderFailure` | `MissingTrustDomain` | The operator has no trust domain configured. | Configure `--trust-domain` or `KLEYM_TRUST_DOMAIN` before starting the operator. |
 | `RenderFailure` | `ClusterSPIFFEIDCRDMissing` | SPIRE Controller Manager or its `ClusterSPIFFEID` CRD is missing. | Install SPIRE Controller Manager and confirm the `clusterspiffeids.spire.spiffe.io` CRD exists. |
+| `RenderFailure` | `ManagedOutputApplyFailed` | The Kubernetes API rejected or failed a managed `ClusterSPIFFEID` list, create, update, or delete request. | Check API server availability, RBAC, admission errors, and SPIRE Controller Manager CRD health; the controller returns the API error for retry. |
 
 ## Missing CRDs
 

--- a/internal/controller/inferenceidentitybinding_controller.go
+++ b/internal/controller/inferenceidentitybinding_controller.go
@@ -52,6 +52,7 @@ const (
 	conditionReasonInitializing              = "Initializing"
 	conditionReasonInvalidPoolRef            = "InvalidPoolRef"
 	conditionReasonClusterSPIFFEIDCRDMissing = "ClusterSPIFFEIDCRDMissing"
+	conditionReasonManagedOutputApplyFailed  = "ManagedOutputApplyFailed"
 
 	fieldIndexPoolRefName          = "spec.poolRef.name"
 	infraNotReadyRequeueAfter      = 30 * time.Second
@@ -231,6 +232,18 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(
 			)
 			return ctrl.Result{RequeueAfter: infraNotReadyRequeueAfter}, nil
 		}
+		stateErr := newManagedOutputApplyFailedStateError(err)
+		applyFailureStatus(&binding.Status, binding.Generation, stateErr)
+		if patchErr := r.patchStatusFromBase(ctx, statusBase, binding); patchErr != nil {
+			return ctrl.Result{}, patchErr
+		}
+		r.recordTerminalOutcome(binding)
+		logger.Info(
+			"applied failure status",
+			logKeyCondition, stateErr.conditionType,
+			logKeyReason, stateErr.reason,
+		)
+		r.recordEventf(binding, corev1.EventTypeWarning, stateErr.reason, "%s", stateErr.message)
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/inferenceidentitybinding_controller.go
+++ b/internal/controller/inferenceidentitybinding_controller.go
@@ -181,6 +181,9 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(
 			return ctrl.Result{}, err
 		}
 		if err := r.applyStateError(ctx, binding, stateErr); err != nil {
+			if statusErr := r.patchManagedOutputApplyFailureStatus(ctx, statusBase, binding, err); statusErr != nil {
+				return ctrl.Result{}, statusErr
+			}
 			return ctrl.Result{}, err
 		}
 		if err := r.patchStatusFromBase(ctx, statusBase, binding); err != nil {
@@ -213,6 +216,9 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(
 		if meta.IsNoMatchError(err) {
 			stateErr := newClusterSPIFFEIDCRDMissingStateError()
 			if err := r.applyStateError(ctx, binding, stateErr); err != nil {
+				if statusErr := r.patchManagedOutputApplyFailureStatus(ctx, statusBase, binding, err); statusErr != nil {
+					return ctrl.Result{}, statusErr
+				}
 				return ctrl.Result{}, err
 			}
 			if err := r.patchStatusFromBase(ctx, statusBase, binding); err != nil {
@@ -232,18 +238,9 @@ func (r *InferenceIdentityBindingReconciler) Reconcile(
 			)
 			return ctrl.Result{RequeueAfter: infraNotReadyRequeueAfter}, nil
 		}
-		stateErr := newManagedOutputApplyFailedStateError(err)
-		applyFailureStatus(&binding.Status, binding.Generation, stateErr)
-		if patchErr := r.patchStatusFromBase(ctx, statusBase, binding); patchErr != nil {
-			return ctrl.Result{}, patchErr
+		if statusErr := r.patchManagedOutputApplyFailureStatus(ctx, statusBase, binding, err); statusErr != nil {
+			return ctrl.Result{}, statusErr
 		}
-		r.recordTerminalOutcome(binding)
-		logger.Info(
-			"applied failure status",
-			logKeyCondition, stateErr.conditionType,
-			logKeyReason, stateErr.reason,
-		)
-		r.recordEventf(binding, corev1.EventTypeWarning, stateErr.reason, "%s", stateErr.message)
 		return ctrl.Result{}, err
 	}
 
@@ -454,6 +451,28 @@ func (r *InferenceIdentityBindingReconciler) applyStateError(
 	}
 
 	applyFailureStatus(&binding.Status, binding.Generation, stateErr)
+	return nil
+}
+
+func (r *InferenceIdentityBindingReconciler) patchManagedOutputApplyFailureStatus(
+	ctx context.Context,
+	statusBase *kleymv1alpha1.InferenceIdentityBinding,
+	binding *kleymv1alpha1.InferenceIdentityBinding,
+	applyErr error,
+) error {
+	stateErr := newManagedOutputApplyFailedStateError(applyErr)
+	applyFailureStatus(&binding.Status, binding.Generation, stateErr)
+	if err := r.patchStatusFromBase(ctx, statusBase, binding); err != nil {
+		return err
+	}
+	r.recordTerminalOutcome(binding)
+	logger := logf.FromContext(ctx)
+	logger.Info(
+		"applied failure status",
+		logKeyCondition, stateErr.conditionType,
+		logKeyReason, stateErr.reason,
+	)
+	r.recordEventf(binding, corev1.EventTypeWarning, stateErr.reason, "%s", stateErr.message)
 	return nil
 }
 

--- a/internal/controller/inferenceidentitybinding_resolver.go
+++ b/internal/controller/inferenceidentitybinding_resolver.go
@@ -50,3 +50,13 @@ func newClusterSPIFFEIDCRDMissingStateError() *reconcileStateError {
 		"ClusterSPIFFEID CRD is not installed",
 	)
 }
+
+// newManagedOutputApplyFailedStateError maps transient managed-output API
+// failures to the RenderFailure taxonomy from docs/spec/operator.md.
+func newManagedOutputApplyFailedStateError(err error) *reconcileStateError {
+	return newStateError(
+		conditionTypeRenderFailure,
+		conditionReasonManagedOutputApplyFailed,
+		"Managed ClusterSPIFFEID output could not be applied: "+err.Error(),
+	)
+}

--- a/internal/controller/inferenceidentitybinding_taxonomy_test.go
+++ b/internal/controller/inferenceidentitybinding_taxonomy_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	stderrors "errors"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -12,6 +13,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kleymv1alpha1 "github.com/sonda-red/kleym/api/v1alpha1"
@@ -68,6 +70,81 @@ func TestReconcileConditionTaxonomySuccess(t *testing.T) {
 	}
 	if current.Status.RenderedClusterSPIFFEID.SelectorFingerprint == "" {
 		t.Fatalf("renderedClusterSPIFFEID.selectorFingerprint was not populated")
+	}
+}
+
+func TestReconcileManagedOutputApplyFailureSetsFailureStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newControllerTestScheme(t)
+	binding := newPoolOnlyBinding("binding-managed-output-apply-failure", "")
+	binding.Status = kleymv1alpha1.InferenceIdentityBindingStatus{
+		ComputedSpiffeIDs: []kleymv1alpha1.ComputedSpiffeIDStatus{{
+			SpiffeID: "spiffe://stale.example/ns/default/pool/old",
+		}},
+		RenderedSelectors: []kleymv1alpha1.RenderedSelectorStatus{{
+			SpiffeID:  "spiffe://stale.example/ns/default/pool/old",
+			Selectors: []string{"k8s:ns:default", "k8s:sa:old"},
+		}},
+		RenderedClusterSPIFFEID: &kleymv1alpha1.RenderedClusterSPIFFEIDStatus{
+			Name:                "stale",
+			SpiffeID:            "spiffe://stale.example/ns/default/pool/old",
+			SelectorFingerprint: "sha256:stale",
+		},
+		Conditions: []metav1.Condition{{
+			Type:    conditionTypeReady,
+			Status:  metav1.ConditionTrue,
+			Reason:  conditionReasonReconciled,
+			Message: "stale success",
+		}},
+	}
+
+	applyErr := stderrors.New("create managed ClusterSPIFFEID failed")
+	baseClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+		WithObjects(newTestPool(), binding).
+		Build()
+	k8sClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		Create: func(
+			ctx context.Context,
+			k8sClient client.WithWatch,
+			obj client.Object,
+			opts ...client.CreateOption,
+		) error {
+			if obj.GetObjectKind().GroupVersionKind() == clusterSPIFFEIDGVK {
+				return applyErr
+			}
+			return k8sClient.Create(ctx, obj, opts...)
+		},
+	})
+	reconciler := &InferenceIdentityBindingReconciler{
+		Config: testOperatorConfig(),
+		Client: k8sClient,
+		Scheme: scheme,
+	}
+
+	result, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: binding.Name},
+	})
+	if !stderrors.Is(err, applyErr) {
+		t.Fatalf("Reconcile error = %v, want %v", err, applyErr)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("result = %#v, want empty result", result)
+	}
+
+	current := fetchBinding(t, ctx, k8sClient, binding.Name)
+	assertPrimaryFailureCondition(t, current, conditionTypeRenderFailure, conditionReasonManagedOutputApplyFailed)
+	if len(current.Status.ComputedSpiffeIDs) != 0 {
+		t.Fatalf("computedSpiffeIDs = %d, want cleared on managed-output apply failure", len(current.Status.ComputedSpiffeIDs))
+	}
+	if len(current.Status.RenderedSelectors) != 0 {
+		t.Fatalf("renderedSelectors = %d, want cleared on managed-output apply failure", len(current.Status.RenderedSelectors))
+	}
+	if current.Status.RenderedClusterSPIFFEID != nil {
+		t.Fatalf("renderedClusterSPIFFEID = %#v, want cleared on managed-output apply failure", current.Status.RenderedClusterSPIFFEID)
 	}
 }
 
@@ -217,6 +294,7 @@ func TestConditionTaxonomyAllowedReasonStrings(t *testing.T) {
 		"invalid-service-account-name": {got: identity.ReasonInvalidServiceAccountName, want: "InvalidServiceAccountName"},
 		"invalid-spiffe-id":            {got: identity.ReasonInvalidSPIFFEID, want: "InvalidSPIFFEID"},
 		"clusterspiffeid-crd-missing":  {got: conditionReasonClusterSPIFFEIDCRDMissing, want: "ClusterSPIFFEIDCRDMissing"},
+		"managed-output-apply-failed":  {got: conditionReasonManagedOutputApplyFailed, want: "ManagedOutputApplyFailed"},
 	}
 
 	for name, tc := range cases {

--- a/internal/controller/inferenceidentitybinding_taxonomy_test.go
+++ b/internal/controller/inferenceidentitybinding_taxonomy_test.go
@@ -148,6 +148,83 @@ func TestReconcileManagedOutputApplyFailureSetsFailureStatus(t *testing.T) {
 	}
 }
 
+func TestReconcileFailureCleanupApplyFailureSetsManagedOutputFailureStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newControllerTestScheme(t)
+	binding := newPoolOnlyBinding("binding-managed-output-cleanup-failure", "")
+	binding.Spec.PoolRef.Name = "missing-pool"
+	binding.Status = kleymv1alpha1.InferenceIdentityBindingStatus{
+		ComputedSpiffeIDs: []kleymv1alpha1.ComputedSpiffeIDStatus{{
+			SpiffeID: "spiffe://stale.example/ns/default/pool/old",
+		}},
+		RenderedSelectors: []kleymv1alpha1.RenderedSelectorStatus{{
+			SpiffeID:  "spiffe://stale.example/ns/default/pool/old",
+			Selectors: []string{"k8s:ns:default", "k8s:sa:old"},
+		}},
+		RenderedClusterSPIFFEID: &kleymv1alpha1.RenderedClusterSPIFFEIDStatus{
+			Name:                "stale",
+			SpiffeID:            "spiffe://stale.example/ns/default/pool/old",
+			SelectorFingerprint: "sha256:stale",
+		},
+		Conditions: []metav1.Condition{{
+			Type:    conditionTypeReady,
+			Status:  metav1.ConditionTrue,
+			Reason:  conditionReasonReconciled,
+			Message: "stale success",
+		}},
+	}
+
+	cleanupErr := stderrors.New("list managed ClusterSPIFFEIDs for cleanup failed")
+	baseClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
+		WithObjects(binding).
+		Build()
+	k8sClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		List: func(
+			ctx context.Context,
+			k8sClient client.WithWatch,
+			list client.ObjectList,
+			opts ...client.ListOption,
+		) error {
+			clusterSPIFFEIDListGVK := clusterSPIFFEIDGVK.GroupVersion().WithKind(clusterSPIFFEIDGVK.Kind + "List")
+			if list.GetObjectKind().GroupVersionKind() == clusterSPIFFEIDListGVK {
+				return cleanupErr
+			}
+			return k8sClient.List(ctx, list, opts...)
+		},
+	})
+	reconciler := &InferenceIdentityBindingReconciler{
+		Config: testOperatorConfig(),
+		Client: k8sClient,
+		Scheme: scheme,
+	}
+
+	result, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: binding.Name},
+	})
+	if !stderrors.Is(err, cleanupErr) {
+		t.Fatalf("Reconcile error = %v, want %v", err, cleanupErr)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("result = %#v, want empty result", result)
+	}
+
+	current := fetchBinding(t, ctx, k8sClient, binding.Name)
+	assertPrimaryFailureCondition(t, current, conditionTypeRenderFailure, conditionReasonManagedOutputApplyFailed)
+	if len(current.Status.ComputedSpiffeIDs) != 0 {
+		t.Fatalf("computedSpiffeIDs = %d, want cleared on cleanup failure", len(current.Status.ComputedSpiffeIDs))
+	}
+	if len(current.Status.RenderedSelectors) != 0 {
+		t.Fatalf("renderedSelectors = %d, want cleared on cleanup failure", len(current.Status.RenderedSelectors))
+	}
+	if current.Status.RenderedClusterSPIFFEID != nil {
+		t.Fatalf("renderedClusterSPIFFEID = %#v, want cleared on cleanup failure", current.Status.RenderedClusterSPIFFEID)
+	}
+}
+
 func TestReconcileConditionTaxonomyFailures(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Classify generic managed `ClusterSPIFFEID` API failures with a visible binding status reason.
- Clear rendered identity and managed-resource status on those failures so status-only clients do not read stale rendered output.

## What I Changed And Why

- Added `ManagedOutputApplyFailed` under the existing `RenderFailure` taxonomy for managed `ClusterSPIFFEID` list/create/update/delete API failures.
- Preserved retry behavior by patching failure status, recording the warning event, and returning the original API error to controller-runtime.
- Covered both the normal managed-output apply path and cleanup failures that happen after an already-classified binding failure.
- Kept `ClusterSPIFFEIDCRDMissing` on the existing infrastructure retry timer and left rendered SPIFFE ID shape, selector rendering, managed resource rendering, and CLI behavior unchanged.

## Related Issue

- Closes #260

## Scope Check

- This follows the issue scope by limiting changes to managed-output reconciliation status, taxonomy tests, and documentation.
- Left out CLI drift comparison, runtime evidence, authorization, scheduling, gateway behavior, selector derivation, and SPIFFE ID shape changes.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): updated to define `ManagedOutputApplyFailed`, retry behavior, and clearing rendered status fields.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI output and inspection behavior did not change.
- Other docs: updated `docs/reference/conditions.md`, `docs/reference/api.md`, `docs/reference/resources.md`, and `docs/troubleshooting.md`.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `go test ./internal/controller -run 'Test(ReconcileManagedOutputApplyFailureSetsFailureStatus|ReconcileFailureCleanupApplyFailureSetsManagedOutputFailureStatus|ConditionTaxonomyAllowedReasonStrings)$' -count=1`
  - `go test ./internal/identity`
  - `make setup-envtest`
  - `make test`
  - `make lint`
  - `make docs-build`
  - rendered docs inspection: checked generated `public/spec/operator/index.html`, `public/reference/conditions/index.html`, `public/reference/api/index.html`, `public/reference/resources/index.html`, `public/troubleshooting/index.html`, and `public/sitemap.xml` for `ManagedOutputApplyFailed`, canonical metadata, and JSON-LD where applicable.
- Tests not run and why: `make test-e2e-chainsaw` was not run; this is a controller status/taxonomy and docs change without a new cluster e2e scenario.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or secret handling.
- It changes status reporting for managed identity registration output failures, not trust-boundary enforcement, selector derivation, SPIFFE ID shape, authorization, or workload matching behavior.
- GitHub issue and PR context was treated as untrusted project context; no untrusted instructions were used to run commands, expose secrets, or broaden scope.