### PR TITLE
fix(controller): fail fast on undeclared typed informer reads

### DIFF
--- a/cmd/kleym-operator/main.go
+++ b/cmd/kleym-operator/main.go
@@ -29,6 +29,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -154,6 +155,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
+		Cache:                  managerCacheOptions(),
 		Metrics:                metricsServerOptions,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
@@ -198,5 +200,15 @@ func main() {
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
+	}
+}
+
+// managerCacheOptions keeps cache-backed reads limited to resources whose
+// informers were declared during controller setup. The manager client keeps
+// unstructured external resources on live reads under controller-runtime's
+// default behavior; do not convert them to cached typed reads without a watch.
+func managerCacheOptions() cache.Options {
+	return cache.Options{
+		ReaderFailOnMissingInformer: true,
 	}
 }

--- a/cmd/kleym-operator/main_test.go
+++ b/cmd/kleym-operator/main_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 Kalin Daskalov.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+func TestManagerCacheOptionsFailForUndeclaredTypedRead(t *testing.T) {
+	t.Parallel()
+
+	testScheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(testScheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	options := managerCacheOptions()
+	options.Scheme = testScheme
+	reader, err := cache.New(&rest.Config{Host: "https://localhost"}, options)
+	if err != nil {
+		t.Fatalf("create cache: %v", err)
+	}
+
+	testCases := []struct {
+		name string
+		read func() error
+	}{
+		{
+			name: "Get",
+			read: func() error {
+				return reader.Get(context.Background(), types.NamespacedName{}, &corev1.ConfigMap{})
+			},
+		},
+		{
+			name: "List",
+			read: func() error {
+				return reader.List(context.Background(), &corev1.ConfigMapList{})
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.read()
+			var notCached *cache.ErrResourceNotCached
+			if !errors.As(err, &notCached) {
+				t.Fatalf("cache %s error = %v, want ErrResourceNotCached", testCase.name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Configure the operator cache to fail undeclared typed reads instead of creating informers on demand.
- Add focused coverage for undeclared typed `Get` and `List` reads.

## What I Changed And Why

- Added `ReaderFailOnMissingInformer` to the production manager cache options so future typed cache reads require an explicitly declared informer.
- Kept the unstructured external-resource access boundary documented in the manager setup.
- Added a cache-level test that verifies both typed `Get` and `List` return `ErrResourceNotCached` for an undeclared `ConfigMap` informer.

## Related Issue

- Fixes #263

## Scope Check

- Implements the issue's cache/informer hygiene requirement without changing controller reconciliation, watches, managed output, selectors, identity rendering, status, or metrics.
- No follow-up ideas were included in this PR.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because this does not change the operator product or reconciliation contract.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI behavior is unchanged.
- Other docs: not needed because the cache policy is documented in code and covered by a focused test.

## Follow-Up Work

- None.

## Verification

- Commands run:
  - `go test ./cmd/kleym-operator`
  - `make test`
  - `make lint`
- Tests not run and why:
  - `make test-e2e-chainsaw` was not run because this change only covers in-process controller-runtime cache behavior.

## Security Review

- This PR does not touch GitHub Actions, CI, release automation, credentials, or trust boundaries.
- The change narrows controller cache behavior by rejecting undeclared typed reads rather than allowing implicit informer creation.