### PR TITLE
docs(operator): add boundary label ownership reference

### DIFF
--- a/docs/reference/_index.md
+++ b/docs/reference/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Reference
 weight: 50
-description: "Reference documentation for Kleym API fields, conditions, managed resources, compatibility, dependencies, and GAIE support."
+description: "Reference documentation for Kleym API fields, boundary-label ownership, conditions, managed resources, compatibility, dependencies, and GAIE support."
 aliases:
   - /operator/reference/
 ---
@@ -9,6 +9,7 @@ aliases:
 Stable API facts for fields, conditions, dependencies, compatibility, and managed resources.
 
 - [API](/reference/api/): `InferenceIdentityBinding` fields, defaults, status fields, and external objects resolved by the controller.
+- [Boundary Label Ownership](/reference/boundary-label-ownership/): opt-in Kubernetes admission control for platform-owned identity boundary labels.
 - [Conditions](/reference/conditions/): current condition types, reasons, and status behavior.
 - [Managed Resources](/reference/resources/): resources written by `kleym-operator`, managed labels, naming, and watch behavior.
 - [Compatibility](/reference/compatibility/): compatibility surfaces, change checklist, and upgrade checks.

--- a/docs/reference/boundary-label-ownership.md
+++ b/docs/reference/boundary-label-ownership.md
@@ -1,0 +1,88 @@
+---
+title: Boundary Label Ownership
+weight: 35
+description: "Opt-in Kubernetes admission policy reference for platform-controlled Kleym identity boundary labels on Pods."
+---
+
+`identity.kleym.sonda.red/*` labels select a workload identity boundary. They
+are security-sensitive: an actor that can choose one can select a corresponding
+Kleym-managed SPIFFE identity.
+
+Kleym does not enforce this ownership at the Pod API. It never creates or
+mutates workloads, pools, or Pods. A platform must enforce ownership at
+admission and grant the relevant workload permissions separately.
+
+## Opt-In Admission Reference
+
+[`boundary-label-ownership.yaml`][reference-manifest] is an opt-in,
+cluster-scoped reference manifest. It uses the stable
+`admissionregistration.k8s.io/v1` `ValidatingAdmissionPolicy` API, available in
+Kubernetes v1.30 and later. It is not included in the default Kleym install or
+the reference-environment kustomization.
+
+The manifest treats the authenticator-provided group
+`kleym.sonda.red/platform-workload-operators` as a concrete platform-controlled
+actor group. Replace that group only with the group your authentication system
+actually asserts for the platform workload operator.
+
+Apply the policy and binding deliberately, after reviewing their cluster-wide
+effect:
+
+```sh
+kubectl apply -f test/reference/inference-environment/boundary-label-ownership.yaml
+```
+
+The policy and its binding apply to Pod `CREATE` and `UPDATE` requests in every
+namespace. They enforce these rules:
+
+| Request | Result |
+| --- | --- |
+| Create a Pod with no reserved label | Allowed by this policy. |
+| Create a Pod with a reserved label | Allowed only for a member of `kleym.sonda.red/platform-workload-operators`. |
+| Add, change, or remove a reserved label on an existing Pod | Denied for every actor, including the platform group. |
+| Change ordinary Pod metadata without touching a reserved label | Allowed by this policy; Kubernetes RBAC and other admission controls still apply. |
+
+The CEL update validation compares the reserved-label subset of the old and new
+Pod metadata in both directions. This rejects additions, value changes, and
+removals while leaving non-reserved metadata updates outside this policy.
+
+## Boundary Changes Use Replacement Pods
+
+To change `identity.kleym.sonda.red/variant=prefill` to `decode`, do not mutate
+the existing Pod. The allowed platform actor deletes or replaces the workload's
+Pod through its normal workload-management path, then creates the replacement
+Pod with `identity.kleym.sonda.red/variant=decode`. The policy authorizes the
+reserved label at creation time and rejects any attempt to change the old Pod's
+boundary in place.
+
+This is a Pod-level control. A Deployment, Job, or other workload controller
+must create its replacement Pods as an identity that belongs to the configured
+platform group if its templates use the reserved prefix.
+
+## Responsibility Boundaries
+
+This reference policy owns only admission control for reserved Pod labels. It
+does not grant permissions and does not govern any other identity input:
+
+- Kubernetes RBAC and any additional platform admission controls authorize
+  `InferenceIdentityBinding` create, update, and patch requests.
+- Kubernetes RBAC and admission control authorize service-account assignment on
+  Pods.
+- Kleym remains read-only for workloads, pools, and Pods; it has no
+  workload-mutation RBAC permissions.
+
+Use the least privilege appropriate to the platform. In particular, do not
+infer that the example actor group should receive broad binding-write or
+service-account-assignment permission merely because it may create Pods with a
+reserved boundary label.
+
+## Removal
+
+Remove the binding before the policy:
+
+```sh
+kubectl delete validatingadmissionpolicybinding kleym-reserved-identity-boundary-labels
+kubectl delete validatingadmissionpolicy kleym-reserved-identity-boundary-labels
+```
+
+[reference-manifest]: https://github.com/sonda-red/kleym/blob/main/test/reference/inference-environment/boundary-label-ownership.yaml

--- a/docs/spec/operator.md
+++ b/docs/spec/operator.md
@@ -209,7 +209,13 @@ An identity boundary label is security-sensitive metadata. Permission to assign 
 
 `identity.kleym.sonda.red/*` is reserved for platform-controlled boundary labels. Cluster admission policy must restrict assignment and mutation of reserved labels to platform-controlled actors. Boundary labels are immutable for the lifetime of a Pod; boundary changes use replacement Pods.
 
-Kleym does not mutate workloads, pools, or Pods.
+Deployments must enforce this ownership with Kubernetes admission control. See
+[Boundary Label Ownership][boundary-label-ownership] for an opt-in native
+Kubernetes reference policy.
+
+Kubernetes RBAC and admission control remain responsible for
+`InferenceIdentityBinding` writes and service-account assignment. Kleym does
+not mutate workloads, pools, or Pods and has no workload-mutation RBAC.
 
 ## CLI Boundary
 
@@ -236,3 +242,4 @@ current inspection contract is defined in the [CLI Spec](/spec/cli/).
 [conditions-reference]: /reference/conditions/
 [dependencies]: /reference/dependencies/
 [gaie-compatibility]: /reference/gaie-compatibility/
+[boundary-label-ownership]: /reference/boundary-label-ownership/

--- a/test/chainsaw/boundary-label-ownership/actors.yaml
+++ b/test/chainsaw/boundary-label-ownership/actors.yaml
@@ -1,0 +1,51 @@
+# Test-only authorization. The production reference intentionally leaves Pod
+# authorization to the platform's RBAC design.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kleym-boundary-label-ownership-test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-writer
+  namespace: kleym-boundary-label-ownership-test
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: untrusted-pod-writer
+  namespace: kleym-boundary-label-ownership-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-writer
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: untrusted-workload-writer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: platform-pod-writers
+  namespace: kleym-boundary-label-ownership-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-writer
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: kleym.sonda.red/platform-workload-operators

--- a/test/chainsaw/boundary-label-ownership/chainsaw-test.yaml
+++ b/test/chainsaw/boundary-label-ownership/chainsaw-test.yaml
@@ -1,0 +1,125 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: boundary-label-ownership
+spec:
+  description: Verifies reserved identity boundary label admission on a real API server, including immutable Pod boundaries and platform-controlled replacement.
+  timeouts:
+    apply: 30s
+    assert: 30s
+    cleanup: 30s
+    delete: 30s
+    exec: 2m
+  steps:
+    - name: enforce-reserved-boundary-label-ownership
+      try:
+        # CEL admission evaluation and request impersonation need an API server;
+        # they cannot be covered by the controller's Go or envtest contracts.
+        - script:
+            workDir: ../../..
+            content: |
+              set -eu
+
+              namespace="kleym-boundary-label-ownership-test"
+              policy="kleym-reserved-identity-boundary-labels"
+              platform_group="kleym.sonda.red/platform-workload-operators"
+
+              cleanup() {
+                kubectl delete validatingadmissionpolicybinding "${policy}" --ignore-not-found=true
+                kubectl delete validatingadmissionpolicy "${policy}" --ignore-not-found=true
+                kubectl delete namespace "${namespace}" --ignore-not-found=true --wait=true
+              }
+              trap cleanup EXIT
+
+              cleanup
+              kubectl apply -f test/chainsaw/boundary-label-ownership/actors.yaml
+              kubectl apply -f test/reference/inference-environment/boundary-label-ownership.yaml
+
+              policy_ready=false
+              for _ in $(seq 1 30); do
+                output="$(mktemp)"
+                set +e
+                kubectl --as=untrusted-workload-writer -n "${namespace}" create --dry-run=server -f test/chainsaw/boundary-label-ownership/untrusted-boundary-pod.yaml >"${output}" 2>&1
+                status="$?"
+                set -e
+                if [ "${status}" -ne 0 ] && grep -Fq "Only platform workload operators may create Pods with reserved identity boundary labels." "${output}"; then
+                  policy_ready=true
+                  break
+                fi
+                sleep 1
+              done
+              if [ "${policy_ready}" != true ]; then
+                echo "admission policy binding did not become active" >&2
+                cat "${output}" >&2
+                exit 1
+              fi
+
+              kubectl --as=untrusted-workload-writer -n "${namespace}" create -f - <<'EOF'
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: ordinary-metadata
+                labels:
+                  app.kubernetes.io/name: ordinary-metadata
+              spec:
+                containers:
+                  - name: pause
+                    image: registry.k8s.io/pause:3.10
+              EOF
+              kubectl --as=untrusted-workload-writer -n "${namespace}" label pod ordinary-metadata example.com/revision=2
+
+              output="$(mktemp)"
+              set +e
+              kubectl --as=untrusted-workload-writer -n "${namespace}" create -f test/chainsaw/boundary-label-ownership/untrusted-boundary-pod.yaml >"${output}" 2>&1
+              status="$?"
+              set -e
+              if [ "${status}" -eq 0 ]; then
+                echo "expected reserved-label Pod creation to be denied" >&2
+                cat "${output}" >&2
+                exit 1
+              fi
+              grep -F "Only platform workload operators may create Pods with reserved identity boundary labels." "${output}"
+
+              kubectl --as=platform-workload-writer --as-group="${platform_group}" -n "${namespace}" create -f - <<'EOF'
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: boundary-pod
+                labels:
+                  identity.kleym.sonda.red/variant: prefill
+              spec:
+                containers:
+                  - name: pause
+                    image: registry.k8s.io/pause:3.10
+              EOF
+
+              expect_immutable_denial() {
+                output="$(mktemp)"
+                if "$@" >"${output}" 2>&1; then
+                  echo "expected reserved-label Pod update to be denied" >&2
+                  cat "${output}" >&2
+                  exit 1
+                fi
+                grep -F "Reserved identity boundary labels are immutable for the lifetime of a Pod; create a replacement Pod instead." "${output}"
+              }
+
+              expect_immutable_denial kubectl --as=platform-workload-writer --as-group="${platform_group}" -n "${namespace}" label pod ordinary-metadata identity.kleym.sonda.red/variant=prefill
+              expect_immutable_denial kubectl --as=platform-workload-writer --as-group="${platform_group}" -n "${namespace}" label pod boundary-pod identity.kleym.sonda.red/variant=decode --overwrite
+              expect_immutable_denial kubectl --as=platform-workload-writer --as-group="${platform_group}" -n "${namespace}" label pod boundary-pod identity.kleym.sonda.red/variant-
+
+              kubectl --as=platform-workload-writer --as-group="${platform_group}" -n "${namespace}" delete pod boundary-pod --grace-period=0 --force --wait=false
+              kubectl -n "${namespace}" wait --for=delete pod/boundary-pod --timeout=30s
+              kubectl --as=platform-workload-writer --as-group="${platform_group}" -n "${namespace}" create -f - <<'EOF'
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: boundary-pod
+                labels:
+                  identity.kleym.sonda.red/variant: decode
+              spec:
+                containers:
+                  - name: pause
+                    image: registry.k8s.io/pause:3.10
+              EOF
+              test "$(kubectl -n "${namespace}" get pod boundary-pod -o jsonpath='{.metadata.labels.identity\.kleym\.sonda\.red/variant}')" = "decode"

--- a/test/chainsaw/boundary-label-ownership/untrusted-boundary-pod.yaml
+++ b/test/chainsaw/boundary-label-ownership/untrusted-boundary-pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: untrusted-boundary
+  labels:
+    identity.kleym.sonda.red/variant: untrusted
+spec:
+  containers:
+    - name: pause
+      image: registry.k8s.io/pause:3.10

--- a/test/reference/inference-environment/README.md
+++ b/test/reference/inference-environment/README.md
@@ -55,6 +55,16 @@ This reference environment intentionally does not include:
 Those layers are separate from the reference inference environment and should be
 added only by tests or demos that explicitly need them.
 
+## Optional Boundary Label Admission Policy
+
+`boundary-label-ownership.yaml` is a separate, cluster-scoped
+`ValidatingAdmissionPolicy` and binding reference. It is deliberately excluded
+from `kustomization.yaml`: it reserves `identity.kleym.sonda.red/*` for the
+example platform actor group `kleym.sonda.red/platform-workload-operators` and
+therefore affects Pod admission in every namespace. See
+[Boundary Label Ownership](/reference/boundary-label-ownership/) before
+applying it.
+
 Apply the reference manifests with:
 
 ```sh

--- a/test/reference/inference-environment/boundary-label-ownership.yaml
+++ b/test/reference/inference-environment/boundary-label-ownership.yaml
@@ -1,0 +1,41 @@
+# Optional, cluster-scoped reference policy. It is not part of the reference
+# environment kustomization or the default kleym installation.
+#
+# This example treats the authenticator-provided group
+# kleym.sonda.red/platform-workload-operators as the platform-controlled actor
+# group. Grant that group the required Pod permissions separately with RBAC.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: kleym-reserved-identity-boundary-labels
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - pods
+  validations:
+    - expression: >-
+        request.operation != 'CREATE' || !has(object.metadata.labels) || object.metadata.labels.all(key, !key.startsWith('identity.kleym.sonda.red/') || request.userInfo.groups.exists(group, group == 'kleym.sonda.red/platform-workload-operators'))
+      message: Only platform workload operators may create Pods with reserved identity boundary labels.
+      reason: Forbidden
+    - expression: >-
+        request.operation != 'UPDATE' || ((!has(object.metadata.labels) || object.metadata.labels.all(key, !key.startsWith('identity.kleym.sonda.red/') || (has(oldObject.metadata.labels) && key in oldObject.metadata.labels && object.metadata.labels[key] == oldObject.metadata.labels[key]))) && (!has(oldObject.metadata.labels) || oldObject.metadata.labels.all(key, !key.startsWith('identity.kleym.sonda.red/') || (has(object.metadata.labels) && key in object.metadata.labels && oldObject.metadata.labels[key] == object.metadata.labels[key]))))
+      message: Reserved identity boundary labels are immutable for the lifetime of a Pod; create a replacement Pod instead.
+      reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: kleym-reserved-identity-boundary-labels
+spec:
+  policyName: kleym-reserved-identity-boundary-labels
+  validationActions:
+    - Deny


### PR DESCRIPTION
## Summary

- Add an opt-in native Kubernetes admission-policy reference for reserved Kleym identity-boundary labels.
- Add a focused Chainsaw scenario that proves the reference policy's allowed and denied Pod admission behavior.

## What I Changed And Why

- Add a cluster-scoped `ValidatingAdmissionPolicy` and binding that limits reserved-label assignment on Pod creation to the documented platform actor group and makes reserved labels immutable after creation.
- Keep the policy outside the default installation and reference-environment kustomization because it applies across namespaces.
- Add the policy boundary and responsibility split to the operator spec, with deployment-specific details in a reference page.

## Related Issue

- Closes #278

## Scope Check

- Implements the reserved-label ownership controls, reference documentation, and Kubernetes admission validation requested by #278.
- Does not change Kleym reconciliation, workload mutation RBAC, binding-write authorization, service-account authorization, or SPIRE conformance behavior.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): updated with the required admission-enforcement boundary and a link to the reference policy.
- CLI Spec (`docs/spec/cli.md`): not needed because the read-only CLI contract is unchanged.
- Other docs: updated with the Boundary Label Ownership reference page, reference index entry, and reference-environment guidance.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run: `bin/chainsaw test test/chainsaw/boundary-label-ownership --fail-fast` on a fresh Kind v1.34 cluster; `make docs-build`; `git diff --check`.
- Tests not run and why: `make test` and `make lint` were not run because this change adds documentation, Kubernetes manifests, and a focused API-server admission test without Go, controller, generated-artifact, or build-logic changes.

## Security Review

- This PR adds a cluster-wide admission reference for a security-sensitive label prefix. It uses Kubernetes-native `ValidatingAdmissionPolicy` with `failurePolicy: Fail` and `Deny` enforcement, is excluded from Kleym's default installation, and grants no RBAC permissions itself.
- No GitHub Actions, CI, release automation, credentials, secrets, or untrusted command-execution paths are changed.