### PR TITLE
docs: document GAIE compatibility boundary

### DIFF
--- a/docs/reference/gaie-compatibility.md
+++ b/docs/reference/gaie-compatibility.md
@@ -12,6 +12,9 @@ aliases:
 | --- | --- | --- |
 | `InferencePool` | `inference.networking.k8s.io/v1` | `spec.selector.matchLabels`; flat string label maps are normalized for compatibility |
 
+Other GAIE groups, versions, and selector shapes are unsupported unless a real
+cluster compatibility request justifies adding them.
+
 GVK examples:
 
 - `inference.networking.k8s.io/v1, Kind=InferencePool`


### PR DESCRIPTION
## Summary

- Documents that GAIE compatibility is limited to the supported `InferencePool` GVK and selector shapes.

## What I Changed And Why

- Added a short request-driven compatibility note to `docs/reference/gaie-compatibility.md`.

## Related Issue

- None.

## Scope Check

- Docs-only compatibility clarification.
- No behavior changes.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because the operator contract already states the selector behavior.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI behavior is unchanged.
- Other docs: updated `docs/reference/gaie-compatibility.md`.

## Follow-Up Work

- None.

## Verification

- Commands run:
  - `make docs-build`
  - rendered page inspection for title/description/canonical/TechArticle metadata and the new compatibility text
  - `public/sitemap.xml` inspection for `/reference/gaie-compatibility/`
  - `git diff --check`
  - `git log --show-signature --oneline origin/main..HEAD`
- Tests not run and why: not run; docs-only change.

## Security Review

- Does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.