### PR TITLE
docs(operator): align identity boundary guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ The in-cluster `kleym-operator` watches `InferencePool` workload intent, then co
 ## Where kleym fits
 
 - The [Gateway API Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/) describes inference workloads in Kubernetes.
-- `kleym-operator` turns that intent into workload identity registrations with tenant-safe selectors.
-- SPIRE Controller Manager applies those registrations so SPIRE can issue identities to the matching workloads.
+- `kleym-operator` turns that intent into workload identity registrations constrained by namespace, service account, pool, and a reserved identity-boundary label.
+- SPIRE Controller Manager translates managed `ClusterSPIFFEID` resources into SPIRE registration entries; SPIRE Server issues SVIDs, while SPIRE Agent attests workloads and delivers credentials.
 
 ## Why kleym
 
-- Derives stable SPIFFE identities from Gateway API Inference Extension resources instead of ad hoc labels.
-- Keeps selector rendering tenant-safe by intersecting namespace, service account, and pool-derived selectors.
-- Delegates identity issuance and rotation to SPIRE Controller Manager instead of writing SPIRE entries directly.
+- Derives stable SPIFFE identities from declared pool, service-account, and workload-variant intent.
+- Keeps selector rendering workload-constrained with mandatory namespace, service account, pool-derived, and identity-boundary selectors.
+- Writes `ClusterSPIFFEID` intent for SPIRE Controller Manager instead of writing SPIRE registration entries or issuing credentials.
 
 ## Scope boundary
 
@@ -50,8 +50,9 @@ Kleym stops at identity registration. `kleym-operator` does not deploy inference
 
 - `InferenceIdentityBinding` declares identity intent and a reserved label boundary for one `InferencePool` workload variant.
 - `kleym-operator` resolves the pool to an internal inference target anchored as `pool/<pool-name>`.
-- The controller combines that target with the binding namespace, service account, and identity boundary to render deterministic selectors and variant SPIFFE IDs.
-- Managed `ClusterSPIFFEID` resources are reconciled for SPIRE Controller Manager.
+- The controller combines that target with the binding namespace, service account, and mandatory identity boundary to render deterministic selectors and variant SPIFFE IDs.
+- Peer bindings are evaluated for structural exclusivity before managed output is created or updated.
+- Conflicting or duplicate identity claims have their managed `ClusterSPIFFEID` output withdrawn; absence is confirmed before the conflict is reported as settled and before peers may recreate output.
 
 ## Quickstart
 
@@ -62,6 +63,7 @@ Prerequisites:
 - `kubectl`
 - Access to a Kubernetes cluster with the Gateway API Inference Extension [`InferencePool`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/) CRD
 - SPIRE Controller Manager with the `ClusterSPIFFEID` CRD
+- Cluster admission policy that controls assignment of `identity.kleym.sonda.red/*` Pod labels and prevents changing them during a Pod's lifetime; see [`docs/install.md`](docs/install.md#identity-boundary-admission-policy)
 - Docker for Kind-backed e2e; the e2e targets bootstrap `kind` and Chainsaw under `bin/`
 
 Run the controller locally:
@@ -131,7 +133,9 @@ flowchart TD
         D1Y["Clean up ClusterSPIFFEIDs\nRemove finalizer"]
         F["Ensure finalizer"]
         RESOLVE["Resolve poolRef → Pool"]
-        RENDER["Derive selectors from pool\nValidate safety selectors\nRender SPIFFE ID"]
+        RENDER["Derive selectors from pool\nValidate mandatory boundary + selectors\nRender SPIFFE ID"]
+        PEERS{"Exclusive from peers?"}
+        WITHDRAW["Withdraw conflict output\nConfirm absence"]
         APPLY["Reconcile ClusterSPIFFEID"]
         STATUS["Patch status + emit events"]
     end
@@ -146,7 +150,9 @@ flowchart TD
     D1 -->|yes| D1Y
     D1 -->|no| F --> RESOLVE
     P --> RESOLVE
-    RESOLVE --> RENDER --> APPLY --> STATUS
+    RESOLVE --> RENDER --> PEERS
+    PEERS -->|yes| APPLY --> STATUS
+    PEERS -->|no| WITHDRAW --> STATUS
     APPLY --> CS --> SCM --> SR
     STATUS --> B
 
@@ -161,7 +167,8 @@ flowchart TD
     class B binding
     class P gaie
     class D1 gate
-    class D1Y,F,RESOLVE,RENDER,APPLY controller
+    class D1Y,F,RESOLVE,RENDER,APPLY,WITHDRAW controller
+    class PEERS gate
     class STATUS status
     class CS,SCM,SR spire
 ```

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -6,7 +6,9 @@ Service through `config/default`.
 
 External dependency CRDs are not included. Install Gateway API Inference
 Extension CRDs and SPIRE Controller Manager, including the `ClusterSPIFFEID`
-CRD, before starting kleym.
+CRD, before starting kleym. The cluster must also enforce the reserved
+identity-boundary label controls described in the
+[installation prerequisites](../docs/install.md#identity-boundary-admission-policy).
 
 For Kustomize, Flux, Argo CD, release pinning, and Helm guidance, see
 [`docs/install.md`](../docs/install.md#gitops-install).

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -22,7 +22,9 @@ The in-cluster `kleym-operator` watches `InferencePool` workload intent, then co
 
 - primary input: [`InferencePool`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/)
 - primary output: deterministic `ClusterSPIFFEID` resources
-- safety model: namespace and service account selectors are always present; unsafe or ambiguous state is refused
+- safety model: namespace, service account, pool, and identity-boundary selectors are mandatory; peer bindings must be structurally exclusive
+- fail-closed behavior: unsafe, conflicting, or duplicate claims retain no managed output, and output absence is confirmed before conflicts settle
+- enforcement assumption: cluster admission controls reserved identity-boundary labels and keeps them immutable for each Pod lifetime
 
 ## Documentation Map
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -10,7 +10,7 @@ aliases:
 
 Kleym uses inference workload identity to mean identity registration derived from a Kubernetes inference serving boundary, not from a pod alone. In the current contract, that serving boundary is a Gateway API Inference Extension (GAIE) `InferencePool` referenced by an `InferenceIdentityBinding`.
 
-The binding namespace and required service account constrain which workloads may match. Selectors from the referenced pool provide workload provenance, while `spec.identityBoundary` selects one label-defined workload variant. `kleym-operator` resolves the pool, validates structural exclusivity against peer bindings, and reconciles a managed SPIRE Controller Manager `ClusterSPIFFEID` only when the variant is exclusive.
+The binding namespace and required service account constrain which workloads may match. Selectors from the referenced pool provide workload provenance, while the required `spec.identityBoundary` selects one label-defined workload variant. `kleym-operator` resolves the pool, validates structural exclusivity against peer bindings, and reconciles a managed SPIRE Controller Manager `ClusterSPIFFEID` only when the variant is exclusive. SPIRE Controller Manager translates that resource into registration entries; SPIRE Server issues SVIDs, while SPIRE Agent attests workloads and delivers credentials.
 
 This stops at identity registration. Kleym does not deploy inference workloads, route traffic, configure gateways, evaluate request policy, issue credentials, or prove runtime SVID use. The authoritative behavior is defined in the [Operator Spec](/spec/operator/).
 
@@ -38,7 +38,8 @@ boundary label value identifies the variant within the pool.
 
 ## Safety Selectors
 
-Safety selectors are the controller's proof that the rendered identity stays inside the intended tenant boundary.
+Safety selectors constrain the rendered workload match; they do not authorize
+who may create bindings or assign workload labels.
 
 Every rendered identity must include:
 
@@ -51,6 +52,13 @@ Every rendered identity must include:
 Within one namespace and service account, different SPIFFE IDs are structurally
 exclusive only when they use the same boundary label key with different values.
 Duplicate SPIFFE IDs, reused values, and different boundary keys fail closed.
+The controller withdraws managed output for every member of a conflict group and
+confirms it is absent before reporting the conflict as settled. A deleting peer
+remains a competitor until its output is confirmed absent.
+
+Structural exclusivity assumes that cluster admission restricts reserved
+boundary labels to platform-controlled actors and keeps them immutable for each
+Pod lifetime. See [Identity Boundary Admission Policy](/install/#identity-boundary-admission-policy).
 
 ## See Also
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -31,6 +31,7 @@ Use a Kubernetes cluster with these dependencies already installed:
 - Gateway API Inference Extension CRD for the reference `InferencePool`
 - SPIRE Controller Manager with the `ClusterSPIFFEID` CRD
 - `kleym-operator` installed and running
+- [identity-boundary admission policy](/install/#identity-boundary-admission-policy) that controls `identity.kleym.sonda.red/*` labels and prevents mutation during a Pod's lifetime
 
 Confirm the external CRDs and controller are present:
 
@@ -56,6 +57,10 @@ kubectl -n kleym-reference-inference rollout status deployment/reference-model-s
 
 Expected observation: the reference namespace, service account, workload, and
 `InferencePool` exist before any binding is applied.
+
+The fixture Pod template already carries the reserved boundary label. The
+cluster admission policy, not Kleym, must authorize that platform-controlled
+assignment and prevent later changes to the label.
 
 ## Apply The Binding
 

--- a/docs/design/reconciliation.md
+++ b/docs/design/reconciliation.md
@@ -10,20 +10,32 @@ aliases:
 
 For each `InferenceIdentityBinding`, the reconciler currently does the following:
 
-1. Fetch the binding and ensure the `kleym.sonda.red/inferenceidentitybinding-finalizer` is present.
-2. Resolve the referenced `InferencePool` from `spec.poolRef`.
+1. Fetch the binding. If it is deleting, remove recorded managed output, confirm
+   absence, and only then remove the
+   `kleym.sonda.red/inferenceidentitybinding-finalizer`.
+2. Otherwise, ensure the finalizer and resolve the referenced `InferencePool`
+   from `spec.poolRef`.
 3. Resolve the pool to identity anchor `pool/<pool-name>` plus pod-label selector inputs.
-4. Render namespace and service-account safety selectors from the binding and merge them with the resolved target selectors.
-5. Validate selector safety before rendering or writing output.
-6. Render the deterministic service-account-scoped inference target SPIFFE ID.
-7. Create, update, or delete managed `ClusterSPIFFEID` resources to match the rendered identity.
-8. Patch binding status and emit events for success or failure.
+4. Validate the required identity boundary and render the mandatory namespace,
+   service-account, complete pool, and boundary selectors.
+5. Render the deterministic service-account-scoped inference target SPIFFE ID.
+6. Evaluate peer bindings using the pairwise exclusivity contract in the
+   [Operator Spec](/spec/operator/#identity-boundary-and-exclusivity).
+7. For a conflict or duplicate claim, withdraw managed output from every
+   conflict member and confirm absence before settling `Conflict=True`.
+8. For an exclusive claim, create or update the managed `ClusterSPIFFEID` only
+   after any previously recorded output is confirmed absent.
+9. Patch binding status and emit events for success or failure.
 
 ## Requeue Sources
 
 The controller does not only react to the binding itself. It also watches:
 
 - `InferencePool`, so selector changes requeue only bindings whose `spec.poolRef.name` points at that pool
+- peer `InferenceIdentityBinding` objects, so binding creation, update, and
+  deletion converge every affected peer without relying on in-memory state
+- managed `ClusterSPIFFEID` objects, so deletion or drift requeues the binding
+  that recorded the output name
 
 That keeps the rendered identity tied to current pool state instead of only the binding object.
 
@@ -31,6 +43,19 @@ Watch predicates filter status-only update events to avoid hot loops. Create and
 
 ## Failure Shape
 
-The reconciler treats invalid references, unsafe selectors, and render failures as controller state, not as crashes. In those paths it updates status, emits an event, and removes stale managed output instead of leaving outdated `ClusterSPIFFEID` resources behind.
+The reconciler treats invalid references, unsafe selectors, conflicts, and
+render failures as controller state, not as crashes. Invalid boundaries report
+`UnsafeSelector=True` with reason `InvalidIdentityBoundary`. Conflict members
+report `Conflict=True` only after their managed output is absent; duplicate
+SPIFFE ID claims use reason `DuplicateIdentityBinding`, while other boundary
+conflicts use `IdentityBoundaryConflict`.
 
-For missing required external CRDs (`InferencePool` or `ClusterSPIFFEID`), the reconciler also schedules a timed retry (`RequeueAfter`) so recovery does not depend on unrelated future events.
+When old or conflicting output deletion is still converging, rendered output is
+cleared and `Ready=Unknown` with reason `Initializing` records that absence has
+not yet been confirmed. API uncertainty is not absence confirmation.
+
+Controller setup fails when the supported `InferencePool` GVK is not served, so
+installing that CRD requires restarting an operator that already failed startup.
+After startup, a missing `ClusterSPIFFEID` CRD is a managed-output failure and
+uses a timed retry (`RequeueAfter`) so recovery does not depend on unrelated
+watch events.

--- a/docs/design/selector-safety.md
+++ b/docs/design/selector-safety.md
@@ -1,7 +1,7 @@
 ---
 title: Selector Safety
 weight: 20
-description: "Selector safety design for proving namespace, service account, and pool boundaries before rendering SPIFFE identities."
+description: "Selector safety design for constraining namespace, service account, pool, and identity-boundary workload matches before rendering SPIFFE identities."
 aliases:
   - /operator/design/selector-safety/
 ---
@@ -22,10 +22,23 @@ The current implementation requires:
 - a namespace selector: `k8s:ns:<binding-namespace>`
 - a service account selector: `k8s:sa:<service-account>`
 - selectors derived from the referenced pool
+- one boundary selector rendered from required `spec.identityBoundary`:
+  `k8s:pod-label:<label-key>:<label-value>`
 
 If the namespace selector does not match the binding namespace, reconciliation fails.
 
 If no service account selector is present, reconciliation fails.
+
+An invalid, missing, or non-reserved boundary fails with
+`UnsafeSelector=True` reason `InvalidIdentityBoundary`. Different SPIFFE IDs in
+the same namespace and service account are exclusive only when their boundary
+keys match and their values differ. Other relationships conflict; the exact
+pairwise rules remain authoritative in the
+[Operator Spec](/spec/operator/#identity-boundary-and-exclusivity).
+
+Conflict members retain no managed output. The controller withdraws their owned
+`ClusterSPIFFEID` resources and confirms absence before reporting the conflict
+as settled or permitting peers to recreate output.
 
 ## Pool Selector Constraints
 
@@ -52,7 +65,12 @@ did not specify. `matchExpressions` are not rendered.
 
 ## Selector Ownership
 
-Users provide only `serviceAccountName`. Kleym renders the namespace and
-service-account selectors internally and derives pool selectors from `poolRef`.
-The final selector set is de-duplicated and sorted before it is reported in
-status or written to managed `ClusterSPIFFEID` output.
+Users declare `serviceAccountName` and `identityBoundary`; Kleym renders the
+namespace and service-account selectors internally and derives pool selectors
+from `poolRef`. The final selector set is de-duplicated and sorted before it is
+reported in status or written to managed `ClusterSPIFFEID` output.
+
+Selector exclusivity depends on the boundary label remaining platform
+controlled and immutable for the Pod lifetime. Kleym does not enforce workload
+label writes; installation must provide the external admission policy described
+in [Identity Boundary Admission Policy](/install/#identity-boundary-admission-policy).

--- a/docs/examples/_index.md
+++ b/docs/examples/_index.md
@@ -20,6 +20,7 @@ These examples assume:
 - Gateway API Inference Extension (GAIE) CRDs are installed for [`InferencePool`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/)
 - SPIFFE Runtime Environment (SPIRE) Controller Manager is installed with the [`ClusterSPIFFEID` CRD](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md)
 - `kleym-operator` is running
+- the required [identity-boundary admission policy](/install/#identity-boundary-admission-policy) controls reserved labels and makes them immutable for each Pod lifetime
 
 The manifests show the GAIE fields `kleym-operator` consumes. For full GAIE
 object shape and additional optional fields, use the [GAIE API types index](https://gateway-api-inference-extension.sigs.k8s.io/api-types/).
@@ -29,7 +30,7 @@ For SPIFFE and SPIRE background, see [SPIFFE overview](https://spiffe.io/docs/la
 
 | Example | Use it when | Outcome |
 | --- | --- | --- |
-| [Basic Binding](/examples/basic-binding/) | You need one identity per serving pool. | One managed `ClusterSPIFFEID` for the referenced pool. |
+| [Basic Binding](/examples/basic-binding/) | You need one identity for a service account and label-defined pool variant. | One managed `ClusterSPIFFEID` for the declared variant. |
 
 ## Recommended Reading Order
 

--- a/docs/examples/basic-binding.md
+++ b/docs/examples/basic-binding.md
@@ -28,6 +28,7 @@ spec:
   selector:
     matchLabels:
       app: model-server
+---
 apiVersion: kleym.sonda.red/v1alpha1
 kind: InferenceIdentityBinding
 metadata:
@@ -41,6 +42,12 @@ spec:
     labelKey: identity.kleym.sonda.red/variant
     labelValue: prefill
 ```
+
+The selected Pods must carry
+`identity.kleym.sonda.red/variant=prefill`. Apply this example only after the
+cluster has the required
+[identity-boundary admission policy](/install/#identity-boundary-admission-policy);
+Kleym neither adds the label nor enforces its Pod-lifetime immutability.
 
 ## Expected Outcome
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,12 +18,25 @@ previewing the documentation site locally. CLI usage is documented separately in
 - Access to a Kubernetes cluster
 - Gateway API Inference Extension (GAIE) CRD for [`InferencePool`](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/)
 - SPIFFE Runtime Environment (SPIRE) Controller Manager with the [`ClusterSPIFFEID` CRD](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md)
+- An admission-policy implementation for the identity-boundary label controls described below
 - Docker for Kind-backed e2e; the e2e targets bootstrap `kind` and Chainsaw under `bin/`
 - Hugo Extended `0.146+` for docs preview/build
 
 The repository bootstraps local tool binaries under `bin/` through `make` targets, so you do not need to install `controller-gen`, `kustomize`, `setup-envtest`, `golangci-lint`, `kind`, or Chainsaw globally.
 
 For identity-system background, see [SPIFFE overview](https://spiffe.io/docs/latest/spiffe-about/overview/) and [SPIRE concepts](https://spiffe.io/docs/latest/spire-about/spire-concepts/).
+
+## Identity Boundary Admission Policy
+
+Before creating bindings or labeled workloads, install cluster admission policy
+for the reserved `identity.kleym.sonda.red/*` Pod-label prefix. The policy must:
+
+- allow assignment of reserved boundary labels only by platform-controlled actors
+- reject adding, changing, or removing a reserved boundary label on an existing Pod; boundary changes require replacement Pods
+
+Use a Kubernetes admission controller, policy engine, or webhook appropriate to
+your cluster. Kleym does not install this external policy or mutate Pods. The
+authoritative ownership requirement is [Boundary Label Ownership](/spec/operator/#boundary-label-ownership).
 
 ## Run Locally
 

--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -50,7 +50,7 @@ When `--clusterspiffeid-class-name` is empty, SPIRE Controller Manager must be c
 5. Status records operator configuration, validated identity-boundary state, rendered output, conflicts, and conditions. The status rules are defined in [Status Contract](#status-contract).
 6. The CRD exposes printer columns for `POOL`, `BOUNDARY`, `READY`, `REASON`, and `SPIFFE ID` so `kubectl get inferenceidentitybindings.kleym.sonda.red -A` is the primary binding list view.
 
-[API Reference][api-reference] and [Conditions Reference][conditions-reference] document implemented API and condition surfaces. Follow-on API, controller, and CLI work must update those references before these boundary fields and reasons are shipped.
+[API Reference][api-reference] and [Conditions Reference][conditions-reference] document the implemented API and condition surfaces.
 
 ## Resolved Inference Target Contract
 
@@ -211,9 +211,11 @@ An identity boundary label is security-sensitive metadata. Permission to assign 
 
 Kleym does not mutate workloads, pools, or Pods.
 
-## CLI Impact
+## CLI Boundary
 
-The CLI remains read only. Follow-on CLI work must expose the declared boundary key and value, full normalized pool selector, conflict peers and causes, and managed output state. It must consume the operator's boundary and conflict status rather than implement a separate exclusivity model. This issue does not change the current CLI specification or report format.
+The CLI remains read only and consumes operator status. It does not reconcile
+resources or implement a separate identity-boundary exclusivity model. The
+current inspection contract is defined in the [CLI Spec](/spec/cli/).
 
 ## Safety Invariants
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,8 +22,11 @@ In normal operation:
 - `Ready=True` with reason `Reconciled`
 - all failure conditions are `False` with reason `Resolved`
 
-If reconciliation fails, `Ready=False` and the triggering condition becomes `True`.
-`Ready=False` carries the same reason and message as the single active failure condition.
+A settled validation, conflict, or managed-output failure sets `Ready=False`;
+the single active failure condition carries the same reason and message.
+`Ready=Unknown` with reason `Initializing` means reconciliation has not settled,
+including while the controller waits to confirm old or conflicting managed
+output is absent.
 
 ## Condition And Reason Map
 
@@ -33,12 +36,33 @@ If reconciliation fails, `Ready=False` and the triggering condition becomes `Tru
 | `InvalidRef` | `TargetPoolNotFound` | The binding points to an `InferencePool` that does not exist. | Create the pool or correct `spec.poolRef`. |
 | `InvalidRef` | `InferencePoolCRDMissing` | The GAIE `InferencePool` CRD is not installed in the cluster. | Install the required GAIE CRDs before reconciling bindings. |
 | `UnsafeSelector` | `InvalidPoolSelector` | The pool selector cannot be normalized into a rendered selector set, or its label keys or values are malformed. | Use a deterministic `matchLabels`-style selector with valid Kubernetes label keys and values. Do not rely on whitespace trimming. |
-| `UnsafeSelector` | `UnsafeSelector` | The rendered selector set is missing namespace or service account safety constraints, or would widen beyond the tenant boundary. | Ensure `serviceAccountName` and the pool-derived selector stay within the intended workload boundary. |
+| `UnsafeSelector` | `UnsafeSelector` | The rendered selector set is missing namespace or service account constraints, or would widen beyond the required workload match. | Ensure `serviceAccountName` and the pool-derived selector preserve the intended workload match. |
+| `UnsafeSelector` | `InvalidIdentityBoundary` | The required boundary key or value is missing, malformed, empty, or the key is outside `identity.kleym.sonda.red/*`. | Set a valid reserved `identityBoundary.labelKey` and nonempty Kubernetes label value. |
+| `Conflict` | `IdentityBoundaryConflict` | Peer claims in the same namespace and service account reuse a boundary value or use different boundary keys, so exclusivity is not proven. | Give distinct variants the same platform-controlled boundary key with different values, then wait for all conflicting output to be confirmed absent. |
+| `Conflict` | `DuplicateIdentityBinding` | This binding and at least one peer render the same SPIFFE ID. | Remove the duplicate claim or change its identity inputs; selector differences do not make duplicate SPIFFE IDs valid. |
 | `RenderFailure` | `InvalidServiceAccountName` | `spec.serviceAccountName` is empty or not a valid Kubernetes service account name. | Set `serviceAccountName` to the exact workload service account. |
 | `RenderFailure` | `InvalidSPIFFEID` | The computed SPIFFE ID is not valid. | Check the referenced namespace and pool names. |
 | `RenderFailure` | `MissingTrustDomain` | The operator has no trust domain configured. | Configure `--trust-domain` or `KLEYM_TRUST_DOMAIN` before starting the operator. |
 | `RenderFailure` | `ClusterSPIFFEIDCRDMissing` | SPIRE Controller Manager or its `ClusterSPIFFEID` CRD is missing. | Install SPIRE Controller Manager and confirm the `clusterspiffeids.spire.spiffe.io` CRD exists. |
 | `RenderFailure` | `ManagedOutputApplyFailed` | The Kubernetes API rejected or failed a managed `ClusterSPIFFEID` list, create, update, or delete request. | Check API server availability, RBAC, admission errors, and SPIRE Controller Manager CRD health; the controller returns the API error for retry. |
+
+## Conflict Diagnosis
+
+When `Conflict=True`, inspect `status.conflicts`. Each item identifies a peer
+binding and a precise cause:
+
+| Cause | Meaning |
+| --- | --- |
+| `BoundaryValueReuse` | Different SPIFFE IDs in the same namespace and service account reuse the same boundary key and value. |
+| `BoundaryKeyMismatch` | Different SPIFFE IDs in the same namespace and service account use different boundary keys, which does not prove disjointness. |
+| `DuplicateSPIFFEID` | Both bindings render the same SPIFFE ID; this is a duplicate claim regardless of selectors or boundary declarations. |
+
+Conflict output is fail closed. The controller withdraws every owned
+`ClusterSPIFFEID` in the conflict group and reports the settled conflict only
+after absence is confirmed. While deletion or a prior identity replacement is
+pending, expect cleared rendered output and `Ready=Unknown` with reason
+`Initializing`. A deleting peer remains a competitor until its output absence
+is confirmed, so do not recreate output manually.
 
 ## Missing CRDs
 


### PR DESCRIPTION
## Summary

- Align user-facing documentation with the implemented fail-closed identity-boundary contract.
- Document the external admission-policy prerequisite for reserved boundary labels.
- Correct reconciliation, troubleshooting, SPIRE responsibility, and example guidance that had drifted from the operator spec.

## What I Changed And Why

- Updated overview, concepts, and design guidance to include mandatory boundary selectors, peer exclusivity evaluation, conflict-output withdrawal, and confirmed absence.
- Added one canonical installation section for reserved-label assignment and Pod-lifetime immutability, with links from deployment, demo, and examples.
- Corrected SPIRE Controller Manager versus SPIRE Server/Agent responsibilities.
- Fixed the basic binding example so its pool and binding parse as separate Kubernetes documents.
- Replaced issue-stage wording in the operator spec with durable current-contract language.

## Related Issue

- Fixes #284

## Scope Check

- The PR is documentation-only and follows issue #284.
- Broader CLI documentation consolidation, agent instructions, route aliases, and information-architecture restructuring remain separate cleanup work.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): updated to remove stale implementation-stage wording without changing behavior.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI behavior and output are unchanged.
- Other docs: updated README, deployment guidance, concepts, design, installation, examples, demo, and troubleshooting.

## Follow-Up Work

- Consolidate duplicated CLI reference pages and broader documentation structure separately.

## Verification

- `make docs-build` — passed; 39 pages, 24 aliases.
- Extracted the first YAML block from `docs/examples/basic-binding.md` and parsed it with PyYAML — two documents: `InferencePool`, `InferenceIdentityBinding`.
- Inspected rendered title, description, canonical metadata, JSON-LD, and sitemap entries for every changed published page — passed.
- `git diff --check` — passed.
- Tests not run because the change is documentation-only and does not modify code, API, generated manifests, or build logic.

## Security Review

- The PR documents an existing trust boundary: reserved identity-boundary labels require platform-controlled assignment and Pod-lifetime immutability through external admission policy.
- It does not change GitHub Actions, CI, release automation, credentials, permissions, or runtime enforcement.