### PR TITLE
fix(api): validate service account names at admission

### DIFF
--- a/api/v1alpha1/inferenceidentitybinding_types.go
+++ b/api/v1alpha1/inferenceidentitybinding_types.go
@@ -51,10 +51,11 @@ type InferenceIdentityBindingSpec struct {
 	// +required
 	PoolRef InferencePoolTargetRef `json:"poolRef"`
 
-	// serviceAccountName is the Kubernetes service account required in every rendered identity selector set.
+	// serviceAccountName is the DNS-1123 subdomain Kubernetes service account required in every rendered identity selector set.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 	ServiceAccountName string `json:"serviceAccountName"`
 }
 

--- a/config/crd/bases/kleym.sonda.red_inferenceidentitybindings.yaml
+++ b/config/crd/bases/kleym.sonda.red_inferenceidentitybindings.yaml
@@ -72,10 +72,11 @@ spec:
                 - name
                 type: object
               serviceAccountName:
-                description: serviceAccountName is the Kubernetes service account
-                  required in every rendered identity selector set.
+                description: serviceAccountName is the DNS-1123 subdomain Kubernetes
+                  service account required in every rendered identity selector set.
                 maxLength: 253
                 minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
             required:
             - poolRef

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -33,13 +33,13 @@ External SPIFFE/SPIRE references:
 | --- | --- | --- |
 | `poolRef.name` | Yes | References an `InferencePool` in the same namespace. |
 | `poolRef.group` | No | Constrains pool resolution to `inference.networking.k8s.io`. |
-| `serviceAccountName` | Yes | Kubernetes service account required in every rendered identity selector set. |
+| `serviceAccountName` | Yes | Admission-validated DNS-1123 subdomain Kubernetes service account required in every rendered identity selector set. |
 
 Current validation rules enforced by the CRD:
 
 - `poolRef.name` is required.
 - `poolRef.group`, when set, must be `inference.networking.k8s.io`.
-- `serviceAccountName` is required.
+- `serviceAccountName` is required and admission-validated as a DNS-1123 subdomain with a maximum length of 253 characters.
 
 ## Status Fields
 

--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -44,7 +44,7 @@ When `--clusterspiffeid-class-name` is empty, SPIRE Controller Manager must be c
 `InferenceIdentityBinding` is namespaced. Pool references stay in that namespace.
 
 1. `poolRef` references one [`InferencePool`][gaie-inferencepool]. The pool is the required workload anchor and selector provenance source.
-2. `serviceAccountName` is required. It scopes both the SPIFFE ID path and the mandatory `k8s:sa:<serviceAccountName>` selector.
+2. `serviceAccountName` is required and admission-validated as a DNS-1123 subdomain with a maximum length of 253 characters. It scopes both the SPIFFE ID path and the mandatory `k8s:sa:<serviceAccountName>` selector.
 3. `identityBoundary.labelKey` and `identityBoundary.labelValue` are required. `labelKey` must be a valid Kubernetes label key and use the reserved `identity.kleym.sonda.red/` prefix. `labelValue` must be a valid, nonempty Kubernetes label value. Bindings declare both values; the referenced pool does not repeat them.
 4. SPIFFE IDs are deterministic under the configured trust domain: `spiffe://<trustDomain>/ns/<namespace>/sa/<serviceAccountName>/inference/pool/<pool-name>/variant/<labelValue>`.
 5. Status records operator configuration, validated identity-boundary state, rendered output, conflicts, and conditions. The status rules are defined in [Status Contract](#status-contract).

--- a/internal/controller/inferenceidentitybinding_envtest_test.go
+++ b/internal/controller/inferenceidentitybinding_envtest_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kleymv1alpha1 "github.com/sonda-red/kleym/api/v1alpha1"
@@ -74,17 +75,21 @@ var _ = Describe("InferenceIdentityBinding Envtest Coverage", func() {
 		return pool
 	}
 
-	It("initializes the full canonical condition set for render failures", func() {
+	It("initializes the full canonical condition set for legacy invalid service accounts", func() {
 		poolName := newName("pool-unsafe")
 		bindingName := newName("binding-unsafe")
 
 		createPool(poolName)
 
 		binding := &kleymv1alpha1.InferenceIdentityBinding{
-			ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: bindingName},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  testNamespace,
+				Name:       bindingName,
+				Finalizers: []string{inferenceIdentityBindingFinalizer},
+			},
 			Spec: kleymv1alpha1.InferenceIdentityBindingSpec{
 				PoolRef:            kleymv1alpha1.InferencePoolTargetRef{Name: poolName},
-				ServiceAccountName: "bad_service_account",
+				ServiceAccountName: "inference-sa",
 			},
 		}
 		Expect(k8sClient.Create(ctx, binding)).To(Succeed())
@@ -92,7 +97,11 @@ var _ = Describe("InferenceIdentityBinding Envtest Coverage", func() {
 			cleanupBinding(types.NamespacedName{Namespace: testNamespace, Name: bindingName})
 		})
 
-		reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: k8sClient, Scheme: k8sClient.Scheme()}
+		legacyObjectClient := legacyInvalidServiceAccountClient{
+			Client: k8sClient,
+			key:    types.NamespacedName{Namespace: testNamespace, Name: bindingName},
+		}
+		reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: legacyObjectClient, Scheme: k8sClient.Scheme()}
 		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: bindingName}})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -154,3 +163,30 @@ var _ = Describe("InferenceIdentityBinding Envtest Coverage", func() {
 	})
 
 })
+
+type legacyInvalidServiceAccountClient struct {
+	client.Client
+	key types.NamespacedName
+}
+
+// Get simulates an object persisted before service-account admission validation.
+func (c legacyInvalidServiceAccountClient) Get(
+	ctx context.Context,
+	key client.ObjectKey,
+	object client.Object,
+	options ...client.GetOption,
+) error {
+	if err := c.Client.Get(ctx, key, object, options...); err != nil {
+		return err
+	}
+	if key != c.key {
+		return nil
+	}
+
+	legacyBinding, ok := object.(*kleymv1alpha1.InferenceIdentityBinding)
+	if ok {
+		// The API server now rejects this value; runtime validation must handle legacy objects safely.
+		legacyBinding.Spec.ServiceAccountName = "bad_service_account"
+	}
+	return nil
+}

--- a/internal/controller/inferenceidentitybinding_setup_partial_crd_test.go
+++ b/internal/controller/inferenceidentitybinding_setup_partial_crd_test.go
@@ -76,6 +76,7 @@ func TestSetupWithManagerStartsAndReconcilesWithCurrentPoolCRD(t *testing.T) {
 		t.Fatalf("create manager: %v", err)
 	}
 	assertLegacyPoolGroupRejectedByCRD(t, context.Background(), mgr.GetClient())
+	assertServiceAccountNameValidationAtCRDAdmission(t, context.Background(), mgr.GetClient())
 
 	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: mgr.GetClient(),
@@ -239,6 +240,46 @@ func assertLegacyPoolGroupRejectedByCRD(
 	err := k8sClient.Create(ctx, binding)
 	if !apierrors.IsInvalid(err) {
 		t.Fatalf("create binding with legacy pool group error = %v, want Invalid", err)
+	}
+}
+
+// assertServiceAccountNameValidationAtCRDAdmission verifies CRD admission matches the DNS-1123 service account contract.
+func assertServiceAccountNameValidationAtCRDAdmission(
+	t *testing.T,
+	ctx context.Context,
+	k8sClient client.Client,
+) {
+	t.Helper()
+
+	invalidBinding := &kleymv1alpha1.InferenceIdentityBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      "invalid-service-account-rejected",
+		},
+		Spec: kleymv1alpha1.InferenceIdentityBindingSpec{
+			PoolRef:            kleymv1alpha1.InferencePoolTargetRef{Name: "pool-current"},
+			ServiceAccountName: "Invalid_ServiceAccount",
+		},
+	}
+	if err := k8sClient.Create(ctx, invalidBinding); !apierrors.IsInvalid(err) {
+		t.Fatalf("create binding with invalid service account error = %v, want Invalid", err)
+	}
+
+	validBinding := &kleymv1alpha1.InferenceIdentityBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      "dns-subdomain-service-account-admitted",
+		},
+		Spec: kleymv1alpha1.InferenceIdentityBindingSpec{
+			PoolRef:            kleymv1alpha1.InferencePoolTargetRef{Name: "pool-current"},
+			ServiceAccountName: "inference.service-account",
+		},
+	}
+	if err := k8sClient.Create(ctx, validBinding); err != nil {
+		t.Fatalf("create binding with DNS-1123 subdomain service account: %v", err)
+	}
+	if err := k8sClient.Delete(ctx, validBinding); err != nil {
+		t.Fatalf("delete admitted binding: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Reject invalid `InferenceIdentityBinding.spec.serviceAccountName` values at CRD admission using Kubernetes DNS-1123 subdomain semantics.
- Preserve runtime validation for legacy or schema-bypassed objects.

## What I Changed And Why

- Added the generated CRD pattern and retained the existing 253-character maximum to match `validation.IsDNS1123Subdomain`.
- Added envtest coverage for rejected invalid input and admitted valid dotted names.
- Kept runtime `RenderFailure` coverage by simulating a legacy persisted invalid binding in test code.

## Related Issue

- Fixes #262

## Scope Check

- Implements the admission validation, generated CRD, focused test coverage, and documentation requested by #262.
- No selector rendering, SPIFFE ID, managed-output, status, finalizer, or reconciliation behavior changes are included.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): updated with DNS-1123 admission validation and the 253-character limit.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI behavior is unchanged.
- Other docs: updated `docs/reference/api.md` to describe the CRD rule.

## Follow-Up Work

- Proposed follow-up issue(s): none.

## Verification

- Commands run: `make manifests`, `make generate`, `make test`, `make lint`, `make docs-build`, `git diff --check`.
- Rendered `reference/api` metadata and sitemap entry inspected after the docs build.
- Tests not run and why: `make test-e2e-chainsaw` was not run; this admission behavior is covered by envtest and does not require a Kind cluster.

## Security Review

- No GitHub Actions, CI, release automation, credentials, or secret-handling changes.
- The change tightens API admission for a service-account value used in identity selectors; runtime validation remains as defense in depth for legacy or schema-bypassed objects.
