### PR TITLE
docs(operator): document binding write authorization boundary

### DIFF
--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -16,6 +16,25 @@ Kleym does not own inference workloads, schedulers, routes, gateways, serving be
 
 Dependency facts live in [Dependencies][dependencies]. Supported GAIE inputs live in [GAIE Compatibility][gaie-compatibility].
 
+## Binding Write Authorization Boundary
+
+`InferenceIdentityBinding` is a namespaced resource, but `kleym-operator`
+reconciles each successful binding into a cluster-scoped SPIRE Controller
+Manager `ClusterSPIFFEID` resource. Create, update, or patch permission on
+`InferenceIdentityBinding` is therefore a privileged namespace capability: it
+delegates permission to request Kleym-managed SPIRE identity registration for
+workloads in that namespace.
+
+Kubernetes RBAC and admission policy decide who may create, update, or patch
+bindings. Kleym does not perform tenant authorization for binding authors. Broad
+application-developer write access to `InferenceIdentityBinding` should be a
+deliberate delegation of identity-registration authority.
+
+Selector safety is separate from authorization. The namespace, service-account,
+and pool selectors constrain the rendered `ClusterSPIFFEID` workload match, but
+they are not the authorization decision for whether a user may request identity
+registration.
+
 ## Operator Configuration
 
 `kleym-operator` requires install-level identity configuration at startup.


### PR DESCRIPTION
## Summary

- Documents the `InferenceIdentityBinding` write authorization boundary in the operator spec.

## What I Changed And Why

- Added a `Binding Write Authorization Boundary` section to `docs/spec/operator.md`.
- Clarifies that namespaced bindings reconcile into cluster-scoped SPIRE Controller Manager `ClusterSPIFFEID` resources.
- States that `InferenceIdentityBinding` create/update/patch access is a privileged namespace capability controlled by Kubernetes RBAC and admission policy, while selector safety only constrains the rendered workload match.

## Related Issue

- Closes #266

## Scope Check

- Follows the issue scope as a docs-only security-model clarification.
- No controller behavior, API shape, CRD/RBAC manifests, selector rendering, SPIFFE ID format, or policy/approval workflow changes.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): updated.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI behavior is unchanged.
- Other docs: not needed; the operator spec is the authoritative contract and the change is intentionally narrow.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run:
  - `make docs-build` — passed with Hugo Extended 0.162.1.
  - Rendered docs inspection confirmed `/spec/operator/` contains the new section, has title/description/canonical metadata, TechArticle/Breadcrumb JSON-LD, and sitemap inclusion.
  - Independent review pass found no must-fix or should-fix items.
- Tests not run and why: Go tests not run; docs-only change.

## Security Review

- This PR documents a trust/authorization boundary but does not touch GitHub Actions, CI, release automation, credentials, code execution, or runtime authorization behavior.
- Least privilege posture is preserved by documenting that Kubernetes RBAC/admission, not Kleym controller logic, controls binding write delegation.