### PR TITLE
ci: skip draft pull request jobs

### DIFF
--- a/.github/workflows/chainsaw-e2e.yml
+++ b/.github/workflows/chainsaw-e2e.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
   push:
     branches:
       - main

--- a/.github/workflows/chainsaw-e2e.yml
+++ b/.github/workflows/chainsaw-e2e.yml
@@ -20,7 +20,7 @@ jobs:
   chainsaw:
     name: Kind + Chainsaw
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.head_ref, 'renovate/') }}
+    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.draft) && !contains(github.head_ref, 'renovate/') }}
     env:
       GOFLAGS: -buildvcs=false -p=2
       GOMAXPROCS: "2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       GOFLAGS: -buildvcs=false -p=2
       GOMAXPROCS: "2"
@@ -44,6 +45,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       GOFLAGS: -buildvcs=false -p=2
       GOMAXPROCS: "2"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,7 @@ jobs:
   build:
     name: Build Docs
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
     paths:
       - "docs/**"
       - "hugo.yaml"

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -7,6 +7,7 @@ on:
     types:
       - opened
       - edited
+      - ready_for_review
       - synchronize
 
 permissions:
@@ -16,6 +17,7 @@ jobs:
   lint:
     name: Validate Conventional Commit
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Check PR title
         uses: amannn/action-semantic-pull-request@v6

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -153,7 +153,9 @@ Docs-related pull requests and pushes to `main` run a dedicated docs workflow th
 ## CI And Releases
 
 - CI workflows run on GitHub-hosted runners (`ubuntu-latest`) and must not depend on local or self-hosted infrastructure.
-- `.github/workflows/ci.yml` runs separate `Lint` and `Test` jobs on pull requests and pushes to `main`
-- `.github/workflows/chainsaw-e2e.yml` runs the Kind-backed Chainsaw reconciliation check on pull requests, pushes to `main`, and manual dispatch
+- `.github/workflows/ci.yml` runs separate `Lint` and `Test` jobs on non-draft pull requests and pushes to `main`
+- `.github/workflows/chainsaw-e2e.yml` runs the Kind-backed Chainsaw reconciliation check on non-draft pull requests, pushes to `main`, and manual dispatch
+- `.github/workflows/docs.yml` builds documentation changes on non-draft pull requests, pushes to `main`, and manual dispatch
+- `.github/workflows/pr-title.yml` validates titles on non-draft pull requests, including when a draft is marked ready for review
 - `.github/workflows/release.yml` runs by manual `workflow_dispatch` from the GitHub Actions UI, builds artifacts and images, creates the release tag, and creates a GitHub Release
 - Follow Conventional Commits for PR titles. See `RELEASING.md` for the manual release procedure


### PR DESCRIPTION
## Summary

- Skip pull-request jobs while a pull request is a draft.
- Run CI, docs, Chainsaw E2E, and title validation when a draft becomes ready for review.

## What I Changed And Why

- Added draft-state job guards to CI, Chainsaw E2E, and docs workflows while preserving push and manual-dispatch behavior.
- Kept the existing Renovate exclusion in Chainsaw E2E and combined it with the draft guard.
- Explicitly subscribed each pull-request workflow to `ready_for_review`, so a draft's checks start when it is published.

## Related Issue

- Not ticket-driven.

## Scope Check

- Restricts the existing pull-request jobs to published pull requests; push, manual-dispatch, permissions, and job commands remain unchanged.
- No release or permission redesign is included.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because no operator behavior or API contract changed.
- CLI Spec (`docs/spec/cli.md`): not needed because no CLI behavior changed.
- Other docs: updated `docs/contributing.md` with the non-draft workflow behavior.

## Follow-Up Work

- None.

## Verification

- Commands run: `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/*.yml`; `make lint`; `make docs-build`; targeted assertions for draft guards and `ready_for_review` subscriptions.
- Tests not run and why: `make test` was not run because this changes workflow gating and contributor documentation only; no Go runtime code changed.

## Security Review

- This PR touches GitHub Actions CI only. It preserves each workflow's existing read-only permissions, does not add secrets or write-capable tokens, and does not introduce untrusted shell execution paths.