### PR TITLE
feat(controller): render service-account-scoped inference identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Kleym stops at identity registration. `kleym-operator` does not deploy inference
 ## How it works
 
 - `InferenceIdentityBinding` declares identity intent for one `InferencePool`.
-- `kleym-operator` resolves the pool directly.
-- The controller renders deterministic selectors and SPIFFE IDs from those inputs.
+- `kleym-operator` resolves the pool to an internal inference target anchored as `pool/<pool-name>`.
+- The controller combines that target with the binding namespace and service account to render deterministic selectors and SPIFFE IDs.
 - Managed `ClusterSPIFFEID` resources are reconciled for SPIRE Controller Manager.
 
 ## Quickstart
@@ -173,7 +173,7 @@ Docs live under [`docs/`](docs/), with the published site at <https://kleym.sond
 | Topic | What it covers |
 | --- | --- |
 | [`docs/install.md`](docs/install.md) | Local run, deployment, GitOps install, metrics, and validation commands |
-| [`docs/concepts.md`](docs/concepts.md) | GAIE pool input, pool identity, and selector safety |
+| [`docs/concepts.md`](docs/concepts.md) | GAIE pool input, service-account-scoped inference target identity, and selector safety |
 | [`docs/architecture.md`](docs/architecture.md) | End-to-end controller flow |
 | [`docs/demo.md`](docs/demo.md) | Reference binding-to-`ClusterSPIFFEID` walkthrough |
 | [`docs/examples/`](docs/examples/) | Concrete manifests and expected outcomes |

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -29,7 +29,7 @@ The in-cluster `kleym-operator` watches `InferencePool` workload intent, then co
 ### Operator docs
 
 - [Install](/install/): local run, deployment, GitOps install, metrics, and validation commands
-- [Concepts](/concepts/): GAIE pool input, pool identity, and selector safety
+- [Concepts](/concepts/): GAIE pool input, service-account-scoped inference target identity, and selector safety
 - [Architecture](/architecture/): end-to-end reconcile flow from binding intent to SPIRE registration resources
 - [Demo](/demo/): reference binding-to-`ClusterSPIFFEID` walkthrough
 - [Examples](/examples/): concrete manifests and expected reconciliation outcomes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,6 +50,6 @@ This flow uses Gateway API Inference Extension (GAIE) objects as upstream inputs
 
 ## See Also
 
-- Read [Concepts](/concepts/) for the pool identity and selector model.
+- Read [Concepts](/concepts/) for the resolved inference target identity and selector model.
 - Read [Managed Resources](/reference/resources/) for the concrete output object shape.
 - Read [Reconciliation](/design/reconciliation/) for the controller flow in more detail.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,7 +1,7 @@
 ---
 title: Concepts
 weight: 10
-description: "Kleym concepts for inference workload identity, Gateway API Inference Extension InferencePool inputs, pool identity, and selector safety."
+description: "Kleym concepts for service-account-scoped inference target identity, Gateway API Inference Extension InferencePool inputs, and selector safety."
 aliases:
   - /operator/concepts/
 ---
@@ -10,7 +10,7 @@ aliases:
 
 Kleym uses inference workload identity to mean identity registration derived from a Kubernetes inference serving boundary, not from a pod alone. In the current contract, that serving boundary is a Gateway API Inference Extension (GAIE) `InferencePool` referenced by an `InferenceIdentityBinding`.
 
-The binding namespace and required service account constrain which workloads may match. Selectors from the referenced pool provide workload provenance. `kleym-operator` combines those facts to render one deterministic pool SPIFFE ID and reconcile a managed SPIRE Controller Manager `ClusterSPIFFEID`.
+The binding namespace and required service account constrain which workloads may match. Selectors from the referenced pool provide workload provenance. `kleym-operator` resolves the pool to an inference target, combines that target with the service-account boundary, and reconciles a managed SPIRE Controller Manager `ClusterSPIFFEID`.
 
 This stops at identity registration. Kleym does not deploy inference workloads, route traffic, configure gateways, evaluate request policy, issue credentials, or prove runtime SVID use. The authoritative behavior is defined in the [Operator Spec](/spec/operator/).
 
@@ -21,13 +21,19 @@ This stops at identity registration. Kleym does not deploy inference workloads, 
 
 `kleym-operator` supports the documented `InferencePool` GVK in [GAIE Compatibility](/reference/gaie-compatibility/).
 
-## Pool Identity
+## Resolved Inference Target Identity
 
-Kleym renders one identity for the referenced serving pool. The SPIFFE ID form is:
+Kleym renders one identity for the required service account and resolved
+inference target. The SPIFFE ID form is:
 
 ```text
-spiffe://<trustDomain>/ns/<namespace>/pool/<pool-name>
+spiffe://<trustDomain>/ns/<namespace>/sa/<serviceAccountName>/inference/<anchor-kind>/<anchor-name>
 ```
+
+The current GAIE `InferencePool` source resolves to anchor kind `pool` and an
+anchor name equal to the pool name. The source GVK and binding name remain
+provenance rather than identity path material. The same pool rendered for two
+different service accounts therefore produces two distinct SPIFFE IDs.
 
 ## Safety Selectors
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -114,7 +114,7 @@ kubectl get clusterspiffeids.spire.spiffe.io \
 
 Expected observation: exactly one managed `ClusterSPIFFEID` exists. Its
 `spec.spiffeIDTemplate` is
-`spiffe://kleym.sonda.red/ns/kleym-reference-inference/pool/reference-pool`,
+`spiffe://kleym.sonda.red/ns/kleym-reference-inference/sa/reference-inference/inference/pool/reference-pool`,
 its pod selector matches the reference pool selector, and its workload selectors
 include the reference namespace, service account, and pool labels.
 

--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -11,5 +11,5 @@ identity boundaries, and downstream consumption patterns.
 
 - [Reconciliation](/design/reconciliation/): current controller flow.
 - [Selector Safety](/design/selector-safety/): selector validation rationale.
-- [Identity Boundaries](/design/identity-boundaries/): pool identity boundary.
+- [Identity Boundaries](/design/identity-boundaries/): service-account-scoped inference target identity boundary.
 - [Downstream Patterns](/design/downstream-patterns/): non-normative gateway, proxy, and policy handoff patterns.

--- a/docs/design/identity-boundaries.md
+++ b/docs/design/identity-boundaries.md
@@ -1,16 +1,20 @@
 ---
 title: Identity Boundaries
 weight: 15
-description: "Design rationale for Kleym identity boundaries across namespaces, service accounts, and inference pools."
+description: "Design rationale for service-account-scoped inference target identities across namespaces, service accounts, and inference pools."
 aliases:
   - /operator/design/identity-boundaries/
 ---
 
 ## Boundaries
 
-One SPIFFE identity represents the serving pool pods selected by the referenced
-`InferencePool`.
+One SPIFFE identity represents workloads at the intersection of a required
+service account and a resolved inference target.
 
-The pool defines where inference runs. Kleym adds namespace and service-account
-selectors so the identity remains tied to the binding namespace and the expected
-workload service account.
+The current `InferencePool` source resolves to identity anchor `pool/<pool-name>`.
+Kleym combines that anchor with the binding namespace and service account in the
+SPIFFE ID, and enforces the same namespace and service account through mandatory
+workload selectors.
+
+Raw source GVK data and binding names remain provenance. They do not define the
+workload principal and do not enter SPIFFE ID paths.

--- a/docs/design/reconciliation.md
+++ b/docs/design/reconciliation.md
@@ -12,10 +12,10 @@ For each `InferenceIdentityBinding`, the reconciler currently does the following
 
 1. Fetch the binding and ensure the `kleym.sonda.red/inferenceidentitybinding-finalizer` is present.
 2. Resolve the referenced `InferencePool` from `spec.poolRef`.
-3. Derive pod-label selectors from `pool.spec.selector`.
-4. Render namespace and service-account safety selectors from the binding and merge them with the pool-derived selectors.
+3. Resolve the pool to identity anchor `pool/<pool-name>` plus pod-label selector inputs.
+4. Render namespace and service-account safety selectors from the binding and merge them with the resolved target selectors.
 5. Validate selector safety before rendering or writing output.
-6. Render the deterministic pool SPIFFE ID.
+6. Render the deterministic service-account-scoped inference target SPIFFE ID.
 7. Create, update, or delete managed `ClusterSPIFFEID` resources to match the rendered identity.
 8. Patch binding status and emit events for success or failure.
 

--- a/docs/examples/_index.md
+++ b/docs/examples/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Examples
 weight: 40
-description: "Kleym example manifests for pool identity registration with expected reconciliation output."
+description: "Kleym example manifests for service-account-scoped inference target identity registration with expected reconciliation output."
 aliases:
   - /operator/examples/
 ---

--- a/docs/examples/basic-binding.md
+++ b/docs/examples/basic-binding.md
@@ -1,12 +1,12 @@
 ---
 title: Basic Binding
 weight: 10
-description: "Basic InferenceIdentityBinding example that renders one pool-level SPIFFE identity and managed ClusterSPIFFEID resource."
+description: "Basic InferenceIdentityBinding example that renders one service-account-scoped inference target identity and managed ClusterSPIFFEID resource."
 aliases:
   - /operator/examples/basic-binding/
 ---
 
-This example shows the current pool identity flow.
+This example shows a service-account-scoped identity anchored to a GAIE pool.
 
 `kleym-operator` currently consumes only a small slice of the referenced Gateway API Inference Extension (GAIE) objects:
 
@@ -43,7 +43,7 @@ spec:
 
 The binding should reconcile to a managed `ClusterSPIFFEID` with:
 
-- SPIFFE ID `spiffe://kleym.sonda.red/ns/default/pool/pool-a`
+- SPIFFE ID `spiffe://kleym.sonda.red/ns/default/sa/inference-sa/inference/pool/pool-a`
 - a pod selector equivalent to `matchLabels.app=model-server`
 - workload selectors including:
   - `k8s:ns:default`
@@ -61,7 +61,7 @@ metadata:
     kleym.sonda.red/binding-name: pool-a
     kleym.sonda.red/binding-namespace: default
 spec:
-  spiffeIDTemplate: spiffe://kleym.sonda.red/ns/default/pool/pool-a
+  spiffeIDTemplate: spiffe://kleym.sonda.red/ns/default/sa/inference-sa/inference/pool/pool-a
   podSelector:
     matchLabels:
       app: model-server

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -79,11 +79,15 @@ until the operator has reconciled the binding and written status.
 
 ## Current Defaults
 
-The controller always renders deterministic pool SPIFFE IDs under its configured trust domain:
+The controller always renders deterministic service-account-scoped inference
+target SPIFFE IDs under its configured trust domain:
 
 ```text
-spiffe://<trustDomain>/ns/<namespace>/pool/<pool-name>
+spiffe://<trustDomain>/ns/<namespace>/sa/<serviceAccountName>/inference/<anchor-kind>/<anchor-name>
 ```
+
+For the current GAIE source, `<anchor-kind>` is `pool` and `<anchor-name>` is
+the referenced pool name.
 
 ## External Objects Resolved
 

--- a/docs/reference/resources.md
+++ b/docs/reference/resources.md
@@ -45,7 +45,7 @@ Managed `ClusterSPIFFEID` names are deterministic and derived from:
 - the `kleym-operator` controller name
 - binding namespace
 - binding name
-- rendered pool identity kind
+- rendered identity anchor kind (`pool` for the current GAIE source)
 - a short hash of the SPIFFE ID
 
 That keeps names DNS-safe while allowing the SPIFFE ID to remain the real identity contract.

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -82,7 +82,7 @@ Status does not compare live managed `ClusterSPIFFEID` output, prove SVID issuan
 1. Resolve the binding and `poolRef`.
 2. Choose identity config by precedence: explicit flag, binding status, then CLI default.
 3. Record config values and sources. If binding status lacks operator config, add a warning finding.
-4. Render identity and deterministic `ClusterSPIFFEID` output with shared Kleym logic.
+4. Resolve the pool to the same inference target identity model used by the operator, then render identity and deterministic `ClusterSPIFFEID` output with shared Kleym logic.
 5. Read pods when permitted and report pods or containers matching rendered Kubernetes-observable selectors.
 6. Preserve current binding conditions.
 7. Emit the report and exit according to finding severity.
@@ -103,7 +103,7 @@ Matched pods are not proof of SVID issuance, workload attestation, identity cons
 
 ## Implementation Boundary
 
-The CLI and operator share pure GAIE resolution, selector derivation, selector rendering, SPIFFE ID rendering, and deterministic `ClusterSPIFFEID` naming logic. `kleym` does not import controller orchestration, finalizer handling, watches, status patching, or resource mutation logic.
+The CLI and operator share pure GAIE resolution, the source-independent resolved inference target model, selector rendering, SPIFFE ID rendering, and deterministic `ClusterSPIFFEID` naming logic. `kleym` does not import controller orchestration, finalizer handling, watches, status patching, or resource mutation logic.
 
 ## References
 

--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -43,13 +43,25 @@ When `--clusterspiffeid-class-name` is empty, SPIRE Controller Manager must be c
 `InferenceIdentityBinding` is namespaced. Pool references stay in that namespace.
 
 1. `poolRef` references one [`InferencePool`][gaie-inferencepool]. The pool is the required workload anchor and selector provenance source.
-2. `serviceAccountName` is required. Kleym renders safety selectors internally as `k8s:ns:<binding namespace>` and `k8s:sa:<serviceAccountName>`.
-3. SPIFFE IDs are always deterministic under the configured trust domain: `spiffe://<trustDomain>/ns/<namespace>/pool/<pool-name>`.
+2. `serviceAccountName` is required. It scopes the rendered identity path, and Kleym renders safety selectors internally as `k8s:ns:<binding namespace>` and `k8s:sa:<serviceAccountName>`.
+3. SPIFFE IDs are always deterministic under the configured trust domain: `spiffe://<trustDomain>/ns/<namespace>/sa/<serviceAccountName>/inference/<anchor-kind>/<anchor-name>`.
 4. Status records `trustDomain`, `clusterSPIFFEIDClassName`, `computedSpiffeIDs`, `renderedSelectors`, `renderedClusterSPIFFEID`, and conditions. The current pool-only condition taxonomy is limited to `Ready`, `InvalidRef`, `UnsafeSelector`, and `RenderFailure`.
 5. `trustDomain` and `clusterSPIFFEIDClassName` record the operator config values used for the latest status update. They are observation data for read-only inspection compatibility; they do not make trust domain or class name per-binding spec intent.
 6. The CRD exposes printer columns for `POOL`, `READY`, `REASON`, and `SPIFFE ID` so `kubectl get inferenceidentitybindings.kleym.sonda.red -A` is the primary binding list view.
 
 Field details live in [API Reference][api-reference]. Condition details live in [Conditions Reference][conditions-reference].
+
+## Resolved Inference Target Contract
+
+Identity and selector rendering consume a resolved inference target after the
+referenced source object has been read. A GAIE `InferencePool` resolves to
+identity anchor kind `pool`, with the anchor name equal to the pool name.
+
+The canonical identity path contains the binding namespace, required service
+account, and resolved identity anchor. Source provenance such as the raw source
+group, version, or kind and the `InferenceIdentityBinding` name remains outside
+the SPIFFE ID. Two bindings for the same namespace and pool but different
+service accounts therefore render different SPIFFE IDs.
 
 ## Rendered Selector Contract
 
@@ -120,11 +132,12 @@ returns the API error so reconciliation retries.
 1. Discover the supported GAIE pool GVK served by the cluster and watch it.
 2. Fail startup when the supported `InferencePool` GVK is not available.
 3. Resolve `poolRef` only to documented supported GAIE groups.
-4. Derive pod selection from the referenced pool, then combine it with internal namespace and service-account safety selectors.
-5. Refuse unsafe selectors. If the selector set cannot be proven to stay within the binding namespace and required service account boundary, set `UnsafeSelector` and produce no managed output.
-6. Render the SPIFFE ID and managed `ClusterSPIFFEID` shape deterministically. Rendered output fields are documented in [Managed Resources][managed-resources].
-7. After startup succeeds, treat missing managed-output CRDs and infrastructure-not-ready states as transient by retrying reconciliation on a timer.
-8. On deletion, delete managed `ClusterSPIFFEID` children first and keep the binding finalizer until a follow-up list confirms no managed children remain.
+4. Resolve the referenced pool into the inference target identity anchor and pod-selector inputs.
+5. Combine resolved target selectors with internal namespace and service-account safety selectors.
+6. Refuse unsafe selectors. If the selector set cannot be proven to stay within the binding namespace and required service account boundary, set `UnsafeSelector` and produce no managed output.
+7. Render the SPIFFE ID and managed `ClusterSPIFFEID` shape deterministically. Rendered output fields are documented in [Managed Resources][managed-resources].
+8. After startup succeeds, treat missing managed-output CRDs and infrastructure-not-ready states as transient by retrying reconciliation on a timer.
+9. On deletion, delete managed `ClusterSPIFFEID` children first and keep the binding finalizer until a follow-up list confirms no managed children remain.
 
 Selector rationale is expanded in [Selector Safety][selector-safety].
 

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -31,7 +31,7 @@ Kleym stops at identity registration. It does not deploy inference workloads, ro
 
 ## Key Resources
 
-- [Concepts](https://kleym.sonda.red/concepts/) - GAIE InferencePool input, pool identity, and selector safety.
+- [Concepts](https://kleym.sonda.red/concepts/) - GAIE InferencePool input, service-account-scoped inference target identity, and selector safety.
 - [Architecture](https://kleym.sonda.red/architecture/) - End-to-end control flow from `InferenceIdentityBinding` to SPIRE registration state.
 - [API reference](https://kleym.sonda.red/reference/api/) - `InferenceIdentityBinding` API fields and validation rules.
 - [Managed resources](https://kleym.sonda.red/reference/resources/) - Managed `ClusterSPIFFEID` output shape.

--- a/internal/cli/inspect_test.go
+++ b/internal/cli/inspect_test.go
@@ -121,11 +121,11 @@ func TestInspectBindingDefaultTextUsesRunner(t *testing.T) {
 	fakeReport.GeneratedAt = "2026-05-18T10:11:12Z"
 	fakeReport.BindingRef = inspection.BindingInspectionBindingRef{Namespace: "tenant-a", Name: "binding-a"}
 	fakeReport.RenderedIdentity = inspection.BindingInspectionRenderedIdentity{
-		SPIFFEID: "spiffe://kleym.sonda.red/ns/tenant-a/pool/pool-a",
+		SPIFFEID: "spiffe://kleym.sonda.red/ns/tenant-a/sa/model-sa/inference/pool/pool-a",
 	}
 	fakeReport.RenderedClusterSPIFFEID = inspection.BindingInspectionRenderedClusterSPIFFEID{
 		Name:     "tenant-a-binding-a-1234abcd",
-		SPIFFEID: "spiffe://kleym.sonda.red/ns/tenant-a/pool/pool-a",
+		SPIFFEID: "spiffe://kleym.sonda.red/ns/tenant-a/sa/model-sa/inference/pool/pool-a",
 	}
 	newBindingInspectionRunner = func(_ *Options) (inspection.BindingInspector, error) {
 		return fixedInspectionRunner{report: fakeReport}, nil
@@ -149,7 +149,7 @@ func TestInspectBindingDefaultTextUsesRunner(t *testing.T) {
 	for _, want := range []string{
 		"Binding: tenant-a/binding-a",
 		"Identity:",
-		"SPIFFE ID: spiffe://kleym.sonda.red/ns/tenant-a/pool/pool-a",
+		"SPIFFE ID: spiffe://kleym.sonda.red/ns/tenant-a/sa/model-sa/inference/pool/pool-a",
 		"ClusterSPIFFEID:",
 		"Name: tenant-a-binding-a-1234abcd",
 		"Findings: none",

--- a/internal/controller/inferenceidentitybinding_controller.go
+++ b/internal/controller/inferenceidentitybinding_controller.go
@@ -425,7 +425,7 @@ func (r *InferenceIdentityBindingReconciler) computeDesiredState(
 		).GetName(),
 		logKeySelectors, identity.Selectors,
 		logKeyPodSelector, identity.PodSelector,
-		logKeyPool, identity.PoolRef,
+		logKeyPool, identity.IdentityAnchor.Name,
 	)
 
 	return desiredBindingState{

--- a/internal/controller/inferenceidentitybinding_delete_test.go
+++ b/internal/controller/inferenceidentitybinding_delete_test.go
@@ -154,7 +154,7 @@ func TestReconcileCorrectsClusterSPIFFEIDDriftOnResync(t *testing.T) {
 	labels["drifted"] = "true"
 	drifted.SetLabels(labels)
 	drifted.Object["spec"] = map[string]any{
-		"spiffeIDTemplate":          "spiffe://drifted.example/ns/default/pool/pool-a",
+		"spiffeIDTemplate":          "spiffe://drifted.example/ns/default/sa/inference-sa/inference/pool/pool-a",
 		"podSelector":               map[string]any{"matchLabels": map[string]any{"app": "drifted"}},
 		"workloadSelectorTemplates": []any{"k8s:ns:default", "k8s:sa:drifted"},
 	}
@@ -200,7 +200,7 @@ func newManagedClusterSPIFFEIDForBinding(
 	managed.SetName(name)
 	managed.SetLabels(spirecm.ManagedClusterSPIFFEIDLabels(binding))
 	managed.Object["spec"] = map[string]any{
-		"spiffeIDTemplate": "spiffe://example.test/ns/default/pool/example",
+		"spiffeIDTemplate": "spiffe://example.test/ns/default/sa/inference-sa/inference/pool/example",
 	}
 	return managed
 }

--- a/internal/controller/inferenceidentitybinding_logging_test.go
+++ b/internal/controller/inferenceidentitybinding_logging_test.go
@@ -52,10 +52,10 @@ func TestReconcileLogsStructuredSuccessPath(t *testing.T) {
 	})
 	logs.requireEntry(t, "rendered identity from inference intent", map[string]string{
 		logKeyPool:     "pool-a",
-		logKeySpiffeID: "spiffe://kleym.sonda.red/ns/default/pool/pool-a",
+		logKeySpiffeID: "spiffe://kleym.sonda.red/ns/default/sa/inference-sa/inference/pool/pool-a",
 	})
 	logs.requireEntry(t, "creating managed ClusterSPIFFEID", map[string]string{
-		logKeySpiffeID: "spiffe://kleym.sonda.red/ns/default/pool/pool-a",
+		logKeySpiffeID: "spiffe://kleym.sonda.red/ns/default/sa/inference-sa/inference/pool/pool-a",
 	})
 	logs.requireEntry(t, "applied success status", map[string]string{
 		logKeyCondition: conditionTypeReady,
@@ -115,7 +115,7 @@ func TestReconcileClusterSPIFFEIDsLogsApplyDecisions(t *testing.T) {
 	scheme := newControllerTestScheme(t)
 	binding := newPoolOnlyBinding("binding-log-apply", "pool-a")
 	identity := renderedIdentity{
-		SpiffeID: "spiffe://kleym.sonda.red/ns/default/pool/pool-a",
+		SpiffeID: "spiffe://kleym.sonda.red/ns/default/sa/inference-sa/inference/pool/pool-a",
 		Selectors: []string{
 			"k8s:ns:default",
 			"k8s:pod-label:app:model-server",
@@ -124,7 +124,6 @@ func TestReconcileClusterSPIFFEIDsLogsApplyDecisions(t *testing.T) {
 		PodSelector: map[string]any{
 			"matchLabels": map[string]any{"app": "model-server"},
 		},
-		PoolRef: "pool-a",
 	}
 
 	drifted := spirecm.DesiredClusterSPIFFEID(binding, identity, "")

--- a/internal/controller/inferenceidentitybinding_metrics_test.go
+++ b/internal/controller/inferenceidentitybinding_metrics_test.go
@@ -38,7 +38,7 @@ func TestDeriveBindingOutcomeLabelsReady(t *testing.T) {
 	binding := newPoolOnlyBinding("binding-ready", "")
 	initializeConditions(&binding.Status, 1)
 	applySuccessStatus(&binding.Status, binding.Generation, []renderedIdentity{{
-		SpiffeID: "spiffe://kleym.sonda.red/ns/default/pool/pool-a",
+		SpiffeID: "spiffe://kleym.sonda.red/ns/default/sa/inference-sa/inference/pool/pool-a",
 	}}, nil)
 
 	labels, ok := deriveBindingOutcomeLabels(binding, false)
@@ -230,8 +230,8 @@ func TestIdentityBindingGaugeCollectorAggregatesOutcomes(t *testing.T) {
 	initializeConditions(&unsafe.Status, 1)
 	initializeConditions(&initializing.Status, 1)
 
-	applySuccessStatus(&readyA.Status, readyA.Generation, []renderedIdentity{{SpiffeID: "spiffe://kleym.sonda.red/ns/default/pool/pool-a"}}, nil)
-	applySuccessStatus(&readyB.Status, readyB.Generation, []renderedIdentity{{SpiffeID: "spiffe://kleym.sonda.red/ns/default/pool/pool-a"}}, nil)
+	applySuccessStatus(&readyA.Status, readyA.Generation, []renderedIdentity{{SpiffeID: "spiffe://kleym.sonda.red/ns/default/sa/inference-sa/inference/pool/pool-a"}}, nil)
+	applySuccessStatus(&readyB.Status, readyB.Generation, []renderedIdentity{{SpiffeID: "spiffe://kleym.sonda.red/ns/default/sa/inference-sa/inference/pool/pool-a"}}, nil)
 	applyFailureStatus(&unsafe.Status, unsafe.Generation, newStateError(conditionTypeUnsafeSelector, "UnsafeSelector", "selectors are unsafe"))
 
 	k8sClient := fake.NewClientBuilder().

--- a/internal/controller/inferenceidentitybinding_render.go
+++ b/internal/controller/inferenceidentitybinding_render.go
@@ -29,7 +29,7 @@ func (r *InferenceIdentityBindingReconciler) renderIdentity(
 	binding *kleymv1alpha1.InferenceIdentityBinding,
 	pool *unstructured.Unstructured,
 ) (identity.RenderedIdentity, error) {
-	podSelector, poolDerivedSelectors, err := gaie.DeriveSelectorsFromPool(pool)
+	target, err := gaie.ResolveInferenceTarget(pool)
 	if err != nil {
 		return identity.RenderedIdentity{}, &identity.StateError{
 			ConditionType: identity.ConditionTypeUnsafeSelector,
@@ -38,11 +38,10 @@ func (r *InferenceIdentityBindingReconciler) renderIdentity(
 		}
 	}
 	return identity.PlanIdentity(identity.PlanInput{
-		Binding:              binding,
-		TrustDomain:          r.Config.TrustDomain,
-		PoolName:             pool.GetName(),
-		PodSelector:          podSelector,
-		PoolDerivedSelectors: poolDerivedSelectors,
+		Namespace:          binding.Namespace,
+		ServiceAccountName: binding.Spec.ServiceAccountName,
+		TrustDomain:        r.Config.TrustDomain,
+		Target:             target,
 	})
 }
 

--- a/internal/controller/inferenceidentitybinding_render_test.go
+++ b/internal/controller/inferenceidentitybinding_render_test.go
@@ -64,6 +64,42 @@ func TestRenderIdentityPassesValidGAIESelectorIntoIdentityPlan(t *testing.T) {
 	if identity.PodSelector["matchLabels"] == nil {
 		t.Fatalf("expected GAIE matchLabels selector to be passed into identity plan, got %v", identity.PodSelector)
 	}
+	if identity.SpiffeID != "spiffe://kleym.sonda.red/ns/default/sa/inference-sa/inference/pool/pool-valid-selector" {
+		t.Fatalf("spiffeID = %q, want service-account-scoped pool target identity", identity.SpiffeID)
+	}
+}
+
+func TestRenderIdentityDistinguishesServiceAccountsForTheSamePool(t *testing.T) {
+	t.Parallel()
+
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig()}
+	pool := testRenderPool("pool-a", map[string]any{"app": "model-server"})
+
+	firstBinding := testRenderBinding("binding-a", "pool-a")
+	first, err := reconciler.renderIdentity(firstBinding, pool)
+	if err != nil {
+		t.Fatalf("renderIdentity returned error: %v", err)
+	}
+
+	secondBinding := testRenderBinding("binding-b", "pool-a")
+	secondBinding.Spec.ServiceAccountName = "other-inference-sa"
+	second, err := reconciler.renderIdentity(secondBinding, pool)
+	if err != nil {
+		t.Fatalf("renderIdentity returned error: %v", err)
+	}
+
+	if first.SpiffeID == second.SpiffeID {
+		t.Fatalf("SPIFFE IDs match for different service accounts: %q", first.SpiffeID)
+	}
+
+	samePrincipalBinding := testRenderBinding("binding-c", "pool-a")
+	samePrincipal, err := reconciler.renderIdentity(samePrincipalBinding, pool)
+	if err != nil {
+		t.Fatalf("renderIdentity returned error: %v", err)
+	}
+	if first.SpiffeID != samePrincipal.SpiffeID {
+		t.Fatalf("binding name changed SPIFFE ID: %q != %q", first.SpiffeID, samePrincipal.SpiffeID)
+	}
 }
 
 func testRenderBinding(name, poolName string) *kleymv1alpha1.InferenceIdentityBinding {

--- a/internal/controller/inferenceidentitybinding_resolver_test.go
+++ b/internal/controller/inferenceidentitybinding_resolver_test.go
@@ -105,8 +105,8 @@ func TestReconcileUsesOperatorConfigForRenderedOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read spec.spiffeIDTemplate: %v", err)
 	}
-	if spiffeID != "spiffe://example.org/ns/default/pool/pool-a" {
-		t.Fatalf("spiffeIDTemplate = %q, want spiffe://example.org/ns/default/pool/pool-a", spiffeID)
+	if spiffeID != "spiffe://example.org/ns/default/sa/inference-sa/inference/pool/pool-a" {
+		t.Fatalf("spiffeIDTemplate = %q, want spiffe://example.org/ns/default/sa/inference-sa/inference/pool/pool-a", spiffeID)
 	}
 	className, _, err := unstructured.NestedString(list.Items[0].Object, "spec", "className")
 	if err != nil {

--- a/internal/controller/inferenceidentitybinding_status_test.go
+++ b/internal/controller/inferenceidentitybinding_status_test.go
@@ -112,7 +112,7 @@ func TestApplySuccessStatusRecordsRenderedSelectors(t *testing.T) {
 		"k8s:sa:inference-sa",
 	}
 
-	spiffeID := "spiffe://example.org/ns/default/pool/pool-a"
+	spiffeID := "spiffe://example.org/ns/default/sa/inference-sa/inference/pool/pool-a"
 	applySuccessStatus(
 		&status,
 		4,
@@ -121,7 +121,7 @@ func TestApplySuccessStatusRecordsRenderedSelectors(t *testing.T) {
 			Selectors: wantSelectors,
 		}},
 		[]kleymv1alpha1.RenderedClusterSPIFFEIDStatus{{
-			Name:                "kleym-default-binding-pool-e2d8bd8d",
+			Name:                "kleym-default-binding-pool-34c1d5c4",
 			SpiffeID:            spiffeID,
 			SelectorFingerprint: identity.SelectorFingerprint(wantSelectors),
 		}},
@@ -154,15 +154,15 @@ func TestApplyFailureStatusClearsRenderedManagedStatus(t *testing.T) {
 	generation := int64(3)
 	status := kleymv1alpha1.InferenceIdentityBindingStatus{
 		ComputedSpiffeIDs: []kleymv1alpha1.ComputedSpiffeIDStatus{{
-			SpiffeID: "spiffe://example.org/ns/default/pool/pool-a",
+			SpiffeID: "spiffe://example.org/ns/default/sa/inference-sa/inference/pool/pool-a",
 		}},
 		RenderedSelectors: []kleymv1alpha1.RenderedSelectorStatus{{
-			SpiffeID:  "spiffe://example.org/ns/default/pool/pool-a",
+			SpiffeID:  "spiffe://example.org/ns/default/sa/inference-sa/inference/pool/pool-a",
 			Selectors: []string{"k8s:ns:default"},
 		}},
 		RenderedClusterSPIFFEID: &kleymv1alpha1.RenderedClusterSPIFFEIDStatus{
-			Name:                "kleym-default-binding-pool-e2d8bd8d",
-			SpiffeID:            "spiffe://example.org/ns/default/pool/pool-a",
+			Name:                "kleym-default-binding-pool-34c1d5c4",
+			SpiffeID:            "spiffe://example.org/ns/default/sa/inference-sa/inference/pool/pool-a",
 			SelectorFingerprint: "sha256:old",
 			ObservedGeneration:  &generation,
 		},
@@ -185,11 +185,11 @@ func TestRenderedClusterSPIFFEIDStatusRecordsObservedGeneration(t *testing.T) {
 	t.Parallel()
 
 	rendered := renderedIdentity{
-		SpiffeID:  "spiffe://example.org/ns/default/pool/pool-a",
+		SpiffeID:  "spiffe://example.org/ns/default/sa/inference-sa/inference/pool/pool-a",
 		Selectors: []string{"k8s:ns:default", "k8s:sa:inference-sa"},
 	}
 	object := &unstructured.Unstructured{}
-	object.SetName("kleym-default-binding-pool-e2d8bd8d")
+	object.SetName("kleym-default-binding-pool-34c1d5c4")
 	object.SetGeneration(7)
 
 	status := renderedClusterSPIFFEIDStatus(rendered, object)

--- a/internal/controller/inferenceidentitybinding_taxonomy_test.go
+++ b/internal/controller/inferenceidentitybinding_taxonomy_test.go
@@ -81,15 +81,15 @@ func TestReconcileManagedOutputApplyFailureSetsFailureStatus(t *testing.T) {
 	binding := newPoolOnlyBinding("binding-managed-output-apply-failure", "")
 	binding.Status = kleymv1alpha1.InferenceIdentityBindingStatus{
 		ComputedSpiffeIDs: []kleymv1alpha1.ComputedSpiffeIDStatus{{
-			SpiffeID: "spiffe://stale.example/ns/default/pool/old",
+			SpiffeID: "spiffe://stale.example/ns/default/sa/inference-sa/inference/pool/old",
 		}},
 		RenderedSelectors: []kleymv1alpha1.RenderedSelectorStatus{{
-			SpiffeID:  "spiffe://stale.example/ns/default/pool/old",
+			SpiffeID:  "spiffe://stale.example/ns/default/sa/inference-sa/inference/pool/old",
 			Selectors: []string{"k8s:ns:default", "k8s:sa:old"},
 		}},
 		RenderedClusterSPIFFEID: &kleymv1alpha1.RenderedClusterSPIFFEIDStatus{
 			Name:                "stale",
-			SpiffeID:            "spiffe://stale.example/ns/default/pool/old",
+			SpiffeID:            "spiffe://stale.example/ns/default/sa/inference-sa/inference/pool/old",
 			SelectorFingerprint: "sha256:stale",
 		},
 		Conditions: []metav1.Condition{{
@@ -157,15 +157,15 @@ func TestReconcileFailureCleanupApplyFailureSetsManagedOutputFailureStatus(t *te
 	binding.Spec.PoolRef.Name = "missing-pool"
 	binding.Status = kleymv1alpha1.InferenceIdentityBindingStatus{
 		ComputedSpiffeIDs: []kleymv1alpha1.ComputedSpiffeIDStatus{{
-			SpiffeID: "spiffe://stale.example/ns/default/pool/old",
+			SpiffeID: "spiffe://stale.example/ns/default/sa/inference-sa/inference/pool/old",
 		}},
 		RenderedSelectors: []kleymv1alpha1.RenderedSelectorStatus{{
-			SpiffeID:  "spiffe://stale.example/ns/default/pool/old",
+			SpiffeID:  "spiffe://stale.example/ns/default/sa/inference-sa/inference/pool/old",
 			Selectors: []string{"k8s:ns:default", "k8s:sa:old"},
 		}},
 		RenderedClusterSPIFFEID: &kleymv1alpha1.RenderedClusterSPIFFEIDStatus{
 			Name:                "stale",
-			SpiffeID:            "spiffe://stale.example/ns/default/pool/old",
+			SpiffeID:            "spiffe://stale.example/ns/default/sa/inference-sa/inference/pool/old",
 			SelectorFingerprint: "sha256:stale",
 		},
 		Conditions: []metav1.Condition{{

--- a/internal/gaie/resolver.go
+++ b/internal/gaie/resolver.go
@@ -27,7 +27,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/sonda-red/kleym/internal/identity"
 )
+
+const inferencePoolIdentityAnchorKind = "pool"
 
 // ResolveInferencePool reads a pool from the first matching supported GAIE GVK.
 func ResolveInferencePool(
@@ -158,4 +162,21 @@ func DeriveSelectorsFromPool(pool *unstructured.Unstructured) (map[string]any, [
 	}
 
 	return selectorMap, derivedSelectors, nil
+}
+
+// ResolveInferenceTarget maps a resolved GAIE InferencePool to source-independent identity inputs.
+func ResolveInferenceTarget(pool *unstructured.Unstructured) (identity.ResolvedInferenceTarget, error) {
+	podSelector, derivedSelectors, err := DeriveSelectorsFromPool(pool)
+	if err != nil {
+		return identity.ResolvedInferenceTarget{}, err
+	}
+
+	return identity.ResolvedInferenceTarget{
+		IdentityAnchor: identity.IdentityAnchor{
+			Kind: inferencePoolIdentityAnchorKind,
+			Name: pool.GetName(),
+		},
+		PodSelector:      podSelector,
+		DerivedSelectors: derivedSelectors,
+	}, nil
 }

--- a/internal/gaie/resolver_test.go
+++ b/internal/gaie/resolver_test.go
@@ -98,6 +98,31 @@ func TestResolveInferencePoolPropagatesUnexpectedReaderError(t *testing.T) {
 	}
 }
 
+func TestResolveInferenceTargetUsesPoolIdentityAnchor(t *testing.T) {
+	t.Parallel()
+
+	pool := testPool("pool-a")
+	pool.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "inference.networking.k8s.io",
+		Version: "v1",
+		Kind:    "InferencePool",
+	})
+
+	target, err := ResolveInferenceTarget(pool)
+	if err != nil {
+		t.Fatalf("ResolveInferenceTarget returned error: %v", err)
+	}
+	if target.IdentityAnchor.Kind != "pool" || target.IdentityAnchor.Name != "pool-a" {
+		t.Fatalf("identity anchor = %+v, want pool/pool-a", target.IdentityAnchor)
+	}
+	if _, ok := target.PodSelector["matchLabels"].(map[string]any); !ok {
+		t.Fatalf("pod selector = %v, want matchLabels", target.PodSelector)
+	}
+	if !slices.Contains(target.DerivedSelectors, "k8s:pod-label:app:model-server") {
+		t.Fatalf("derived selectors = %v, want pool label selector", target.DerivedSelectors)
+	}
+}
+
 func TestConditionTaxonomyReasonStrings(t *testing.T) {
 	t.Parallel()
 

--- a/internal/identity/render.go
+++ b/internal/identity/render.go
@@ -28,7 +28,6 @@ import (
 
 // PlanIdentity computes desired identity state from resolved, read-only inputs.
 func PlanIdentity(input PlanInput) (Plan, error) {
-	binding := input.Binding
 	if strings.TrimSpace(input.TrustDomain) == "" {
 		return Plan{}, newStateError(
 			ConditionTypeRenderFailure,
@@ -38,12 +37,12 @@ func PlanIdentity(input PlanInput) (Plan, error) {
 	}
 
 	templateData := renderTemplateData{
-		Namespace:   binding.Namespace,
-		BindingName: binding.Name,
-		PoolName:    input.PoolName,
+		Namespace:          input.Namespace,
+		ServiceAccountName: input.ServiceAccountName,
+		IdentityAnchor:     input.Target.IdentityAnchor,
 	}
 
-	renderedSelectors, err := renderSafetySelectors(binding.Namespace, binding.Spec.ServiceAccountName)
+	renderedSelectors, err := renderSafetySelectors(input.Namespace, input.ServiceAccountName)
 	if err != nil {
 		return Plan{}, newStateError(
 			ConditionTypeRenderFailure,
@@ -51,10 +50,17 @@ func PlanIdentity(input PlanInput) (Plan, error) {
 			err.Error(),
 		)
 	}
+	if err := validateIdentityAnchor(input.Target.IdentityAnchor); err != nil {
+		return Plan{}, newStateError(
+			ConditionTypeRenderFailure,
+			ReasonInvalidSPIFFEID,
+			err.Error(),
+		)
+	}
 
-	selectors := append(renderedSelectors, input.PoolDerivedSelectors...)
+	selectors := append(renderedSelectors, input.Target.DerivedSelectors...)
 	selectors = UniqueAndSorted(selectors)
-	if err := validateRenderedSafetySelectors(binding.Namespace, selectors); err != nil {
+	if err := validateRenderedSafetySelectors(input.Namespace, selectors); err != nil {
 		return Plan{}, newStateError(
 			ConditionTypeUnsafeSelector,
 			ReasonUnsafeSelector,
@@ -62,7 +68,7 @@ func PlanIdentity(input PlanInput) (Plan, error) {
 		)
 	}
 
-	spiffeID := renderPoolSPIFFEID(input.TrustDomain, templateData)
+	spiffeID := renderInferenceTargetSPIFFEID(input.TrustDomain, templateData)
 	if !strings.HasPrefix(spiffeID, "spiffe://") {
 		return Plan{}, newStateError(
 			ConditionTypeRenderFailure,
@@ -72,10 +78,10 @@ func PlanIdentity(input PlanInput) (Plan, error) {
 	}
 
 	return Plan{
-		SpiffeID:    spiffeID,
-		Selectors:   selectors,
-		PodSelector: input.PodSelector,
-		PoolRef:     input.PoolName,
+		SpiffeID:       spiffeID,
+		Selectors:      selectors,
+		PodSelector:    input.Target.PodSelector,
+		IdentityAnchor: input.Target.IdentityAnchor,
 	}, nil
 }
 
@@ -93,9 +99,33 @@ func renderSafetySelectors(namespace, serviceAccountName string) ([]string, erro
 	}, nil
 }
 
-// renderPoolSPIFFEID computes the fixed pool SPIFFE ID form defined by docs/spec/operator.md.
-func renderPoolSPIFFEID(trustDomain string, data renderTemplateData) string {
-	return fmt.Sprintf("spiffe://%s/ns/%s/pool/%s", trustDomain, data.Namespace, data.PoolName)
+// validateIdentityAnchor keeps source resolver output safe before it enters the SPIFFE path.
+func validateIdentityAnchor(anchor IdentityAnchor) error {
+	if strings.TrimSpace(anchor.Kind) == "" {
+		return fmt.Errorf("identity anchor kind must not be empty")
+	}
+	if strings.TrimSpace(anchor.Name) == "" {
+		return fmt.Errorf("identity anchor name must not be empty")
+	}
+	if strings.Contains(anchor.Kind, "/") || strings.Contains(anchor.Name, "/") {
+		return fmt.Errorf("identity anchor segments must not contain /")
+	}
+	if anchor.Kind != strings.TrimSpace(anchor.Kind) || anchor.Name != strings.TrimSpace(anchor.Name) {
+		return fmt.Errorf("identity anchor segments must not include leading or trailing whitespace")
+	}
+	return nil
+}
+
+// renderInferenceTargetSPIFFEID computes the resolved-target SPIFFE ID form from docs/spec/operator.md.
+func renderInferenceTargetSPIFFEID(trustDomain string, data renderTemplateData) string {
+	return fmt.Sprintf(
+		"spiffe://%s/ns/%s/sa/%s/inference/%s/%s",
+		trustDomain,
+		data.Namespace,
+		data.ServiceAccountName,
+		data.IdentityAnchor.Kind,
+		data.IdentityAnchor.Name,
+	)
 }
 
 // validateRenderedSafetySelectors verifies that internally-rendered safety selectors are still present.

--- a/internal/identity/render.go
+++ b/internal/identity/render.go
@@ -60,7 +60,7 @@ func PlanIdentity(input PlanInput) (Plan, error) {
 
 	selectors := append(renderedSelectors, input.Target.DerivedSelectors...)
 	selectors = UniqueAndSorted(selectors)
-	if err := validateRenderedSafetySelectors(input.Namespace, selectors); err != nil {
+	if err := validateRenderedSafetySelectors(input.Namespace, input.ServiceAccountName, selectors); err != nil {
 		return Plan{}, newStateError(
 			ConditionTypeUnsafeSelector,
 			ReasonUnsafeSelector,
@@ -129,7 +129,7 @@ func renderInferenceTargetSPIFFEID(trustDomain string, data renderTemplateData) 
 }
 
 // validateRenderedSafetySelectors verifies that internally-rendered safety selectors are still present.
-func validateRenderedSafetySelectors(namespace string, selectors []string) error {
+func validateRenderedSafetySelectors(namespace, serviceAccountName string, selectors []string) error {
 	hasNamespaceSelector := false
 	hasServiceAccountSelector := false
 
@@ -145,6 +145,9 @@ func validateRenderedSafetySelectors(namespace string, selectors []string) error
 			serviceAccount := strings.TrimPrefix(selector, "k8s:sa:")
 			if strings.TrimSpace(serviceAccount) == "" {
 				return fmt.Errorf("service account selector must not be empty")
+			}
+			if serviceAccount != serviceAccountName {
+				return fmt.Errorf("selector %q escapes binding service account %q", selector, serviceAccountName)
 			}
 			hasServiceAccountSelector = true
 		}

--- a/internal/identity/render_test.go
+++ b/internal/identity/render_test.go
@@ -192,6 +192,25 @@ func TestPlanIdentityRejectsUnsafeSelector(t *testing.T) {
 	}
 }
 
+func TestPlanIdentityRejectsEscapedServiceAccountSelector(t *testing.T) {
+	t.Parallel()
+
+	input := testPlanInput(testBinding(), "pool-a")
+	input.Target.DerivedSelectors = append(input.Target.DerivedSelectors, "k8s:sa:other-inference-sa")
+
+	_, err := PlanIdentity(input)
+	if err == nil {
+		t.Fatalf("expected escaped service account selector error, got nil")
+	}
+	var stateErr *StateError
+	if !errors.As(err, &stateErr) {
+		t.Fatalf("expected StateError, got %T", err)
+	}
+	if stateErr.ConditionType != ConditionTypeUnsafeSelector || stateErr.Reason != ReasonUnsafeSelector {
+		t.Fatalf("condition/reason = %q/%q, want %q/%q", stateErr.ConditionType, stateErr.Reason, ConditionTypeUnsafeSelector, ReasonUnsafeSelector)
+	}
+}
+
 func TestPlanIdentityRejectsInvalidIdentityAnchor(t *testing.T) {
 	t.Parallel()
 

--- a/internal/identity/render_test.go
+++ b/internal/identity/render_test.go
@@ -42,7 +42,7 @@ func TestPlanIdentityRejectsInvalidServiceAccountName(t *testing.T) {
 	}
 }
 
-func TestPlanIdentityUsesPoolSPIFFEID(t *testing.T) {
+func TestPlanIdentityUsesServiceAccountScopedInferenceTargetSPIFFEID(t *testing.T) {
 	t.Parallel()
 
 	binding := testBinding()
@@ -52,7 +52,7 @@ func TestPlanIdentityUsesPoolSPIFFEID(t *testing.T) {
 		t.Fatalf("PlanIdentity returned error: %v", err)
 	}
 
-	expectedSPIFFEID := "spiffe://example.org/ns/default/pool/pool-a"
+	expectedSPIFFEID := "spiffe://example.org/ns/default/sa/inference-sa/inference/pool/pool-a"
 	if identity.SpiffeID != expectedSPIFFEID {
 		t.Fatalf("spiffeID = %q, want %q", identity.SpiffeID, expectedSPIFFEID)
 	}
@@ -67,11 +67,35 @@ func TestPlanIdentityUsesPoolSPIFFEID(t *testing.T) {
 	}
 }
 
+func TestPlanIdentityDistinguishesServiceAccountsForTheSameTarget(t *testing.T) {
+	t.Parallel()
+
+	firstInput := testPlanInput(testBinding(), "pool-a")
+	first, err := PlanIdentity(firstInput)
+	if err != nil {
+		t.Fatalf("PlanIdentity returned error: %v", err)
+	}
+
+	secondInput := testPlanInput(testBinding(), "pool-a")
+	secondInput.ServiceAccountName = "other-inference-sa"
+	second, err := PlanIdentity(secondInput)
+	if err != nil {
+		t.Fatalf("PlanIdentity returned error: %v", err)
+	}
+
+	if first.SpiffeID == second.SpiffeID {
+		t.Fatalf("SPIFFE IDs match for different service accounts: %q", first.SpiffeID)
+	}
+	if !containsString(second.Selectors, "k8s:sa:other-inference-sa") {
+		t.Fatalf("selectors = %v, want other service account selector", second.Selectors)
+	}
+}
+
 func TestPlanIdentityCanonicalizesRenderedSelectors(t *testing.T) {
 	t.Parallel()
 
 	input := testPlanInput(testBinding(), "pool-a")
-	input.PoolDerivedSelectors = []string{
+	input.Target.DerivedSelectors = []string{
 		"k8s:pod-label:z:last",
 		"k8s:pod-label:app:model-server",
 		"k8s:pod-label:app:model-server",
@@ -153,7 +177,7 @@ func TestPlanIdentityRejectsUnsafeSelector(t *testing.T) {
 	t.Parallel()
 
 	input := testPlanInput(testBinding(), "pool-a")
-	input.PoolDerivedSelectors = append(input.PoolDerivedSelectors, "k8s:ns:other")
+	input.Target.DerivedSelectors = append(input.Target.DerivedSelectors, "k8s:ns:other")
 
 	_, err := PlanIdentity(input)
 	if err == nil {
@@ -165,6 +189,25 @@ func TestPlanIdentityRejectsUnsafeSelector(t *testing.T) {
 	}
 	if stateErr.ConditionType != ConditionTypeUnsafeSelector || stateErr.Reason != "UnsafeSelector" {
 		t.Fatalf("condition/reason = %q/%q, want %q/UnsafeSelector", stateErr.ConditionType, stateErr.Reason, ConditionTypeUnsafeSelector)
+	}
+}
+
+func TestPlanIdentityRejectsInvalidIdentityAnchor(t *testing.T) {
+	t.Parallel()
+
+	input := testPlanInput(testBinding(), "pool-a")
+	input.Target.IdentityAnchor.Name = "bad/pool"
+
+	_, err := PlanIdentity(input)
+	if err == nil {
+		t.Fatalf("expected invalid identity anchor error, got nil")
+	}
+	var stateErr *StateError
+	if !errors.As(err, &stateErr) {
+		t.Fatalf("expected StateError, got %T", err)
+	}
+	if stateErr.ConditionType != ConditionTypeRenderFailure || stateErr.Reason != ReasonInvalidSPIFFEID {
+		t.Fatalf("condition/reason = %q/%q, want %q/%q", stateErr.ConditionType, stateErr.Reason, ConditionTypeRenderFailure, ReasonInvalidSPIFFEID)
 	}
 }
 
@@ -211,11 +254,16 @@ func testPlanInput(
 	poolName string,
 ) PlanInput {
 	return PlanInput{
-		Binding:              binding,
-		TrustDomain:          "example.org",
-		PoolName:             poolName,
-		PodSelector:          map[string]any{"matchLabels": map[string]any{"app": "model-server"}},
-		PoolDerivedSelectors: []string{"k8s:pod-label:app:model-server"},
+		Namespace:          binding.Namespace,
+		ServiceAccountName: binding.Spec.ServiceAccountName,
+		TrustDomain:        "example.org",
+		Target: ResolvedInferenceTarget{
+			IdentityAnchor: IdentityAnchor{Kind: "pool", Name: poolName},
+			PodSelector:    map[string]any{"matchLabels": map[string]any{"app": "model-server"}},
+			DerivedSelectors: []string{
+				"k8s:pod-label:app:model-server",
+			},
+		},
 	}
 }
 

--- a/internal/identity/types.go
+++ b/internal/identity/types.go
@@ -17,8 +17,6 @@ package identity
 
 import (
 	"k8s.io/apimachinery/pkg/types"
-
-	kleymv1alpha1 "github.com/sonda-red/kleym/api/v1alpha1"
 )
 
 const (
@@ -62,30 +60,43 @@ func newStateError(conditionType, reason, message string) *StateError {
 	}
 }
 
+// IdentityAnchor identifies the inference-serving boundary used in a SPIFFE ID.
+type IdentityAnchor struct {
+	Kind string
+	Name string
+}
+
+// ResolvedInferenceTarget carries source-independent identity and selector data.
+// Source-specific resolvers populate it before identity rendering.
+type ResolvedInferenceTarget struct {
+	IdentityAnchor   IdentityAnchor
+	PodSelector      map[string]any
+	DerivedSelectors []string
+}
+
 // PlanInput carries already-resolved identity planning inputs.
 type PlanInput struct {
-	Binding              *kleymv1alpha1.InferenceIdentityBinding
-	TrustDomain          string
-	PoolName             string
-	PodSelector          map[string]any
-	PoolDerivedSelectors []string
+	Namespace          string
+	ServiceAccountName string
+	TrustDomain        string
+	Target             ResolvedInferenceTarget
 }
 
 // Plan is the pure desired identity state shared by the controller and CLI.
 type Plan struct {
-	SpiffeID    string
-	Selectors   []string
-	PodSelector map[string]any
-	PoolRef     string
+	SpiffeID       string
+	Selectors      []string
+	PodSelector    map[string]any
+	IdentityAnchor IdentityAnchor
 }
 
 // RenderedIdentity is kept as a compatibility alias for callers during the package split.
 type RenderedIdentity = Plan
 
 type renderTemplateData struct {
-	Namespace   string
-	BindingName string
-	PoolName    string
+	Namespace          string
+	ServiceAccountName string
+	IdentityAnchor     IdentityAnchor
 }
 
 // NamespacedBindingKey returns the canonical namespace/name key used in logs and messages.

--- a/internal/inspection/inspection.go
+++ b/internal/inspection/inspection.go
@@ -327,7 +327,7 @@ func (i *bindingInspector) inspectRenderedIdentity(
 	}
 	report.Resolved.PoolRef = poolRefToReportRef(poolRef, pool.GroupVersionKind())
 
-	poolSelector, poolDerivedSelectors, err := gaie.DeriveSelectorsFromPool(pool)
+	target, err := gaie.ResolveInferenceTarget(pool)
 	if err != nil {
 		report.Capabilities.GAIEResources = BindingInspectionCapabilityFull
 		i.addFindingForError(report, &identity.StateError{
@@ -339,11 +339,10 @@ func (i *bindingInspector) inspectRenderedIdentity(
 	}
 
 	rendered, err := identity.PlanIdentity(identity.PlanInput{
-		Binding:              binding,
-		TrustDomain:          identityConfig.trustDomain,
-		PoolName:             pool.GetName(),
-		PodSelector:          poolSelector,
-		PoolDerivedSelectors: poolDerivedSelectors,
+		Namespace:          binding.Namespace,
+		ServiceAccountName: binding.Spec.ServiceAccountName,
+		TrustDomain:        identityConfig.trustDomain,
+		Target:             target,
 	})
 	if err != nil {
 		report.Capabilities.GAIEResources = BindingInspectionCapabilityFull
@@ -351,8 +350,8 @@ func (i *bindingInspector) inspectRenderedIdentity(
 		return identity.RenderedIdentity{}, false
 	}
 
-	provenance := selectorProvenance(rendered, poolDerivedSelectors)
-	report.Resolved.PoolSelector = poolSelector
+	provenance := selectorProvenance(rendered, target.DerivedSelectors)
+	report.Resolved.PoolSelector = target.PodSelector
 	report.Resolved.SelectorProvenance = &provenance
 	clusterSPIFFEIDName := spirecm.BuildClusterSPIFFEIDName(binding.Namespace, binding.Name, rendered.SpiffeID)
 	clusterSPIFFEIDHint := spirecm.BuildClusterSPIFFEIDHint(binding)

--- a/internal/inspection/inspection.go
+++ b/internal/inspection/inspection.go
@@ -353,7 +353,12 @@ func (i *bindingInspector) inspectRenderedIdentity(
 	provenance := selectorProvenance(rendered, target.DerivedSelectors)
 	report.Resolved.PoolSelector = target.PodSelector
 	report.Resolved.SelectorProvenance = &provenance
-	clusterSPIFFEIDName := spirecm.BuildClusterSPIFFEIDName(binding.Namespace, binding.Name, rendered.SpiffeID)
+	clusterSPIFFEIDName := spirecm.BuildClusterSPIFFEIDName(
+		binding.Namespace,
+		binding.Name,
+		rendered.IdentityAnchor.Kind,
+		rendered.SpiffeID,
+	)
 	clusterSPIFFEIDHint := spirecm.BuildClusterSPIFFEIDHint(binding)
 	clusterSPIFFEIDFallback := boolPtr(spirecm.RenderFallback())
 	report.RenderedIdentity = BindingInspectionRenderedIdentity{

--- a/internal/inspection/inspection_test.go
+++ b/internal/inspection/inspection_test.go
@@ -44,7 +44,12 @@ func TestInspectBindingSuccessReport(t *testing.T) {
 	if report.BindingRef.Name != "binding-a" {
 		t.Fatalf("bindingRef = %#v", report.BindingRef)
 	}
-	expectedName := spirecm.BuildClusterSPIFFEIDName(binding.Namespace, binding.Name, rendered.SpiffeID)
+	expectedName := spirecm.BuildClusterSPIFFEIDName(
+		binding.Namespace,
+		binding.Name,
+		rendered.IdentityAnchor.Kind,
+		rendered.SpiffeID,
+	)
 	if report.RenderedClusterSPIFFEID.Name != expectedName {
 		t.Fatalf("rendered ClusterSPIFFEID name = %q, want %q", report.RenderedClusterSPIFFEID.Name, expectedName)
 	}

--- a/internal/inspection/inspection_test.go
+++ b/internal/inspection/inspection_test.go
@@ -116,7 +116,7 @@ func TestInspectBindingUsesStatusOperatorConfig(t *testing.T) {
 		t.Fatalf("InspectBinding returned error: %v", err)
 	}
 
-	if report.RenderedIdentity.SPIFFEID != "spiffe://example.org/ns/tenant-a/pool/pool-a" {
+	if report.RenderedIdentity.SPIFFEID != "spiffe://example.org/ns/tenant-a/sa/model-sa/inference/pool/pool-a" {
 		t.Fatalf("rendered spiffeID = %q, want configured trust domain", report.RenderedIdentity.SPIFFEID)
 	}
 	if report.RenderedClusterSPIFFEID.ClassName != "kleym" {
@@ -158,7 +158,7 @@ func TestInspectBindingFlagsOverrideStatusOperatorConfig(t *testing.T) {
 		report.IdentityConfig.ClusterSPIFFEIDClassNameSource != identityConfigSourceFlag {
 		t.Fatalf("identityConfig = %#v, want flag sources", report.IdentityConfig)
 	}
-	if report.RenderedIdentity.SPIFFEID != "spiffe://example.org/ns/tenant-a/pool/pool-a" ||
+	if report.RenderedIdentity.SPIFFEID != "spiffe://example.org/ns/tenant-a/sa/model-sa/inference/pool/pool-a" ||
 		report.RenderedClusterSPIFFEID.ClassName != "kleym" {
 		t.Fatalf("rendered output = %#v / %#v, want flag-rendered output", report.RenderedIdentity, report.RenderedClusterSPIFFEID)
 	}
@@ -272,7 +272,7 @@ func TestInspectBindingIgnoresManagedClusterSPIFFEIDState(t *testing.T) {
 		t.Fatalf("render test identity: %v", err)
 	}
 	managed := spirecm.DesiredClusterSPIFFEID(binding, rendered, "")
-	if err := unstructured.SetNestedField(managed.Object, "spiffe://wrong.example.test/ns/tenant-a/pool/pool-a", "spec", "spiffeIDTemplate"); err != nil {
+	if err := unstructured.SetNestedField(managed.Object, "spiffe://wrong.example.test/ns/tenant-a/sa/model-sa/inference/pool/pool-a", "spec", "spiffeIDTemplate"); err != nil {
 		t.Fatalf("set mismatched spiffeIDTemplate: %v", err)
 	}
 	pod := testInspectionPod("model-server-a", "model-server")
@@ -621,16 +621,15 @@ func inspectionPlanWithTrustDomain(
 	pool *unstructured.Unstructured,
 	trustDomain string,
 ) (identity.Plan, error) {
-	poolSelector, poolDerivedSelectors, err := gaie.DeriveSelectorsFromPool(pool)
+	target, err := gaie.ResolveInferenceTarget(pool)
 	if err != nil {
 		return identity.Plan{}, err
 	}
 	return identity.PlanIdentity(identity.PlanInput{
-		Binding:              binding,
-		TrustDomain:          trustDomain,
-		PoolName:             pool.GetName(),
-		PodSelector:          poolSelector,
-		PoolDerivedSelectors: poolDerivedSelectors,
+		Namespace:          binding.Namespace,
+		ServiceAccountName: binding.Spec.ServiceAccountName,
+		TrustDomain:        trustDomain,
+		Target:             target,
 	})
 }
 

--- a/internal/inspection/report_test.go
+++ b/internal/inspection/report_test.go
@@ -120,7 +120,7 @@ func TestBindingInspectionReportJSONRepresentativeShape(t *testing.T) {
 			},
 		},
 		RenderedIdentity: BindingInspectionRenderedIdentity{
-			SPIFFEID: "spiffe://kleym.sonda.red/ns/tenant-a/pool/pool-a",
+			SPIFFEID: "spiffe://kleym.sonda.red/ns/tenant-a/sa/model-sa/inference/pool/pool-a",
 			PodSelector: map[string]any{
 				"matchLabels": map[string]any{"app": "pool-a"},
 			},
@@ -136,7 +136,7 @@ func TestBindingInspectionReportJSONRepresentativeShape(t *testing.T) {
 		},
 		RenderedClusterSPIFFEID: BindingInspectionRenderedClusterSPIFFEID{
 			Name:     "tenant-a-binding-a-1234abcd",
-			SPIFFEID: "spiffe://kleym.sonda.red/ns/tenant-a/pool/pool-a",
+			SPIFFEID: "spiffe://kleym.sonda.red/ns/tenant-a/sa/model-sa/inference/pool/pool-a",
 			PodSelector: map[string]any{
 				"matchLabels": map[string]any{"app": "pool-a"},
 			},
@@ -289,13 +289,13 @@ func TestWriteBindingInspectionReportTextRepresentativeReport(t *testing.T) {
 			},
 		},
 		RenderedIdentity: BindingInspectionRenderedIdentity{
-			SPIFFEID:          "spiffe://kleym.sonda.red/ns/tenant-a/pool/pool-a",
+			SPIFFEID:          "spiffe://kleym.sonda.red/ns/tenant-a/sa/model-sa/inference/pool/pool-a",
 			PodSelector:       map[string]any{"matchLabels": map[string]any{"app": "pool-a"}},
 			WorkloadSelectors: []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
 		},
 		RenderedClusterSPIFFEID: BindingInspectionRenderedClusterSPIFFEID{
 			Name:              "tenant-a-binding-a-1234abcd",
-			SPIFFEID:          "spiffe://kleym.sonda.red/ns/tenant-a/pool/pool-a",
+			SPIFFEID:          "spiffe://kleym.sonda.red/ns/tenant-a/sa/model-sa/inference/pool/pool-a",
 			PodSelector:       map[string]any{"matchLabels": map[string]any{"app": "pool-a"}},
 			WorkloadSelectors: []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
 			Hint:              "tenant-a/binding-a",
@@ -323,7 +323,7 @@ func TestWriteBindingInspectionReportTextRepresentativeReport(t *testing.T) {
 		"Binding: tenant-a/binding-a",
 		"Source: InferencePool tenant-a/pool-a",
 		"Identity:",
-		"SPIFFE ID: spiffe://kleym.sonda.red/ns/tenant-a/pool/pool-a",
+		"SPIFFE ID: spiffe://kleym.sonda.red/ns/tenant-a/sa/model-sa/inference/pool/pool-a",
 		"namespace: tenant-a",
 		"serviceAccount: model-sa",
 		"ClusterSPIFFEID:",
@@ -350,13 +350,13 @@ func TestWriteBindingInspectionReportTextHealthy(t *testing.T) {
 			Name:      "binding-a",
 		},
 		RenderedIdentity: BindingInspectionRenderedIdentity{
-			SPIFFEID:          "spiffe://kleym.sonda.red/ns/tenant-a/pool/pool-a",
+			SPIFFEID:          "spiffe://kleym.sonda.red/ns/tenant-a/sa/model-sa/inference/pool/pool-a",
 			PodSelector:       map[string]any{"matchLabels": map[string]any{"app": "pool-a"}},
 			WorkloadSelectors: []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
 		},
 		RenderedClusterSPIFFEID: BindingInspectionRenderedClusterSPIFFEID{
 			Name:              "tenant-a-binding-a-1234abcd",
-			SPIFFEID:          "spiffe://kleym.sonda.red/ns/tenant-a/pool/pool-a",
+			SPIFFEID:          "spiffe://kleym.sonda.red/ns/tenant-a/sa/model-sa/inference/pool/pool-a",
 			PodSelector:       map[string]any{"matchLabels": map[string]any{"app": "pool-a"}},
 			WorkloadSelectors: []string{"k8s:ns:tenant-a", "k8s:sa:model-sa"},
 			Hint:              "tenant-a/binding-a",

--- a/internal/inspection/status_test.go
+++ b/internal/inspection/status_test.go
@@ -131,7 +131,7 @@ func testStatusBinding(
 		LastTransitionTime: metav1.Now(),
 	}}
 	binding.Status.RenderedSelectors = []kleymv1alpha1.RenderedSelectorStatus{{
-		SpiffeID: "spiffe://kleym.sonda.red/ns/tenant-a/pool/pool-a",
+		SpiffeID: "spiffe://kleym.sonda.red/ns/tenant-a/sa/model-sa/inference/pool/pool-a",
 		Selectors: []string{
 			"k8s:ns:tenant-a",
 			"k8s:sa:model-sa",

--- a/internal/spirecm/clusterspiffeid.go
+++ b/internal/spirecm/clusterspiffeid.go
@@ -75,7 +75,12 @@ func DesiredClusterSPIFFEID(
 ) *unstructured.Unstructured {
 	object := &unstructured.Unstructured{}
 	object.SetGroupVersionKind(ClusterSPIFFEIDGVK())
-	object.SetName(BuildClusterSPIFFEIDName(binding.Namespace, binding.Name, plan.SpiffeID))
+	object.SetName(BuildClusterSPIFFEIDName(
+		binding.Namespace,
+		binding.Name,
+		plan.IdentityAnchor.Kind,
+		plan.SpiffeID,
+	))
 	object.SetLabels(ManagedClusterSPIFFEIDLabels(binding))
 
 	selectorTemplates := make([]any, 0, len(plan.Selectors))
@@ -111,9 +116,13 @@ func ManagedClusterSPIFFEIDLabels(binding *kleymv1alpha1.InferenceIdentityBindin
 func BuildClusterSPIFFEIDName(
 	namespace string,
 	bindingName string,
+	identityAnchorKind string,
 	spiffeID string,
 ) string {
-	modeText := "pool"
+	modeText := sanitizeDNSLabel(identityAnchorKind)
+	if modeText == "" {
+		modeText = "identity"
+	}
 
 	hashSum := sha1.Sum([]byte(spiffeID))
 	hashSuffix := hex.EncodeToString(hashSum[:nameHashBytes])
@@ -219,7 +228,7 @@ func DriftEntries(desired *unstructured.Unstructured, observed *unstructured.Uns
 func sanitizeDNSLabel(input string) string {
 	lower := strings.ToLower(strings.TrimSpace(input))
 	if lower == "" {
-		return defaultNameValue
+		return ""
 	}
 
 	var labelBuilder strings.Builder
@@ -239,7 +248,7 @@ func sanitizeDNSLabel(input string) string {
 
 	sanitized := strings.Trim(labelBuilder.String(), "-")
 	if sanitized == "" {
-		return defaultNameValue
+		return ""
 	}
 
 	return sanitized

--- a/internal/spirecm/clusterspiffeid_test.go
+++ b/internal/spirecm/clusterspiffeid_test.go
@@ -17,7 +17,7 @@ func TestDesiredClusterSPIFFEIDIncludesHintAndFallback(t *testing.T) {
 	binding.Name = "binding-a"
 	binding.Namespace = "default"
 	plan := identity.Plan{
-		SpiffeID:    "spiffe://kleym.sonda.red/ns/default/pool/pool-a",
+		SpiffeID:    "spiffe://kleym.sonda.red/ns/default/sa/inference-sa/inference/pool/pool-a",
 		PodSelector: map[string]any{"matchLabels": map[string]any{"app": "model-server"}},
 		Selectors:   []string{"k8s:ns:default", "k8s:sa:inference-sa", "k8s:pod-label:app:model-server"},
 	}
@@ -46,14 +46,17 @@ func TestDesiredClusterSPIFFEIDUsesCanonicalSelectorTemplates(t *testing.T) {
 	binding.Namespace = "default"
 	binding.Spec.ServiceAccountName = "inference-sa"
 	plan, err := identity.PlanIdentity(identity.PlanInput{
-		Binding:     binding,
-		TrustDomain: "example.org",
-		PoolName:    "pool-a",
-		PodSelector: map[string]any{"matchLabels": map[string]any{"app": "model-server"}},
-		PoolDerivedSelectors: []string{
-			"k8s:pod-label:team:ml",
-			"k8s:pod-label:app:model-server",
-			"k8s:pod-label:app:model-server",
+		Namespace:          binding.Namespace,
+		ServiceAccountName: binding.Spec.ServiceAccountName,
+		TrustDomain:        "example.org",
+		Target: identity.ResolvedInferenceTarget{
+			IdentityAnchor: identity.IdentityAnchor{Kind: "pool", Name: "pool-a"},
+			PodSelector:    map[string]any{"matchLabels": map[string]any{"app": "model-server"}},
+			DerivedSelectors: []string{
+				"k8s:pod-label:team:ml",
+				"k8s:pod-label:app:model-server",
+				"k8s:pod-label:app:model-server",
+			},
 		},
 	})
 	if err != nil {
@@ -91,7 +94,7 @@ func TestDesiredClusterSPIFFEIDClassName(t *testing.T) {
 	binding.Name = "binding-a"
 	binding.Namespace = "default"
 	plan := identity.Plan{
-		SpiffeID:    "spiffe://example.org/ns/default/pool/pool-a",
+		SpiffeID:    "spiffe://example.org/ns/default/sa/inference-sa/inference/pool/pool-a",
 		PodSelector: map[string]any{"matchLabels": map[string]any{"app": "model-server"}},
 		Selectors:   []string{"k8s:ns:default", "k8s:sa:inference-sa", "k8s:pod-label:app:model-server"},
 	}
@@ -112,5 +115,19 @@ func TestDesiredClusterSPIFFEIDClassName(t *testing.T) {
 	}
 	if classedSpec["className"] != "kleym" {
 		t.Fatalf("className = %q, want kleym", classedSpec["className"])
+	}
+}
+
+func TestBuildClusterSPIFFEIDNameUsesServiceAccountScopedIdentityHash(t *testing.T) {
+	t.Parallel()
+
+	got := BuildClusterSPIFFEIDName(
+		"kleym-reference-inference",
+		"binding",
+		"spiffe://kleym.sonda.red/ns/kleym-reference-inference/sa/reference-inference/inference/pool/reference-pool",
+	)
+	want := "kleym-kleym-reference-inference-binding-pool-e1a1f353"
+	if got != want {
+		t.Fatalf("BuildClusterSPIFFEIDName = %q, want %q", got, want)
 	}
 }

--- a/internal/spirecm/clusterspiffeid_test.go
+++ b/internal/spirecm/clusterspiffeid_test.go
@@ -2,6 +2,7 @@ package spirecm
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -17,9 +18,10 @@ func TestDesiredClusterSPIFFEIDIncludesHintAndFallback(t *testing.T) {
 	binding.Name = "binding-a"
 	binding.Namespace = "default"
 	plan := identity.Plan{
-		SpiffeID:    "spiffe://kleym.sonda.red/ns/default/sa/inference-sa/inference/pool/pool-a",
-		PodSelector: map[string]any{"matchLabels": map[string]any{"app": "model-server"}},
-		Selectors:   []string{"k8s:ns:default", "k8s:sa:inference-sa", "k8s:pod-label:app:model-server"},
+		SpiffeID:       "spiffe://kleym.sonda.red/ns/default/sa/inference-sa/inference/pool/pool-a",
+		PodSelector:    map[string]any{"matchLabels": map[string]any{"app": "model-server"}},
+		Selectors:      []string{"k8s:ns:default", "k8s:sa:inference-sa", "k8s:pod-label:app:model-server"},
+		IdentityAnchor: identity.IdentityAnchor{Kind: "pool", Name: "pool-a"},
 	}
 
 	desired := DesiredClusterSPIFFEID(binding, plan, "")
@@ -94,9 +96,10 @@ func TestDesiredClusterSPIFFEIDClassName(t *testing.T) {
 	binding.Name = "binding-a"
 	binding.Namespace = "default"
 	plan := identity.Plan{
-		SpiffeID:    "spiffe://example.org/ns/default/sa/inference-sa/inference/pool/pool-a",
-		PodSelector: map[string]any{"matchLabels": map[string]any{"app": "model-server"}},
-		Selectors:   []string{"k8s:ns:default", "k8s:sa:inference-sa", "k8s:pod-label:app:model-server"},
+		SpiffeID:       "spiffe://example.org/ns/default/sa/inference-sa/inference/pool/pool-a",
+		PodSelector:    map[string]any{"matchLabels": map[string]any{"app": "model-server"}},
+		Selectors:      []string{"k8s:ns:default", "k8s:sa:inference-sa", "k8s:pod-label:app:model-server"},
+		IdentityAnchor: identity.IdentityAnchor{Kind: "pool", Name: "pool-a"},
 	}
 
 	classless := DesiredClusterSPIFFEID(binding, plan, "")
@@ -124,10 +127,39 @@ func TestBuildClusterSPIFFEIDNameUsesServiceAccountScopedIdentityHash(t *testing
 	got := BuildClusterSPIFFEIDName(
 		"kleym-reference-inference",
 		"binding",
+		"pool",
 		"spiffe://kleym.sonda.red/ns/kleym-reference-inference/sa/reference-inference/inference/pool/reference-pool",
 	)
 	want := "kleym-kleym-reference-inference-binding-pool-e1a1f353"
 	if got != want {
 		t.Fatalf("BuildClusterSPIFFEIDName = %q, want %q", got, want)
+	}
+}
+
+func TestBuildClusterSPIFFEIDNameUsesAnchorKindSegment(t *testing.T) {
+	t.Parallel()
+
+	got := BuildClusterSPIFFEIDName(
+		"default",
+		"binding",
+		"Model Endpoint",
+		"spiffe://example.org/ns/default/sa/inference-sa/inference/model-endpoint/model-a",
+	)
+	if wantSegment := "-model-endpoint-"; !strings.Contains(got, wantSegment) {
+		t.Fatalf("BuildClusterSPIFFEIDName = %q, want sanitized anchor kind segment %q", got, wantSegment)
+	}
+}
+
+func TestBuildClusterSPIFFEIDNameFallsBackForEmptyAnchorKind(t *testing.T) {
+	t.Parallel()
+
+	got := BuildClusterSPIFFEIDName(
+		"default",
+		"binding",
+		" ",
+		"spiffe://example.org/ns/default/sa/inference-sa/inference/pool/pool-a",
+	)
+	if wantSegment := "-identity-"; !strings.Contains(got, wantSegment) {
+		t.Fatalf("BuildClusterSPIFFEIDName = %q, want fallback anchor kind segment %q", got, wantSegment)
 	}
 }

--- a/test/chainsaw/binding-reconciliation/binding-ready.yaml
+++ b/test/chainsaw/binding-reconciliation/binding-ready.yaml
@@ -6,9 +6,9 @@ metadata:
 status:
   trustDomain: kleym.sonda.red
   computedSpiffeIDs:
-    - spiffeID: spiffe://kleym.sonda.red/ns/kleym-reference-inference/pool/reference-pool
+    - spiffeID: spiffe://kleym.sonda.red/ns/kleym-reference-inference/sa/reference-inference/inference/pool/reference-pool
   renderedSelectors:
-    - spiffeID: spiffe://kleym.sonda.red/ns/kleym-reference-inference/pool/reference-pool
+    - spiffeID: spiffe://kleym.sonda.red/ns/kleym-reference-inference/sa/reference-inference/inference/pool/reference-pool
       selectors:
         - k8s:ns:kleym-reference-inference
         - k8s:pod-label:app.kubernetes.io/name:reference-model-server

--- a/test/chainsaw/binding-reconciliation/chainsaw-test.yaml
+++ b/test/chainsaw/binding-reconciliation/chainsaw-test.yaml
@@ -164,7 +164,7 @@ spec:
               kubectl wait --for=delete inferenceidentitybinding/binding \
                 -n kleym-reference-inference \
                 --timeout=60s
-              kubectl wait --for=delete clusterspiffeid/kleym-kleym-reference-inference-binding-pool-e2d8bd8d \
+              kubectl wait --for=delete clusterspiffeid/kleym-kleym-reference-inference-binding-pool-e1a1f353 \
                 --timeout=60s
 
     - name: apply-pool-binding
@@ -194,7 +194,7 @@ spec:
               kubectl wait --for=delete inferenceidentitybinding/pool-binding \
                 -n kleym-reference-inference \
                 --timeout=60s
-              kubectl wait --for=delete clusterspiffeid/kleym-kleym-reference-inference-pool-binding-pool-e2d8bd8d \
+              kubectl wait --for=delete clusterspiffeid/kleym-kleym-reference-inference-pool-binding-pool-e1a1f353 \
                 --timeout=60s
         - script:
             workDir: ../../..

--- a/test/chainsaw/binding-reconciliation/clusterspiffeid.yaml
+++ b/test/chainsaw/binding-reconciliation/clusterspiffeid.yaml
@@ -1,13 +1,13 @@
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: kleym-kleym-reference-inference-binding-pool-e2d8bd8d
+  name: kleym-kleym-reference-inference-binding-pool-e1a1f353
   labels:
     kleym.sonda.red/managed-by: kleym
     kleym.sonda.red/binding-name: binding
     kleym.sonda.red/binding-namespace: kleym-reference-inference
 spec:
-  spiffeIDTemplate: spiffe://kleym.sonda.red/ns/kleym-reference-inference/pool/reference-pool
+  spiffeIDTemplate: spiffe://kleym.sonda.red/ns/kleym-reference-inference/sa/reference-inference/inference/pool/reference-pool
   podSelector:
     matchLabels:
       app.kubernetes.io/name: reference-model-server

--- a/test/chainsaw/binding-reconciliation/pool-binding-ready.yaml
+++ b/test/chainsaw/binding-reconciliation/pool-binding-ready.yaml
@@ -6,9 +6,9 @@ metadata:
 status:
   trustDomain: kleym.sonda.red
   computedSpiffeIDs:
-    - spiffeID: spiffe://kleym.sonda.red/ns/kleym-reference-inference/pool/reference-pool
+    - spiffeID: spiffe://kleym.sonda.red/ns/kleym-reference-inference/sa/reference-inference/inference/pool/reference-pool
   renderedSelectors:
-    - spiffeID: spiffe://kleym.sonda.red/ns/kleym-reference-inference/pool/reference-pool
+    - spiffeID: spiffe://kleym.sonda.red/ns/kleym-reference-inference/sa/reference-inference/inference/pool/reference-pool
       selectors:
         - k8s:ns:kleym-reference-inference
         - k8s:pod-label:app.kubernetes.io/name:reference-model-server

--- a/test/chainsaw/binding-reconciliation/pool-clusterspiffeid.yaml
+++ b/test/chainsaw/binding-reconciliation/pool-clusterspiffeid.yaml
@@ -1,13 +1,13 @@
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: kleym-kleym-reference-inference-pool-binding-pool-e2d8bd8d
+  name: kleym-kleym-reference-inference-pool-binding-pool-e1a1f353
   labels:
     kleym.sonda.red/managed-by: kleym
     kleym.sonda.red/binding-name: pool-binding
     kleym.sonda.red/binding-namespace: kleym-reference-inference
 spec:
-  spiffeIDTemplate: spiffe://kleym.sonda.red/ns/kleym-reference-inference/pool/reference-pool
+  spiffeIDTemplate: spiffe://kleym.sonda.red/ns/kleym-reference-inference/sa/reference-inference/inference/pool/reference-pool
   podSelector:
     matchLabels:
       app.kubernetes.io/name: reference-model-server

--- a/test/e2e/inspectbindingassert/main.go
+++ b/test/e2e/inspectbindingassert/main.go
@@ -11,8 +11,8 @@ import (
 const (
 	referenceNamespace       = "kleym-reference-inference"
 	referenceBinding         = "binding"
-	referenceSPIFFEID        = "spiffe://kleym.sonda.red/ns/kleym-reference-inference/pool/reference-pool"
-	referenceClusterSPIFFEID = "kleym-kleym-reference-inference-binding-pool-e2d8bd8d"
+	referenceSPIFFEID        = "spiffe://kleym.sonda.red/ns/kleym-reference-inference/sa/reference-inference/inference/pool/reference-pool"
+	referenceClusterSPIFFEID = "kleym-kleym-reference-inference-binding-pool-e1a1f353"
 )
 
 func main() {


### PR DESCRIPTION
## Summary

- Renders Kleym identities as service-account-scoped inference target SPIFFE IDs.
- Adds a shared resolved inference target model between GAIE pool resolution and identity planning.
- Updates CLI/operator tests, examples, chainsaw fixtures, and docs for the new rendered identity shape.

## What I Changed And Why

- Added `IdentityAnchor` / `ResolvedInferenceTarget` inputs so source-specific GAIE resolution happens before shared identity rendering.
- Updated operator and CLI inspection paths to call `gaie.ResolveInferenceTarget` and then `identity.PlanIdentity`.
- Changed canonical SPIFFE IDs to `spiffe://<trustDomain>/ns/<namespace>/sa/<serviceAccountName>/inference/<anchor-kind>/<anchor-name>`; GAIE `InferencePool` resolves as `pool/<pool-name>`.
- Added coverage that different service accounts on the same namespace/pool render distinct SPIFFE IDs, while binding names do not enter the principal.

## Related Issue

- Fixes #256

## Scope Check

- Follows the issue scope: public API remains `spec.poolRef` plus `spec.serviceAccountName`; source GVK/group/version and binding names stay outside SPIFFE ID paths.
- Left out runtime enforcement, SVID consumption, gateway/policy/scheduler behavior, and any generic public source reference API.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): updated for the resolved inference target contract and new SPIFFE ID path.
- CLI Spec (`docs/spec/cli.md`): updated to state the CLI resolves the same target identity model as the operator.
- Other docs: updated README, concepts/design/reference/example/demo docs, `docs/static/llms.txt`, and test fixtures that expose rendered SPIFFE IDs.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none from this change.

## Verification

- Commands run:
  - `go test ./internal/identity ./internal/gaie ./internal/controller ./internal/inspection ./internal/spirecm ./internal/cli`
  - `make test`
  - `make lint`
  - `make build`
  - `make docs-build`
  - `git diff --check`
  - searched active repo surfaces for the old `/ns/<namespace>/pool/<pool-name>` SPIFFE form; no matches found
  - inspected rendered docs head/canonical/JSON-LD snippets and `public/sitemap.xml` entries for changed docs pages
- Tests not run and why: chainsaw e2e was not run locally; unit/envtest, build, lint, docs build, and fixture updates cover the repository-local contract change.

## Security Review

- This PR changes workload identity trust-boundary material by moving `serviceAccountName` into the SPIFFE principal path and preserving it as a mandatory selector.
- Does not touch GitHub Actions, CI, release automation, credentials, or secret handling.
- Source provenance and untrusted raw source GVK strings are not rendered into SPIFFE ID paths.