### PR TITLE
docs(operator): define identity boundary contract

### DIFF
--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -45,9 +45,9 @@ When `--clusterspiffeid-class-name` is empty, SPIRE Controller Manager must be c
 
 1. `poolRef` references one [`InferencePool`][gaie-inferencepool]. The pool is the required workload anchor and selector provenance source.
 2. `serviceAccountName` is required. It scopes both the SPIFFE ID path and the mandatory `k8s:sa:<serviceAccountName>` selector.
-3. `identityBoundary.labelKey` is required, must be a valid Kubernetes label key, and must use the reserved `identity.kleym.sonda.red/` prefix. Its value is resolved from the referenced pool's normalized exact label map; bindings do not repeat that value.
-4. SPIFFE IDs are deterministic under the configured trust domain: `spiffe://<trustDomain>/ns/<namespace>/sa/<serviceAccountName>/inference/pool/<pool-name>`.
-5. Status records operator configuration, resolved boundary state, rendered output, conflicts, and conditions. The status rules are defined in [Status Contract](#status-contract).
+3. `identityBoundary.labelKey` and `identityBoundary.labelValue` are required. `labelKey` must be a valid Kubernetes label key and use the reserved `identity.kleym.sonda.red/` prefix. `labelValue` must be a valid, nonempty Kubernetes label value. Bindings declare both values; the referenced pool does not repeat them.
+4. SPIFFE IDs are deterministic under the configured trust domain: `spiffe://<trustDomain>/ns/<namespace>/sa/<serviceAccountName>/inference/pool/<pool-name>/variant/<labelValue>`.
+5. Status records operator configuration, validated identity-boundary state, rendered output, conflicts, and conditions. The status rules are defined in [Status Contract](#status-contract).
 6. The CRD exposes printer columns for `POOL`, `BOUNDARY`, `READY`, `REASON`, and `SPIFFE ID` so `kubectl get inferenceidentitybindings.kleym.sonda.red -A` is the primary binding list view.
 
 [API Reference][api-reference] and [Conditions Reference][conditions-reference] document implemented API and condition surfaces. Follow-on API, controller, and CLI work must update those references before these boundary fields and reasons are shipped.
@@ -58,6 +58,8 @@ Identity and selector rendering consume a resolved inference target after the re
 
 The canonical SPIFFE ID contains the binding namespace, required service account, and resolved identity anchor. Source provenance such as the raw source group, version, or kind and the `InferenceIdentityBinding` name remains outside the SPIFFE ID. Two bindings for the same namespace and pool but different service accounts therefore render different SPIFFE IDs.
 
+An `InferencePool` is the broad model-serving group. Each `InferenceIdentityBinding` claims one label-defined workload variant within that pool, such as `prefill` or `decode`. A variant is a workload subset, not a separate resource or caller authorization model.
+
 ## Rendered Selector Contract
 
 A binding accepts `spec.poolRef`, `spec.serviceAccountName`, and `spec.identityBoundary`; it does not accept user-supplied selector lists or selector source modes.
@@ -67,6 +69,7 @@ Every rendered identity selector set is assembled from these sources:
 1. Mandatory namespace selector rendered internally from the binding namespace: `k8s:ns:<binding namespace>`.
 2. Mandatory service-account selector rendered internally from `spec.serviceAccountName`: `k8s:sa:<serviceAccountName>`.
 3. Pool-derived selectors rendered from the referenced `InferencePool` `spec.selector.matchLabels`.
+4. Mandatory boundary selector rendered from `spec.identityBoundary`: `k8s:pod-label:<labelKey>:<labelValue>`.
 
 The only pool selector compatibility form is an existing flat string map under `spec.selector`; Kleym normalizes it to `matchLabels` before rendering. Pool labels render directly to `k8s:pod-label:<key>:<value>` workload selectors.
 
@@ -82,13 +85,13 @@ Unsupported pool selector input is refused, including:
 
 Rendered selector sets are canonical. Kleym removes duplicate selector strings and sorts the remaining strings lexicographically before writing `status.renderedSelectors`, managed `ClusterSPIFFEID` `spec.workloadSelectorTemplates`, or the rendered selector fingerprint in `status.renderedClusterSPIFFEID.selectorFingerprint`.
 
-The complete normalized pool selector remains the workload match. The identity boundary label proves exclusivity; it does not replace other pool labels in `ClusterSPIFFEID.spec.podSelector` or `spec.workloadSelectorTemplates`.
+The complete normalized pool selector remains the workload match. Kleym adds the declared identity-boundary selector to select one variant within that pool. The boundary label proves exclusivity; it does not replace other pool labels in `ClusterSPIFFEID.spec.podSelector` or `spec.workloadSelectorTemplates`.
 
 Malformed or unsupported pool selector input fails reconciliation with `UnsafeSelector=True` reason `InvalidPoolSelector`. A selector set that would omit or escape the mandatory namespace or service-account boundary fails with `UnsafeSelector=True` reason `UnsafeSelector`. Selector failures produce no managed output and clear rendered output status.
 
 ## Identity Boundary and Exclusivity
 
-After pool selector normalization, Kleym resolves `spec.identityBoundary.labelKey` from the exact label map. The resolved boundary is:
+The binding declares an identity boundary. The resolved boundary is:
 
 ```text
 namespace
@@ -97,7 +100,7 @@ boundary label key
 boundary label value
 ```
 
-The label must be present and have a nonempty value. A missing label produces `UnsafeSelector=True` with reason `MissingIdentityBoundaryLabel`; an empty value produces `UnsafeSelector=True` with reason `EmptyIdentityBoundaryValue`.
+The declared key and value are rendered as a mandatory Pod-label selector. Invalid boundary input is refused with `UnsafeSelector=True` reason `InvalidIdentityBoundary`.
 
 For any two bindings with different rendered SPIFFE IDs, exclusivity is proven only when at least one condition is true:
 
@@ -115,7 +118,7 @@ Two bindings that render the same SPIFFE ID are duplicate identity claims. They 
 
 ## Conflict Behavior
 
-Kleym evaluates potentially conflicting bindings from declared binding and pool state. A conflict group contains every visible binding with a resolved boundary that is either not deleting or still has managed output whose absence has not been confirmed. A deleting binding remains a competitor until its managed output is confirmed absent; peers must not recreate output while that deletion is pending.
+Kleym evaluates potentially conflicting bindings from declared binding and pool state. It forms a conflict group only from bindings that fail the pairwise exclusivity invariant; bindings already proven exclusive are not members. A deleting binding remains a competitor until its managed output is confirmed absent; peers must not recreate output while that deletion is pending.
 
 A conflict member has:
 
@@ -124,7 +127,7 @@ Ready=False
 Conflict=True
 managed ClusterSPIFFEID absent
 rendered output status cleared
-resolved boundary and conflict references populated
+identity boundary and conflict references populated
 ```
 
 Kleym removes every managed `ClusterSPIFFEID` owned by conflict members and confirms absence before settling the conflict state. If output deletion fails, reconciliation reports the API error and retries; it must not report a settled conflict state that implies output absence.
@@ -135,7 +138,7 @@ Kleym removes registration intent. It does not claim immediate invalidation of a
 
 ## Status Contract
 
-On successful resolution, `status.resolvedIdentityBoundary` records the boundary label key and resolved value. It remains available for conflict diagnosis.
+On successful validation, `status.identityBoundary` records the boundary label key and value. It remains available for conflict diagnosis.
 
 `status.conflicts` is present only when `Conflict=True`. Each item describes one peer and one precise cause:
 
@@ -163,7 +166,7 @@ Allowed condition types and reasons:
 | `Ready` | `False` | The same primary failure reason used by the active failure condition. |
 | `Ready` | `Unknown` | `Initializing` |
 | `InvalidRef` | `True` | `InvalidPoolRef`, `TargetPoolNotFound`, `InferencePoolCRDMissing` |
-| `UnsafeSelector` | `True` | `InvalidPoolSelector`, `UnsafeSelector`, `MissingIdentityBoundaryLabel`, `EmptyIdentityBoundaryValue` |
+| `UnsafeSelector` | `True` | `InvalidPoolSelector`, `UnsafeSelector`, `InvalidIdentityBoundary` |
 | `Conflict` | `True` | `IdentityBoundaryConflict`, `DuplicateIdentityBinding` |
 | `RenderFailure` | `True` | `MissingTrustDomain`, `InvalidServiceAccountName`, `InvalidSPIFFEID`, `ClusterSPIFFEIDCRDMissing`, `ManagedOutputApplyFailed` |
 | `InvalidRef` | `False` | `Resolved` |
@@ -187,7 +190,7 @@ If a managed resource cannot be listed, created, updated, or deleted because the
 1. Discover the supported GAIE pool GVK served by the cluster and watch it.
 2. Fail startup when the supported `InferencePool` GVK is not available.
 3. Resolve `poolRef` only to documented supported GAIE groups.
-4. Normalize the referenced pool selector, resolve the declared identity boundary, and preserve the complete selector for rendering.
+4. Normalize the referenced pool selector, validate the declared identity boundary, and preserve the complete selector plus mandatory boundary selector for rendering.
 5. Evaluate boundary exclusivity before managed output creation or update.
 6. Refuse selector failures and conflicts. Both states produce no managed output.
 7. Render the SPIFFE ID and managed `ClusterSPIFFEID` shape deterministically when the binding is exclusive.
@@ -204,7 +207,7 @@ Kleym does not mutate workloads, pools, or Pods.
 
 ## CLI Impact
 
-The CLI remains read only. Follow-on CLI work must expose the configured boundary key, resolved boundary value, full normalized pool selector, conflict peers and causes, and managed output state. It must consume the operator's boundary and conflict status rather than implement a separate exclusivity model. This issue does not change the current CLI specification or report format.
+The CLI remains read only. Follow-on CLI work must expose the declared boundary key and value, full normalized pool selector, conflict peers and causes, and managed output state. It must consume the operator's boundary and conflict status rather than implement a separate exclusivity model. This issue does not change the current CLI specification or report format.
 
 ## Safety Invariants
 

--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -45,7 +45,7 @@ When `--clusterspiffeid-class-name` is empty, SPIRE Controller Manager must be c
 
 1. `poolRef` references one [`InferencePool`][gaie-inferencepool]. The pool is the required workload anchor and selector provenance source.
 2. `serviceAccountName` is required. It scopes both the SPIFFE ID path and the mandatory `k8s:sa:<serviceAccountName>` selector.
-3. `identityBoundary.labelKey` is required and must be a valid Kubernetes label key. Its value is resolved from the referenced pool's normalized exact label map; bindings do not repeat that value.
+3. `identityBoundary.labelKey` is required, must be a valid Kubernetes label key, and must use the reserved `identity.kleym.sonda.red/` prefix. Its value is resolved from the referenced pool's normalized exact label map; bindings do not repeat that value.
 4. SPIFFE IDs are deterministic under the configured trust domain: `spiffe://<trustDomain>/ns/<namespace>/sa/<serviceAccountName>/inference/pool/<pool-name>`.
 5. Status records operator configuration, resolved boundary state, rendered output, conflicts, and conditions. The status rules are defined in [Status Contract](#status-contract).
 6. The CRD exposes printer columns for `POOL`, `BOUNDARY`, `READY`, `REASON`, and `SPIFFE ID` so `kubectl get inferenceidentitybindings.kleym.sonda.red -A` is the primary binding list view.
@@ -198,7 +198,7 @@ If a managed resource cannot be listed, created, updated, or deleted because the
 
 An identity boundary label is security-sensitive metadata. Permission to assign the boundary label or selected service account is therefore identity registration authority.
 
-`identity.kleym.sonda.red/*` is reserved for platform-controlled boundary labels. Application authors must not directly set or mutate reserved labels. A boundary label is immutable for the lifetime of a Pod; boundary changes use replacement Pods.
+`identity.kleym.sonda.red/*` is reserved for platform-controlled boundary labels. Cluster admission policy must restrict assignment and mutation of reserved labels to platform-controlled actors. Boundary labels are immutable for the lifetime of a Pod; boundary changes use replacement Pods.
 
 Kleym does not mutate workloads, pools, or Pods.
 

--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -1,16 +1,16 @@
 ---
 title: Operator Spec
 weight: 10
-description: "Authoritative operator contract for InferenceIdentityBinding, GAIE pool resolution, SPIFFE ID rendering, selector safety, managed output, and status."
+description: "Authoritative operator contract for InferenceIdentityBinding, identity boundaries, GAIE pool resolution, SPIFFE ID rendering, selector safety, managed output, and status."
 ---
 
-`kleym-operator` is an identity registration compiler. It translates inference intent into deterministic Secure Production Identity Framework for Everyone (SPIFFE) identities and writes SPIFFE Runtime Environment (SPIRE) Controller Manager [`ClusterSPIFFEID`][clusterspiffeid] resources.
+`kleym-operator` is an inference identity boundary compiler. It translates declared inference intent into deterministic Secure Production Identity Framework for Everyone (SPIFFE) identities and writes SPIFFE Runtime Environment (SPIRE) Controller Manager [`ClusterSPIFFEID`][clusterspiffeid] resources.
 
 Kleym stops at identity registration. It does not deploy inference workloads, route traffic, configure gateways, evaluate request policy, issue credentials, or write SPIRE registration entries directly.
 
 ## Scope
 
-Kleym owns `InferenceIdentityBinding`, GAIE input resolution, SPIFFE ID rendering, selector safety, managed `ClusterSPIFFEID` reconciliation, status, events, and finalizer cleanup.
+Kleym owns `InferenceIdentityBinding`, GAIE input resolution, identity-boundary resolution, selector safety, managed `ClusterSPIFFEID` reconciliation, status, events, and finalizer cleanup.
 
 Kleym does not own inference workloads, schedulers, routes, gateways, serving behavior, Envoy, OPA, OAuth, OIDC, SPIRE Server, SPIRE Agent, credential issuance, authorization, or audit decisions.
 
@@ -18,40 +18,22 @@ Dependency facts live in [Dependencies][dependencies]. Supported GAIE inputs liv
 
 ## Binding Write Authorization Boundary
 
-`InferenceIdentityBinding` is a namespaced resource, but `kleym-operator`
-reconciles each successful binding into a cluster-scoped SPIRE Controller
-Manager `ClusterSPIFFEID` resource. Create, update, or patch permission on
-`InferenceIdentityBinding` is therefore a privileged namespace capability: it
-delegates permission to request Kleym-managed SPIRE identity registration for
-workloads in that namespace.
+`InferenceIdentityBinding` is a namespaced resource, but `kleym-operator` reconciles each successful binding into a cluster-scoped SPIRE Controller Manager `ClusterSPIFFEID` resource. Create, update, or patch permission on `InferenceIdentityBinding` is therefore a privileged namespace capability: it delegates permission to request Kleym-managed SPIRE identity registration for workloads in that namespace.
 
-Kubernetes RBAC and admission policy decide who may create, update, or patch
-bindings. Kleym does not perform tenant authorization for binding authors. Broad
-application-developer write access to `InferenceIdentityBinding` should be a
-deliberate delegation of identity-registration authority.
+Kubernetes RBAC and admission policy decide who may create, update, or patch bindings. Kleym does not perform tenant authorization for binding authors. Broad application-developer write access to `InferenceIdentityBinding` should be a deliberate delegation of identity-registration authority.
 
-Selector safety is separate from authorization. The namespace, service-account,
-and pool selectors constrain the rendered `ClusterSPIFFEID` workload match, but
-they are not the authorization decision for whether a user may request identity
-registration.
+Selector safety and boundary exclusivity are separate from authorization. Namespace, service-account, and pool selectors constrain the rendered `ClusterSPIFFEID` workload match, but they are not the authorization decision for whether a user may request identity registration.
 
 ## Operator Configuration
 
-`kleym-operator` requires install-level identity configuration at startup.
-Command-line flags are the canonical configuration surface. Environment
-variables are startup-only fallbacks when the matching flag is omitted; they are
-not watched or reloaded after process start.
+`kleym-operator` requires install-level identity configuration at startup. Command-line flags are the canonical configuration surface. Environment variables are startup-only fallbacks when the matching flag is omitted; they are not watched or reloaded after process start.
 
 | Flag | Environment fallback | Required | Behavior |
 | --- | --- | --- | --- |
 | `--trust-domain=<value>` | `KLEYM_TRUST_DOMAIN` | yes | Sets the SPIRE Server trust domain used when rendering every SPIFFE ID. The value must not include `spiffe://`, must not contain `/`, and must not include leading or trailing whitespace. |
 | `--clusterspiffeid-class-name=<value>` | `KLEYM_CLUSTERSPIFFEID_CLASS_NAME` | no | Sets `spec.className` on every managed `ClusterSPIFFEID`. When empty, Kleym omits `spec.className` and keeps classless output. |
 
-Explicit flags take precedence over environment variables, including explicit
-empty values. Missing trust domain from both `--trust-domain` and
-`KLEYM_TRUST_DOMAIN` fails startup with
-`trustDomain must be configured before Kleym can render SPIFFE IDs`. Values
-loaded from environment variables use the same validation rules as flag values.
+Explicit flags take precedence over environment variables, including explicit empty values. Missing trust domain from both `--trust-domain` and `KLEYM_TRUST_DOMAIN` fails startup with `trustDomain must be configured before Kleym can render SPIFFE IDs`. Values loaded from environment variables use the same validation rules as flag values.
 
 `trustDomain` and `ClusterSPIFFEID` class are deployment concerns, not per-binding inference identity intent. They are not fields in `InferenceIdentityBinding.spec`.
 
@@ -62,44 +44,31 @@ When `--clusterspiffeid-class-name` is empty, SPIRE Controller Manager must be c
 `InferenceIdentityBinding` is namespaced. Pool references stay in that namespace.
 
 1. `poolRef` references one [`InferencePool`][gaie-inferencepool]. The pool is the required workload anchor and selector provenance source.
-2. `serviceAccountName` is required. It scopes the rendered identity path, and Kleym renders safety selectors internally as `k8s:ns:<binding namespace>` and `k8s:sa:<serviceAccountName>`.
-3. SPIFFE IDs are always deterministic under the configured trust domain: `spiffe://<trustDomain>/ns/<namespace>/sa/<serviceAccountName>/inference/<anchor-kind>/<anchor-name>`.
-4. Status records `trustDomain`, `clusterSPIFFEIDClassName`, `computedSpiffeIDs`, `renderedSelectors`, `renderedClusterSPIFFEID`, and conditions. The current pool-only condition taxonomy is limited to `Ready`, `InvalidRef`, `UnsafeSelector`, and `RenderFailure`.
-5. `trustDomain` and `clusterSPIFFEIDClassName` record the operator config values used for the latest status update. They are observation data for read-only inspection compatibility; they do not make trust domain or class name per-binding spec intent.
-6. The CRD exposes printer columns for `POOL`, `READY`, `REASON`, and `SPIFFE ID` so `kubectl get inferenceidentitybindings.kleym.sonda.red -A` is the primary binding list view.
+2. `serviceAccountName` is required. It scopes both the SPIFFE ID path and the mandatory `k8s:sa:<serviceAccountName>` selector.
+3. `identityBoundary.labelKey` is required and must be a valid Kubernetes label key. Its value is resolved from the referenced pool's normalized exact label map; bindings do not repeat that value.
+4. SPIFFE IDs are deterministic under the configured trust domain: `spiffe://<trustDomain>/ns/<namespace>/sa/<serviceAccountName>/inference/pool/<pool-name>`.
+5. Status records operator configuration, resolved boundary state, rendered output, conflicts, and conditions. The status rules are defined in [Status Contract](#status-contract).
+6. The CRD exposes printer columns for `POOL`, `BOUNDARY`, `READY`, `REASON`, and `SPIFFE ID` so `kubectl get inferenceidentitybindings.kleym.sonda.red -A` is the primary binding list view.
 
-Field details live in [API Reference][api-reference]. Condition details live in [Conditions Reference][conditions-reference].
+[API Reference][api-reference] and [Conditions Reference][conditions-reference] document implemented API and condition surfaces. Follow-on API, controller, and CLI work must update those references before these boundary fields and reasons are shipped.
 
 ## Resolved Inference Target Contract
 
-Identity and selector rendering consume a resolved inference target after the
-referenced source object has been read. A GAIE `InferencePool` resolves to
-identity anchor kind `pool`, with the anchor name equal to the pool name.
+Identity and selector rendering consume a resolved inference target after the referenced source object has been read. A GAIE `InferencePool` resolves to identity anchor kind `pool`, with the anchor name equal to the pool name.
 
-The canonical identity path contains the binding namespace, required service
-account, and resolved identity anchor. Source provenance such as the raw source
-group, version, or kind and the `InferenceIdentityBinding` name remains outside
-the SPIFFE ID. Two bindings for the same namespace and pool but different
-service accounts therefore render different SPIFFE IDs.
+The canonical SPIFFE ID contains the binding namespace, required service account, and resolved identity anchor. Source provenance such as the raw source group, version, or kind and the `InferenceIdentityBinding` name remains outside the SPIFFE ID. Two bindings for the same namespace and pool but different service accounts therefore render different SPIFFE IDs.
 
 ## Rendered Selector Contract
 
-The current selector contract is pool-only. A binding accepts only
-`spec.poolRef` and `spec.serviceAccountName`; it does not accept user-supplied
-selector lists or selector source modes.
+A binding accepts `spec.poolRef`, `spec.serviceAccountName`, and `spec.identityBoundary`; it does not accept user-supplied selector lists or selector source modes.
 
 Every rendered identity selector set is assembled from these sources:
 
-1. Mandatory namespace selector rendered internally from the binding namespace:
-   `k8s:ns:<binding namespace>`.
-2. Mandatory service-account selector rendered internally from
-   `spec.serviceAccountName`: `k8s:sa:<serviceAccountName>`.
-3. Pool-derived selectors rendered from the referenced `InferencePool`
-   `spec.selector.matchLabels`.
+1. Mandatory namespace selector rendered internally from the binding namespace: `k8s:ns:<binding namespace>`.
+2. Mandatory service-account selector rendered internally from `spec.serviceAccountName`: `k8s:sa:<serviceAccountName>`.
+3. Pool-derived selectors rendered from the referenced `InferencePool` `spec.selector.matchLabels`.
 
-The only pool selector compatibility form is an existing flat string map under
-`spec.selector`; Kleym normalizes it to `matchLabels` before rendering. Pool
-labels render directly to `k8s:pod-label:<key>:<value>` workload selectors.
+The only pool selector compatibility form is an existing flat string map under `spec.selector`; Kleym normalizes it to `matchLabels` before rendering. Pool labels render directly to `k8s:pod-label:<key>:<value>` workload selectors.
 
 Unsupported pool selector input is refused, including:
 
@@ -109,60 +78,82 @@ Unsupported pool selector input is refused, including:
 - empty, malformed, or non-string label values
 - label values with leading or trailing whitespace
 - any `matchExpressions` field, including an empty array
-- selector shapes that cannot be decoded into deterministic string
-  `matchLabels`
+- selector shapes that cannot be decoded into deterministic string `matchLabels`
 
-Rendered selector sets are canonical. Kleym removes duplicate selector strings
-and sorts the remaining strings lexicographically before writing
-`status.renderedSelectors`, managed `ClusterSPIFFEID`
-`spec.workloadSelectorTemplates`, or the rendered selector fingerprint in
-`status.renderedClusterSPIFFEID.selectorFingerprint`.
-The canonical set preserves provenance by selector form: namespace and
-service-account selectors are binding-derived, and `k8s:pod-label` selectors are
-pool-derived.
+Rendered selector sets are canonical. Kleym removes duplicate selector strings and sorts the remaining strings lexicographically before writing `status.renderedSelectors`, managed `ClusterSPIFFEID` `spec.workloadSelectorTemplates`, or the rendered selector fingerprint in `status.renderedClusterSPIFFEID.selectorFingerprint`.
 
-Malformed or unsupported pool selector input fails reconciliation with
-`UnsafeSelector=True` reason `InvalidPoolSelector`. A rendered selector set that
-would omit or escape the mandatory namespace or service-account boundary fails
-with `UnsafeSelector=True` reason `UnsafeSelector`. Selector failures produce no
-managed output and clear `computedSpiffeIDs`, `renderedSelectors`, and
-`renderedClusterSPIFFEID` in status.
+The complete normalized pool selector remains the workload match. The identity boundary label proves exclusivity; it does not replace other pool labels in `ClusterSPIFFEID.spec.podSelector` or `spec.workloadSelectorTemplates`.
 
-## Rendered Managed Status
+Malformed or unsupported pool selector input fails reconciliation with `UnsafeSelector=True` reason `InvalidPoolSelector`. A selector set that would omit or escape the mandatory namespace or service-account boundary fails with `UnsafeSelector=True` reason `UnsafeSelector`. Selector failures produce no managed output and clear rendered output status.
 
-On successful reconciliation, `status.renderedClusterSPIFFEID` exposes the core
-managed `ClusterSPIFFEID` details that status-only clients need for inspection:
-the deterministic managed resource name, the rendered SPIFFE ID, a
-`sha256:<hex>` fingerprint of the canonical selector set, and the observed
-managed resource generation when it is available from Kubernetes.
+## Identity Boundary and Exclusivity
 
-`status.renderedClusterSPIFFEID.spiffeID` is populated from the same rendered
-identity used for `status.computedSpiffeIDs`; it is not a second SPIFFE state.
-`observedGeneration` is omitted when Kubernetes has not reported a persisted
-generation for the managed resource. Kleym does not write `0` as a fake
-generation. If the managed resource cannot be listed, created, updated, or
-deleted because the API request itself fails, reconciliation reports
-`RenderFailure=True` with reason `ManagedOutputApplyFailed`, clears
-`computedSpiffeIDs`, `renderedSelectors`, and `renderedClusterSPIFFEID`, and
-returns the API error so reconciliation retries.
+After pool selector normalization, Kleym resolves `spec.identityBoundary.labelKey` from the exact label map. The resolved boundary is:
 
-## Required Behavior
+```text
+namespace
+service account
+boundary label key
+boundary label value
+```
 
-1. Discover the supported GAIE pool GVK served by the cluster and watch it.
-2. Fail startup when the supported `InferencePool` GVK is not available.
-3. Resolve `poolRef` only to documented supported GAIE groups.
-4. Resolve the referenced pool into the inference target identity anchor and pod-selector inputs.
-5. Combine resolved target selectors with internal namespace and service-account safety selectors.
-6. Refuse unsafe selectors. If the selector set cannot be proven to stay within the binding namespace and required service account boundary, set `UnsafeSelector` and produce no managed output.
-7. Render the SPIFFE ID and managed `ClusterSPIFFEID` shape deterministically. Rendered output fields are documented in [Managed Resources][managed-resources].
-8. After startup succeeds, treat missing managed-output CRDs and infrastructure-not-ready states as transient by retrying reconciliation on a timer.
-9. On deletion, delete managed `ClusterSPIFFEID` children first and keep the binding finalizer until a follow-up list confirms no managed children remain.
+The label must be present and have a nonempty value. A missing label produces `UnsafeSelector=True` with reason `MissingIdentityBoundaryLabel`; an empty value produces `UnsafeSelector=True` with reason `EmptyIdentityBoundaryValue`.
 
-Selector rationale is expanded in [Selector Safety][selector-safety].
+For any two bindings with different rendered SPIFFE IDs, exclusivity is proven only when at least one condition is true:
 
-## Condition Taxonomy
+```text
+namespace differs
+OR
+service account differs
+OR
+boundary label key is equal and boundary label value differs
+```
 
-`InferenceIdentityBinding.status.conditions` is a stable machine-readable contract for reference resolution, selector safety, identity rendering, managed-output application, and reconciliation readiness.
+Every other relationship is a conflict. Different values of one Kubernetes label key are structurally disjoint because one workload cannot hold two values for that key. Different boundary label keys do not prove disjointness. Kleym does not use general selector intersection as a fallback.
+
+Two bindings that render the same SPIFFE ID are duplicate identity claims. They are conflicts even when their selectors or boundary declarations are equal.
+
+## Conflict Behavior
+
+Kleym evaluates potentially conflicting bindings from declared binding and pool state. A conflict group contains every visible binding with a resolved boundary that is either not deleting or still has managed output whose absence has not been confirmed. A deleting binding remains a competitor until its managed output is confirmed absent; peers must not recreate output while that deletion is pending.
+
+A conflict member has:
+
+```text
+Ready=False
+Conflict=True
+managed ClusterSPIFFEID absent
+rendered output status cleared
+resolved boundary and conflict references populated
+```
+
+Kleym removes every managed `ClusterSPIFFEID` owned by conflict members and confirms absence before settling the conflict state. If output deletion fails, reconciliation reports the API error and retries; it must not report a settled conflict state that implies output absence.
+
+Output is recreated only after the complete conflict group becomes exclusive or a deleting member's output absence is confirmed. Binding creation, update, deletion, and referenced pool selector changes must converge every affected peer to the appropriate state.
+
+Kleym removes registration intent. It does not claim immediate invalidation of an SVID already issued from a prior registration.
+
+## Status Contract
+
+On successful resolution, `status.resolvedIdentityBoundary` records the boundary label key and resolved value. It remains available for conflict diagnosis.
+
+`status.conflicts` is present only when `Conflict=True`. Each item describes one peer and one precise cause:
+
+```yaml
+bindingRef:
+  namespace: <peer namespace>
+  name: <peer name>
+cause: BoundaryValueReuse | BoundaryKeyMismatch | DuplicateSPIFFEID
+spiffeID: <peer rendered SPIFFE ID>
+labelKey: <peer boundary label key>
+value: <peer boundary label value>
+```
+
+`bindingRef`, `cause`, and `spiffeID` are required. `labelKey` and `value` are required for boundary causes and omitted for `DuplicateSPIFFEID` when no peer boundary was resolved. Items are sorted by peer namespace, peer name, cause, label key, and value. A binding may have multiple items for multiple peers or causes.
+
+`Conflict=True` uses `DuplicateIdentityBinding` when any item has cause `DuplicateSPIFFEID`; otherwise it uses `IdentityBoundaryConflict`. The condition reason is the coarse conflict class, while each item records the precise cause.
+
+`status.computedSpiffeIDs`, `status.renderedSelectors`, and `status.renderedClusterSPIFFEID` are populated only when `Ready=True`. They are cleared for selector failures and conflicts.
 
 Allowed condition types and reasons:
 
@@ -172,28 +163,59 @@ Allowed condition types and reasons:
 | `Ready` | `False` | The same primary failure reason used by the active failure condition. |
 | `Ready` | `Unknown` | `Initializing` |
 | `InvalidRef` | `True` | `InvalidPoolRef`, `TargetPoolNotFound`, `InferencePoolCRDMissing` |
-| `UnsafeSelector` | `True` | `InvalidPoolSelector`, `UnsafeSelector` |
+| `UnsafeSelector` | `True` | `InvalidPoolSelector`, `UnsafeSelector`, `MissingIdentityBoundaryLabel`, `EmptyIdentityBoundaryValue` |
+| `Conflict` | `True` | `IdentityBoundaryConflict`, `DuplicateIdentityBinding` |
 | `RenderFailure` | `True` | `MissingTrustDomain`, `InvalidServiceAccountName`, `InvalidSPIFFEID`, `ClusterSPIFFEIDCRDMissing`, `ManagedOutputApplyFailed` |
-| `InvalidRef`, `UnsafeSelector`, `RenderFailure` | `False` | `Resolved` |
-| `InvalidRef`, `UnsafeSelector`, `RenderFailure` | `Unknown` | `Initializing` |
+| `InvalidRef` | `False` | `Resolved` |
+| `UnsafeSelector` | `False` | `Resolved` |
+| `Conflict` | `False` | `Resolved` |
+| `RenderFailure` | `False` | `Resolved` |
+| `InvalidRef`, `UnsafeSelector`, `Conflict`, `RenderFailure` | `Unknown` | `Initializing` |
 
-On success, `Ready=True` uses `Reconciled`, every failure condition is `False` with `Resolved`, and rendered identity plus managed-resource status is populated.
+Exactly one primary failure condition is `True`. `Ready=False` uses the same reason and message. Conflict causes are `BoundaryValueReuse`, `BoundaryKeyMismatch`, and `DuplicateSPIFFEID`.
 
-On failure, `Ready=False` uses the same reason and message as the one active failure condition. Exactly one of `InvalidRef`, `UnsafeSelector`, or `RenderFailure` is `True`, and `computedSpiffeIDs`, `renderedSelectors`, plus `renderedClusterSPIFFEID` are cleared.
+## Rendered Managed Status
 
-Dependency-unavailable states use the same taxonomy:
+On successful reconciliation, `status.renderedClusterSPIFFEID` exposes the deterministic managed `ClusterSPIFFEID` name, rendered SPIFFE ID, a `sha256:<hex>` fingerprint of the canonical selector set, and the observed managed-resource generation when Kubernetes reports one.
 
-- Missing GAIE `InferencePool` CRD during pool discovery or pool resolution is `InvalidRef=True` with reason `InferencePoolCRDMissing`. Startup discovery fails when no supported GAIE pool GVK is served.
-- Missing SPIRE Controller Manager `ClusterSPIFFEID` CRD during reconcile is `RenderFailure=True` with reason `ClusterSPIFFEIDCRDMissing` and the reconcile retries on a timer.
-- Generic managed `ClusterSPIFFEID` list, create, update, or delete API failures are `RenderFailure=True` with reason `ManagedOutputApplyFailed`. The reconcile returns the API error for retry and clears rendered identity plus managed-resource status from the failed attempt.
+`status.renderedClusterSPIFFEID.spiffeID` is populated from the same rendered identity used for `status.computedSpiffeIDs`; it is not a second SPIFFE state. `observedGeneration` is omitted when Kubernetes has not reported a persisted generation.
+
+If a managed resource cannot be listed, created, updated, or deleted because the API request fails, reconciliation reports `RenderFailure=True` with reason `ManagedOutputApplyFailed`, clears rendered output status, and returns the API error for retry.
+
+## Required Behavior
+
+1. Discover the supported GAIE pool GVK served by the cluster and watch it.
+2. Fail startup when the supported `InferencePool` GVK is not available.
+3. Resolve `poolRef` only to documented supported GAIE groups.
+4. Normalize the referenced pool selector, resolve the declared identity boundary, and preserve the complete selector for rendering.
+5. Evaluate boundary exclusivity before managed output creation or update.
+6. Refuse selector failures and conflicts. Both states produce no managed output.
+7. Render the SPIFFE ID and managed `ClusterSPIFFEID` shape deterministically when the binding is exclusive.
+8. After startup succeeds, treat missing managed-output CRDs and infrastructure-not-ready states as transient by retrying reconciliation on a timer.
+9. On deletion, delete managed `ClusterSPIFFEID` children first and keep the binding finalizer until a follow-up list confirms no managed children remain.
+
+## Boundary Label Ownership
+
+An identity boundary label is security-sensitive metadata. Permission to assign the boundary label or selected service account is therefore identity registration authority.
+
+`identity.kleym.sonda.red/*` is reserved for platform-controlled boundary labels. Application authors must not directly set or mutate reserved labels. A boundary label is immutable for the lifetime of a Pod; boundary changes use replacement Pods.
+
+Kleym does not mutate workloads, pools, or Pods.
+
+## CLI Impact
+
+The CLI remains read only. Follow-on CLI work must expose the configured boundary key, resolved boundary value, full normalized pool selector, conflict peers and causes, and managed output state. It must consume the operator's boundary and conflict status rather than implement a separate exclusivity model. This issue does not change the current CLI specification or report format.
 
 ## Safety Invariants
 
 1. `InferenceIdentityBinding` is namespaced.
 2. Pool references stay in the binding namespace.
-3. Unsafe selectors are refused.
-4. Deletion keeps the finalizer until managed children are gone.
-5. `kleym-operator` does not create or modify inference deployments, pools, routes, gateways, schedulers, or policy resources.
+3. Namespace and service-account selectors are mandatory.
+4. Full normalized pool selectors are preserved in managed output.
+5. Different managed SPIFFE IDs must satisfy the identity-boundary exclusivity invariant.
+6. Conflicting and duplicate identity claims retain no managed output.
+7. Deletion keeps the finalizer until managed children are gone.
+8. `kleym-operator` does not create or modify inference deployments, pools, routes, gateways, schedulers, or policy resources.
 
 ## References
 
@@ -203,5 +225,3 @@ Dependency-unavailable states use the same taxonomy:
 [conditions-reference]: /reference/conditions/
 [dependencies]: /reference/dependencies/
 [gaie-compatibility]: /reference/gaie-compatibility/
-[managed-resources]: /reference/resources/
-[selector-safety]: /design/selector-safety/


### PR DESCRIPTION
## Summary

- Define explicit `identityBoundary.labelKey` and `labelValue` contract for `InferenceIdentityBinding`.
- Define one binding as an identity claim for a label-defined workload variant within an `InferencePool`.
- Specify structural exclusivity, fail-closed conflict behavior, stable conflict status, and complete selector rendering.

## What I Changed And Why

- Define `InferencePool` as the broad model-serving group and an `InferenceIdentityBinding` as one workload-variant identity claim, including prefill/decode-style subgroups.
- Require a platform-controlled boundary label key and value, preserving the full normalized pool selector while adding the boundary selector for the claimed variant.
- Include the variant value in the deterministic SPIFFE ID so distinct variants using one service account do not become duplicate claims.
- Keep deletion as a conflict competitor until its managed output is confirmed absent, preventing premature peer output recreation.

## Related Issue

- Closes #273

## Scope Check

- Implements the operator-spec contract requested by #273, including the binding-owned variant boundary needed for a pool to contain multiple independently identifiable workload variants.
- Does not implement API types, CRDs, controller behavior, managed output, CLI behavior, generated artifacts, or reference pages; those follow-on changes must implement this contract together.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): updated with the workload-variant identity boundary, variant SPIFFE path, selector rendering, conflict, and status contracts.
- CLI Spec (`docs/spec/cli.md`): not updated because this issue defines follow-on CLI requirements without changing the current report contract.
- Other docs: not updated because API, condition-reference, managed-resource, and example updates require their corresponding implementation work.

## Follow-Up Work

- Proposed follow-up issue(s): API/status types and CRD validation, variant-aware SPIFFE rendering, boundary selector rendering, exclusivity evaluation, peer convergence, output withdrawal, and CLI/reference updates described by the operator contract.

## Verification

- Commands run: `make docs-build`, `git diff --check`.
- Rendered output inspected: operator-spec title, description, canonical URL, workload-variant contract, and sitemap entry.
- Tests not run and why: this is a docs-only contract change with no implementation or generated artifacts.

## Security Review

- No GitHub Actions, CI, release automation, credentials, or secret-handling changes.
- The contract defines a workload-identity trust boundary. Boundary labels use the reserved `identity.kleym.sonda.red/` prefix and require admission-policy protection; no runtime authorization or workload mutation is added.
