### PR TITLE
feat(operator): evaluate identity-boundary exclusivity deterministically

### DIFF
--- a/internal/identity/boundary.go
+++ b/internal/identity/boundary.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 Kalin Daskalov.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package identity
+
+import (
+	"cmp"
+	"slices"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ConflictCause identifies why two identity boundaries are not exclusive.
+type ConflictCause string
+
+const (
+	// CauseBoundaryValueReuse reports equal boundaries that render distinct SPIFFE IDs.
+	CauseBoundaryValueReuse ConflictCause = "BoundaryValueReuse"
+	// CauseBoundaryKeyMismatch reports different boundary keys in one namespace and service account.
+	CauseBoundaryKeyMismatch ConflictCause = "BoundaryKeyMismatch"
+	// CauseDuplicateSPIFFEID reports two bindings that render the same SPIFFE ID.
+	CauseDuplicateSPIFFEID ConflictCause = "DuplicateSPIFFEID"
+)
+
+// BoundaryRecord is validated, resolved identity-boundary state used for exclusivity evaluation.
+// BindingRef.Namespace is the boundary namespace. SpiffeID must be a nonempty rendered SPIFFE ID.
+// Pool selectors are intentionally absent because they do not prove boundary exclusivity.
+type BoundaryRecord struct {
+	BindingRef         types.NamespacedName
+	ServiceAccountName string
+	LabelKey           string
+	LabelValue         string
+	SpiffeID           string
+}
+
+// BoundaryConflict describes one binding's conflict with a peer boundary.
+// The directional shape lets callers group records without coupling evaluation to API status types;
+// peer fields contain only the data needed to project that binding's conflict status.
+type BoundaryConflict struct {
+	BindingRef     types.NamespacedName
+	PeerBindingRef types.NamespacedName
+	Cause          ConflictCause
+	PeerSpiffeID   string
+	PeerLabelKey   string
+	PeerLabelValue string
+}
+
+// EvaluateBoundaryConflicts returns both directional records for every non-exclusive pair.
+// Callers must exclude invalid or unresolved bindings before evaluation. Every input record
+// must have a nonempty rendered SPIFFE ID.
+// Results are ordered by binding namespace and name, then by the peer namespace, peer name, cause,
+// peer label key, and peer label value specified for status in docs/spec/operator.md. Peer SPIFFE ID
+// provides a final deterministic tie-breaker.
+func EvaluateBoundaryConflicts(boundaries []BoundaryRecord) []BoundaryConflict {
+	var conflicts []BoundaryConflict
+	for leftIndex := range boundaries {
+		for rightIndex := leftIndex + 1; rightIndex < len(boundaries); rightIndex++ {
+			left := boundaries[leftIndex]
+			right := boundaries[rightIndex]
+			cause, conflict := evaluateBoundaryPair(left, right)
+			if !conflict {
+				continue
+			}
+
+			conflicts = append(conflicts,
+				boundaryConflict(left.BindingRef, right, cause),
+				boundaryConflict(right.BindingRef, left, cause),
+			)
+		}
+	}
+
+	slices.SortFunc(conflicts, compareBoundaryConflicts)
+	return conflicts
+}
+
+// boundaryConflict projects only the peer fields required by binding conflict status.
+func boundaryConflict(bindingRef types.NamespacedName, peer BoundaryRecord, cause ConflictCause) BoundaryConflict {
+	return BoundaryConflict{
+		BindingRef:     bindingRef,
+		PeerBindingRef: peer.BindingRef,
+		Cause:          cause,
+		PeerSpiffeID:   peer.SpiffeID,
+		PeerLabelKey:   peer.LabelKey,
+		PeerLabelValue: peer.LabelValue,
+	}
+}
+
+// evaluateBoundaryPair applies only the structural exclusivity proofs from the operator spec.
+func evaluateBoundaryPair(left, right BoundaryRecord) (ConflictCause, bool) {
+	if left.SpiffeID == right.SpiffeID {
+		return CauseDuplicateSPIFFEID, true
+	}
+	if left.BindingRef.Namespace != right.BindingRef.Namespace || left.ServiceAccountName != right.ServiceAccountName {
+		return "", false
+	}
+	if left.LabelKey == right.LabelKey {
+		if left.LabelValue != right.LabelValue {
+			return "", false
+		}
+		return CauseBoundaryValueReuse, true
+	}
+	return CauseBoundaryKeyMismatch, true
+}
+
+// compareBoundaryConflicts provides a total order while keeping the documented status fields primary.
+func compareBoundaryConflicts(left, right BoundaryConflict) int {
+	return cmp.Or(
+		cmp.Compare(left.BindingRef.Namespace, right.BindingRef.Namespace),
+		cmp.Compare(left.BindingRef.Name, right.BindingRef.Name),
+		cmp.Compare(left.PeerBindingRef.Namespace, right.PeerBindingRef.Namespace),
+		cmp.Compare(left.PeerBindingRef.Name, right.PeerBindingRef.Name),
+		cmp.Compare(left.Cause, right.Cause),
+		cmp.Compare(left.PeerLabelKey, right.PeerLabelKey),
+		cmp.Compare(left.PeerLabelValue, right.PeerLabelValue),
+		cmp.Compare(left.PeerSpiffeID, right.PeerSpiffeID),
+	)
+}

--- a/internal/identity/boundary_test.go
+++ b/internal/identity/boundary_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2026 Kalin Daskalov.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package identity
+
+import (
+	"slices"
+	"testing"
+	"testing/quick"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestEvaluateBoundaryConflicts(t *testing.T) {
+	t.Parallel()
+
+	base := testBoundaryRecord("binding-a")
+	cases := map[string]struct {
+		change    func(*BoundaryRecord)
+		wantCause ConflictCause
+	}{
+		"duplicate SPIFFE ID overrides different boundary shape": {
+			change: func(peer *BoundaryRecord) {
+				peer.BindingRef.Namespace = "other"
+				peer.ServiceAccountName = "other-sa"
+				peer.LabelKey = "identity.kleym.sonda.red/role"
+				peer.LabelValue = "decode"
+				peer.SpiffeID = base.SpiffeID
+			},
+			wantCause: CauseDuplicateSPIFFEID,
+		},
+		"namespace mismatch proves exclusivity": {
+			change: func(peer *BoundaryRecord) {
+				peer.BindingRef.Namespace = "other"
+				peer.SpiffeID = testSpiffeID("other", peer.ServiceAccountName, "binding-b")
+			},
+		},
+		"service account mismatch proves exclusivity": {
+			change: func(peer *BoundaryRecord) {
+				peer.ServiceAccountName = "other-sa"
+				peer.SpiffeID = testSpiffeID(peer.BindingRef.Namespace, "other-sa", "binding-b")
+			},
+		},
+		"same key and different value proves exclusivity": {
+			change: func(peer *BoundaryRecord) {
+				peer.LabelValue = "decode"
+			},
+		},
+		"same boundary with distinct SPIFFE IDs conflicts": {
+			change:    func(_ *BoundaryRecord) {},
+			wantCause: CauseBoundaryValueReuse,
+		},
+		"different keys with same value conflict": {
+			change: func(peer *BoundaryRecord) {
+				peer.LabelKey = "identity.kleym.sonda.red/role"
+			},
+			wantCause: CauseBoundaryKeyMismatch,
+		},
+		"different keys and values conflict": {
+			change: func(peer *BoundaryRecord) {
+				peer.LabelKey = "identity.kleym.sonda.red/role"
+				peer.LabelValue = "decode"
+			},
+			wantCause: CauseBoundaryKeyMismatch,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			peer := testBoundaryRecord("binding-b")
+			tc.change(&peer)
+			got := EvaluateBoundaryConflicts([]BoundaryRecord{base, peer})
+
+			if tc.wantCause == "" {
+				if len(got) != 0 {
+					t.Fatalf("conflicts = %#v, want none", got)
+				}
+				return
+			}
+			want := []BoundaryConflict{
+				boundaryConflict(base.BindingRef, peer, tc.wantCause),
+				boundaryConflict(peer.BindingRef, base, tc.wantCause),
+			}
+			if !slices.Equal(got, want) {
+				t.Fatalf("conflicts = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestEvaluateBoundaryConflictsIsSymmetricAndOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	property := func(namespaceIndex, serviceAccountIndex, keyIndex, valueIndex, spiffeIDIndex uint8) bool {
+		namespaces := []string{"default", "tenant-a"}
+		serviceAccounts := []string{"inference-sa", "decode-sa"}
+		keys := []string{"identity.kleym.sonda.red/variant", "identity.kleym.sonda.red/role"}
+		values := []string{"prefill", "decode"}
+		pools := []string{"pool-a", "pool-b"}
+
+		left := testBoundaryRecord("binding-a")
+		left.BindingRef.Namespace = namespaces[int(namespaceIndex)%len(namespaces)]
+		left.ServiceAccountName = serviceAccounts[int(serviceAccountIndex)%len(serviceAccounts)]
+		left.LabelKey = keys[int(keyIndex)%len(keys)]
+		left.LabelValue = values[int(valueIndex)%len(values)]
+		left.SpiffeID = testSpiffeID(
+			left.BindingRef.Namespace,
+			left.ServiceAccountName,
+			pools[int(spiffeIDIndex)%len(pools)],
+		)
+		right := testBoundaryRecord("binding-b")
+
+		forward := EvaluateBoundaryConflicts([]BoundaryRecord{left, right})
+		reverse := EvaluateBoundaryConflicts([]BoundaryRecord{right, left})
+		return slices.Equal(forward, reverse)
+	}
+	if err := quick.Check(property, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEvaluateBoundaryConflictsAlwaysClassifiesDuplicateSPIFFEIDs(t *testing.T) {
+	t.Parallel()
+
+	property := func(useOtherNamespace, useOtherServiceAccount, useOtherKey, useOtherValue bool) bool {
+		left := testBoundaryRecord("binding-a")
+		right := testBoundaryRecord("binding-b")
+		if useOtherNamespace {
+			right.BindingRef.Namespace = "tenant-a"
+		}
+		if useOtherServiceAccount {
+			right.ServiceAccountName = "decode-sa"
+		}
+		if useOtherKey {
+			right.LabelKey = "identity.kleym.sonda.red/role"
+		}
+		if useOtherValue {
+			right.LabelValue = "decode"
+		}
+		right.SpiffeID = left.SpiffeID
+
+		got := EvaluateBoundaryConflicts([]BoundaryRecord{left, right})
+		return len(got) == 2 &&
+			got[0].Cause == CauseDuplicateSPIFFEID &&
+			got[1].Cause == CauseDuplicateSPIFFEID
+	}
+	if err := quick.Check(property, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEvaluateBoundaryConflictsSortsMultiplePeers(t *testing.T) {
+	t.Parallel()
+
+	first := testBoundaryRecord("binding-a")
+	second := testBoundaryRecord("binding-b")
+	second.LabelKey = "identity.kleym.sonda.red/role"
+	third := testBoundaryRecord("binding-c")
+
+	inputs := [][]BoundaryRecord{
+		{first, second, third},
+		{first, third, second},
+		{second, first, third},
+		{second, third, first},
+		{third, first, second},
+		{third, second, first},
+	}
+	want := []BoundaryConflict{
+		boundaryConflict(first.BindingRef, second, CauseBoundaryKeyMismatch),
+		boundaryConflict(first.BindingRef, third, CauseBoundaryValueReuse),
+		boundaryConflict(second.BindingRef, first, CauseBoundaryKeyMismatch),
+		boundaryConflict(second.BindingRef, third, CauseBoundaryKeyMismatch),
+		boundaryConflict(third.BindingRef, first, CauseBoundaryValueReuse),
+		boundaryConflict(third.BindingRef, second, CauseBoundaryKeyMismatch),
+	}
+	for index, input := range inputs {
+		if got := EvaluateBoundaryConflicts(input); !slices.Equal(got, want) {
+			t.Fatalf("permutation %d conflicts = %#v, want %#v", index, got, want)
+		}
+	}
+}
+
+func TestEvaluateBoundaryConflictsMixedGraph(t *testing.T) {
+	t.Parallel()
+
+	a := testBoundaryRecord("binding-a")
+	a.LabelKey = "identity.kleym.sonda.red/key-x"
+	a.LabelValue = "one"
+	b := testBoundaryRecord("binding-b")
+	b.LabelKey = "identity.kleym.sonda.red/key-y"
+	b.LabelValue = "one"
+	c := testBoundaryRecord("binding-c")
+	c.LabelKey = "identity.kleym.sonda.red/key-x"
+	c.LabelValue = "two"
+
+	want := []BoundaryConflict{
+		{
+			BindingRef:     a.BindingRef,
+			PeerBindingRef: b.BindingRef,
+			Cause:          CauseBoundaryKeyMismatch,
+			PeerSpiffeID:   b.SpiffeID,
+			PeerLabelKey:   b.LabelKey,
+			PeerLabelValue: b.LabelValue,
+		},
+		{
+			BindingRef:     b.BindingRef,
+			PeerBindingRef: a.BindingRef,
+			Cause:          CauseBoundaryKeyMismatch,
+			PeerSpiffeID:   a.SpiffeID,
+			PeerLabelKey:   a.LabelKey,
+			PeerLabelValue: a.LabelValue,
+		},
+		{
+			BindingRef:     b.BindingRef,
+			PeerBindingRef: c.BindingRef,
+			Cause:          CauseBoundaryKeyMismatch,
+			PeerSpiffeID:   c.SpiffeID,
+			PeerLabelKey:   c.LabelKey,
+			PeerLabelValue: c.LabelValue,
+		},
+		{
+			BindingRef:     c.BindingRef,
+			PeerBindingRef: b.BindingRef,
+			Cause:          CauseBoundaryKeyMismatch,
+			PeerSpiffeID:   b.SpiffeID,
+			PeerLabelKey:   b.LabelKey,
+			PeerLabelValue: b.LabelValue,
+		},
+	}
+	if got := EvaluateBoundaryConflicts([]BoundaryRecord{c, a, b}); !slices.Equal(got, want) {
+		t.Fatalf("conflicts = %#v, want %#v", got, want)
+	}
+}
+
+func testBoundaryRecord(name string) BoundaryRecord {
+	return BoundaryRecord{
+		BindingRef:         types.NamespacedName{Namespace: "default", Name: name},
+		ServiceAccountName: "inference-sa",
+		LabelKey:           "identity.kleym.sonda.red/variant",
+		LabelValue:         "prefill",
+		SpiffeID:           testSpiffeID("default", "inference-sa", name),
+	}
+}
+
+func testSpiffeID(namespace, serviceAccount, pool string) string {
+	return "spiffe://example.org/ns/" + namespace + "/sa/" + serviceAccount + "/inference/pool/" + pool
+}


### PR DESCRIPTION
## Summary

- Add a pure evaluator for deterministic identity-boundary exclusivity conflicts.
- Add contract coverage for pairwise causes, symmetry, ordering, duplicate SPIFFE IDs, and mixed conflict graphs.

## What I Changed And Why

- Model the resolved boundary with its binding reference, service account, boundary label, and rendered SPIFFE ID.
- Return directional conflict records with only the peer fields needed for later status projection.
- Keep the evaluator independent of controller reconciliation, Kubernetes object inspection, and selector-intersection logic so #280 can compose it safely.

## Related Issue

- Closes #277

## Scope Check

- Implements the pure deterministic evaluator and tests required by #277.
- Controller wiring, CRD/API changes, status writes, managed-output withdrawal, and CLI reporting remain with their designated follow-up work.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because the evaluator implements the already accepted #274 contract without changing it.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI behavior is unchanged.
- Other docs: not needed because no user-facing API or behavior is shipped in this prerequisite.

## Follow-Up Work

- The evaluator is the pure prerequisite for #280.

## Verification

- Commands run: `go test -count=1 ./internal/identity`, `make test`, `make lint`, `git diff --check`.
- Tests not run and why: `make test-e2e-chainsaw` was not run; this patch is pure package logic with no Kubernetes reconciliation wiring.

## Security Review

- No GitHub Actions, CI, release automation, credentials, or secret-handling changes.
- The evaluator implements the accepted fail-closed boundary classification rules; it does not create, update, or delete Kubernetes or SPIRE resources.
