### PR TITLE
refactor(controller): remove dead compatibility scaffolding

### DIFF
--- a/cmd/kleym-operator/main.go
+++ b/cmd/kleym-operator/main.go
@@ -179,7 +179,6 @@ func main() {
 
 	if err := (&controller.InferenceIdentityBindingReconciler{
 		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
 		Config: operatorConfig,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "InferenceIdentityBinding")

--- a/internal/controller/inferenceidentitybinding_conflict_test.go
+++ b/internal/controller/inferenceidentitybinding_conflict_test.go
@@ -139,7 +139,7 @@ func TestConflictOutputDeletionFailureReturnsAndDoesNotSettleConflict(t *testing
 			return cli.Delete(ctx, object, opts...)
 		},
 	})
-	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped, Scheme: base.Scheme}
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped}
 	_, err := reconciler.Reconcile(ctx, bindingRequest(second.Name))
 	if !errors.Is(err, deleteErr) {
 		t.Fatalf("Reconcile error = %v, want %v", err, deleteErr)
@@ -182,7 +182,7 @@ func TestConflictCleanupUsesOwnershipRetainedAfterUpdateFailure(t *testing.T) {
 			return cli.Update(ctx, object, opts...)
 		},
 	})
-	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped, Scheme: base.Scheme}
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped}
 	if _, err := reconciler.Reconcile(ctx, bindingRequest(first.Name)); !errors.Is(err, updateErr) {
 		t.Fatalf("failure Reconcile error = %v, want %v", err, updateErr)
 	}
@@ -313,7 +313,6 @@ func newConflictTestReconciler(t *testing.T, objects ...client.Object) *Inferenc
 			WithIndex(&kleymv1alpha1.InferenceIdentityBinding{}, fieldIndexManagedClusterSPIFFEIDName, bindingClusterSPIFFEIDNameIndexValues).
 			WithObjects(objects...).
 			Build(),
-		Scheme: scheme,
 	}
 }
 

--- a/internal/controller/inferenceidentitybinding_controller.go
+++ b/internal/controller/inferenceidentitybinding_controller.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -85,7 +84,6 @@ var (
 // InferenceIdentityBindingReconciler reconciles a InferenceIdentityBinding object
 type InferenceIdentityBindingReconciler struct {
 	client.Client
-	Scheme            *runtime.Scheme
 	Config            OperatorConfig
 	Recorder          events.EventRecorder
 	MetricsRecorder   bindingOutcomeRecorder

--- a/internal/controller/inferenceidentitybinding_delete_test.go
+++ b/internal/controller/inferenceidentitybinding_delete_test.go
@@ -41,7 +41,6 @@ func TestReconcileDeleteWaitsForManagedClusterSPIFFEIDsToDisappear(t *testing.T)
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
 			WithObjects(binding, managed).
 			Build(),
-		Scheme: scheme,
 	}
 
 	fetchedBinding := &kleymv1alpha1.InferenceIdentityBinding{}
@@ -125,7 +124,6 @@ func TestCleanupDoesNotDeleteForeignOutputWithManagedLabels(t *testing.T) {
 	reconciler := &InferenceIdentityBindingReconciler{
 		Config: testOperatorConfig(),
 		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(binding, recorded, foreign).Build(),
-		Scheme: scheme,
 	}
 
 	if err := reconciler.cleanupManagedClusterSPIFFEIDs(ctx, binding); err != nil {
@@ -263,7 +261,7 @@ func TestChangedOutputNameDeleteFailureRetainsRecordedOutput(t *testing.T) {
 			return cli.Delete(ctx, object, opts...)
 		},
 	})
-	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped, Scheme: base.Scheme}
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped}
 	if _, err := reconciler.Reconcile(ctx, bindingRequest(binding.Name)); !errors.Is(err, deleteErr) {
 		t.Fatalf("Reconcile error = %v, want %v", err, deleteErr)
 	}
@@ -323,7 +321,7 @@ func TestChangedOutputNameStatusFailureRetainsReplacementClaim(t *testing.T) {
 			return cli.SubResource(subResourceName).Patch(ctx, object, patch, opts...)
 		},
 	})
-	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped, Scheme: base.Scheme}
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped}
 
 	if _, err := reconciler.Reconcile(ctx, bindingRequest(binding.Name)); !errors.Is(err, statusErr) {
 		t.Fatalf("replacement Reconcile error = %v, want %v", err, statusErr)
@@ -392,7 +390,7 @@ func TestRecordedOutputUpdateFailureRetainsOwnershipAndRetries(t *testing.T) {
 			return cli.Update(ctx, object, opts...)
 		},
 	})
-	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped, Scheme: base.Scheme}
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped}
 
 	if _, err := reconciler.Reconcile(ctx, bindingRequest(binding.Name)); !errors.Is(err, updateErr) {
 		t.Fatalf("first Reconcile error = %v, want %v", err, updateErr)
@@ -451,7 +449,7 @@ func TestCreateStatusPatchFailureRetainsPendingClaimAndRetries(t *testing.T) {
 			return cli.SubResource(subResourceName).Patch(ctx, object, patch, opts...)
 		},
 	})
-	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped, Scheme: base.Scheme}
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped}
 
 	if _, err := reconciler.Reconcile(ctx, bindingRequest("binding-create-status-retry")); !errors.Is(err, statusErr) {
 		t.Fatalf("first Reconcile error = %v, want %v", err, statusErr)
@@ -514,7 +512,7 @@ func TestReservationStatusPatchFailureDoesNotCreateOrPersistClaim(t *testing.T) 
 			return cli.SubResource(subResourceName).Patch(ctx, object, patch, opts...)
 		},
 	})
-	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped, Scheme: base.Scheme}
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped}
 
 	if _, err := reconciler.Reconcile(ctx, bindingRequest("binding-reservation-status-failure")); !errors.Is(err, statusErr) {
 		t.Fatalf("Reconcile error = %v, want %v", err, statusErr)
@@ -585,7 +583,6 @@ func TestFinalizationNoMatchPreservesOwnershipAndFinalizer(t *testing.T) {
 	reconciler := &InferenceIdentityBindingReconciler{
 		Config: testOperatorConfig(),
 		Client: noMatchClient{Client: base, getNoMatchGVK: clusterSPIFFEIDGVK},
-		Scheme: scheme,
 	}
 
 	fetched := fetchBinding(t, ctx, reconciler.Client, binding.Name)
@@ -621,7 +618,6 @@ func TestValidationCleanupNoMatchPreservesOwnershipAndRetries(t *testing.T) {
 	reconciler := &InferenceIdentityBindingReconciler{
 		Config: testOperatorConfig(),
 		Client: noMatchClient{Client: base, getNoMatchGVK: clusterSPIFFEIDGVK},
-		Scheme: scheme,
 	}
 
 	if _, err := reconciler.Reconcile(ctx, bindingRequest(binding.Name)); !meta.IsNoMatchError(err) {
@@ -666,7 +662,7 @@ func TestFinalizerCleanupUsesOwnershipRetainedAfterUpdateFailure(t *testing.T) {
 			return cli.Update(ctx, object, opts...)
 		},
 	})
-	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped, Scheme: base.Scheme}
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: wrapped}
 	if _, err := reconciler.Reconcile(ctx, bindingRequest(binding.Name)); !errors.Is(err, updateErr) {
 		t.Fatalf("failure Reconcile error = %v, want %v", err, updateErr)
 	}
@@ -708,7 +704,6 @@ func TestReconcileCorrectsClusterSPIFFEIDDriftOnResync(t *testing.T) {
 				binding,
 			).
 			Build(),
-		Scheme: scheme,
 	}
 
 	request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: binding.Name}}

--- a/internal/controller/inferenceidentitybinding_envtest_test.go
+++ b/internal/controller/inferenceidentitybinding_envtest_test.go
@@ -65,7 +65,7 @@ func TestObservedGenerationAdvancesAfterBindingSpecChange(t *testing.T) {
 			t.Errorf("delete binding: %v", err)
 			return
 		}
-		reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: k8sClient, Scheme: k8sClient.Scheme()}
+		reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: k8sClient}
 		deadline := time.Now().Add(5 * time.Second)
 		for {
 			if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key}); err != nil {
@@ -86,7 +86,7 @@ func TestObservedGenerationAdvancesAfterBindingSpecChange(t *testing.T) {
 		}
 	})
 
-	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: k8sClient, Scheme: k8sClient.Scheme()}
+	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(), Client: k8sClient}
 	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key}); err != nil {
 		t.Fatalf("initial reconcile: %v", err)
 	}

--- a/internal/controller/inferenceidentitybinding_logging_test.go
+++ b/internal/controller/inferenceidentitybinding_logging_test.go
@@ -32,7 +32,6 @@ func TestReconcileLogsStructuredSuccessPath(t *testing.T) {
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
 			WithObjects(newTestPool(), binding).
 			Build(),
-		Scheme: scheme,
 	}
 
 	_, err := reconciler.Reconcile(ctx, reconcile.Request{
@@ -82,7 +81,6 @@ func TestReconcileLogsFailureStatus(t *testing.T) {
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
 			WithObjects(newTestPool(), binding).
 			Build(),
-		Scheme: scheme,
 	}
 
 	_, err := reconciler.Reconcile(ctx, reconcile.Request{
@@ -140,7 +138,6 @@ func TestReconcileClusterSPIFFEIDsLogsApplyDecisions(t *testing.T) {
 			WithScheme(scheme).
 			WithObjects(binding, drifted).
 			Build(),
-		Scheme: scheme,
 	}
 
 	if _, err := reconciler.reconcileClusterSPIFFEIDs(ctx, binding, []renderedIdentity{identity}); err != nil {

--- a/internal/controller/inferenceidentitybinding_metrics_test.go
+++ b/internal/controller/inferenceidentitybinding_metrics_test.go
@@ -119,7 +119,6 @@ func TestReconcileRecordsSuccessfulTerminalOutcomeAfterStatusPatch(t *testing.T)
 
 	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client:          k8sClient,
-		Scheme:          scheme,
 		MetricsRecorder: recorder,
 	}
 
@@ -160,7 +159,6 @@ func TestReconcileResolvesStaleConflictCondition(t *testing.T) {
 	reconciler := &InferenceIdentityBindingReconciler{
 		Config: testOperatorConfig(),
 		Client: k8sClient,
-		Scheme: scheme,
 	}
 	key := types.NamespacedName{Namespace: testNamespace, Name: binding.Name}
 
@@ -198,7 +196,6 @@ func TestReconcileRecordsFailureTerminalOutcomeAfterStatusPatch(t *testing.T) {
 
 	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client:          k8sClient,
-		Scheme:          scheme,
 		MetricsRecorder: recorder,
 	}
 

--- a/internal/controller/inferenceidentitybinding_render.go
+++ b/internal/controller/inferenceidentitybinding_render.go
@@ -28,10 +28,10 @@ import (
 func (r *InferenceIdentityBindingReconciler) renderIdentity(
 	binding *kleymv1alpha1.InferenceIdentityBinding,
 	pool *unstructured.Unstructured,
-) (identity.RenderedIdentity, error) {
+) (identity.Plan, error) {
 	target, err := gaie.ResolveInferenceTarget(pool)
 	if err != nil {
-		return identity.RenderedIdentity{}, &identity.StateError{
+		return identity.Plan{}, &identity.StateError{
 			ConditionType: identity.ConditionTypeUnsafeSelector,
 			Reason:        identity.ReasonInvalidPoolSelector,
 			Message:       err.Error(),
@@ -66,15 +66,15 @@ func bindingIdentityBoundary(binding *kleymv1alpha1.InferenceIdentityBinding) (i
 func (r *InferenceIdentityBindingReconciler) renderIdentityForBinding(
 	ctx context.Context,
 	binding *kleymv1alpha1.InferenceIdentityBinding,
-) (identity.RenderedIdentity, error) {
+) (identity.Plan, error) {
 	poolRef, err := gaie.BindingPoolRef(binding)
 	if err != nil {
-		return identity.RenderedIdentity{}, err
+		return identity.Plan{}, err
 	}
 
 	pool, err := r.resolveInferencePool(ctx, poolRef)
 	if err != nil {
-		return identity.RenderedIdentity{}, err
+		return identity.Plan{}, err
 	}
 
 	return r.renderIdentity(binding, pool)

--- a/internal/controller/inferenceidentitybinding_resolver_test.go
+++ b/internal/controller/inferenceidentitybinding_resolver_test.go
@@ -26,7 +26,6 @@ func TestReconcileSetsInvalidRefWhenPoolCannotBeResolved(t *testing.T) {
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
 			WithObjects(binding).
 			Build(),
-		Scheme: scheme,
 	}
 
 	_, err := reconciler.Reconcile(ctx, reconcile.Request{
@@ -53,7 +52,6 @@ func TestReconcilePoolOnlyDoesNotRequireObjective(t *testing.T) {
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
 			WithObjects(newTestPool(), binding).
 			Build(),
-		Scheme: scheme,
 	}
 
 	_, err := reconciler.Reconcile(ctx, reconcile.Request{
@@ -83,7 +81,6 @@ func TestReconcileUsesOperatorConfigForRenderedOutput(t *testing.T) {
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
 			WithObjects(newTestPool(), binding).
 			Build(),
-		Scheme: scheme,
 	}
 
 	_, err := reconciler.Reconcile(ctx, reconcile.Request{

--- a/internal/controller/inferenceidentitybinding_setup_partial_crd_test.go
+++ b/internal/controller/inferenceidentitybinding_setup_partial_crd_test.go
@@ -86,7 +86,6 @@ func TestSetupWithManagerStartsAndReconcilesWithCurrentPoolCRD(t *testing.T) {
 
 	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
 	}
 	if err := reconciler.SetupWithManager(mgr); err != nil {
 		t.Fatalf("setup controller with partial CRDs: %v", err)
@@ -232,7 +231,6 @@ func TestSetupWithManagerSkipsClusterSPIFFEIDWatchWhenCRDMissing(t *testing.T) {
 
 	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
 	}
 	if err := reconciler.SetupWithManager(mgr); err != nil {
 		t.Fatalf("setup controller without ClusterSPIFFEID CRD: %v", err)
@@ -350,7 +348,6 @@ func TestSetupWithManagerFailsWithoutAnySupportedGAIEGVKs(t *testing.T) {
 
 	reconciler := &InferenceIdentityBindingReconciler{Config: testOperatorConfig(),
 		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
 	}
 	setupErr := reconciler.SetupWithManager(mgr)
 	if setupErr == nil {

--- a/internal/controller/inferenceidentitybinding_taxonomy_test.go
+++ b/internal/controller/inferenceidentitybinding_taxonomy_test.go
@@ -34,7 +34,6 @@ func TestReconcileConditionTaxonomySuccess(t *testing.T) {
 			WithStatusSubresource(&kleymv1alpha1.InferenceIdentityBinding{}).
 			WithObjects(newTestPool(), binding).
 			Build(),
-		Scheme: scheme,
 	}
 
 	result, err := reconciler.Reconcile(ctx, reconcile.Request{
@@ -125,7 +124,6 @@ func TestReconcileManagedOutputApplyFailureSetsFailureStatus(t *testing.T) {
 	reconciler := &InferenceIdentityBindingReconciler{
 		Config: testOperatorConfig(),
 		Client: k8sClient,
-		Scheme: scheme,
 	}
 
 	result, err := reconciler.Reconcile(ctx, reconcile.Request{
@@ -209,7 +207,6 @@ func TestReconcileFailureCleanupApplyFailureSetsManagedOutputFailureStatus(t *te
 	reconciler := &InferenceIdentityBindingReconciler{
 		Config: testOperatorConfig(),
 		Client: k8sClient,
-		Scheme: scheme,
 	}
 
 	result, err := reconciler.Reconcile(ctx, reconcile.Request{
@@ -347,7 +344,6 @@ func TestReconcileConditionTaxonomyFailures(t *testing.T) {
 			reconciler := &InferenceIdentityBindingReconciler{
 				Config: config,
 				Client: k8sClient,
-				Scheme: scheme,
 			}
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{

--- a/internal/controller/inferenceidentitybinding_types.go
+++ b/internal/controller/inferenceidentitybinding_types.go
@@ -50,7 +50,7 @@ func newStateError(conditionType, reason, message string) *reconcileStateError {
 	}
 }
 
-type renderedIdentity = identity.RenderedIdentity
+type renderedIdentity = identity.Plan
 
 type desiredBindingState struct {
 	identities []renderedIdentity

--- a/internal/controller/inferenceidentitybinding_watch_test.go
+++ b/internal/controller/inferenceidentitybinding_watch_test.go
@@ -214,7 +214,6 @@ func newIndexedWatchTestReconciler(t *testing.T, objects ...client.Object) *Infe
 			WithIndex(&kleymv1alpha1.InferenceIdentityBinding{}, fieldIndexManagedClusterSPIFFEIDName, bindingClusterSPIFFEIDNameIndexValues).
 			WithObjects(objects...).
 			Build(),
-		Scheme: scheme,
 	}
 }
 

--- a/internal/controller/inferenceidentitybinding_watch_test.go
+++ b/internal/controller/inferenceidentitybinding_watch_test.go
@@ -79,7 +79,6 @@ func TestReverseBindingLookupsReturnMissingIndexErrors(t *testing.T) {
 	scheme := newControllerTestScheme(t)
 	reconciler := &InferenceIdentityBindingReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(binding).Build(),
-		Scheme: scheme,
 	}
 
 	if _, err := reconciler.listBindingsReferencingPool(ctx, testNamespace, "pool-a"); err == nil {

--- a/internal/identity/types.go
+++ b/internal/identity/types.go
@@ -100,9 +100,6 @@ type Plan struct {
 	Boundary       Boundary
 }
 
-// RenderedIdentity is kept as a compatibility alias for callers during the package split.
-type RenderedIdentity = Plan
-
 type renderTemplateData struct {
 	Namespace          string
 	ServiceAccountName string

--- a/internal/inspection/inspection.go
+++ b/internal/inspection/inspection.go
@@ -310,12 +310,12 @@ func (i *bindingInspector) inspectRenderedIdentity(
 	availablePoolGVKs []schema.GroupVersionKind,
 	identityConfig resolvedIdentityConfig,
 	report *BindingInspectionReport,
-) (identity.RenderedIdentity, bool) {
+) (identity.Plan, bool) {
 	poolRef, err := gaie.BindingPoolRef(binding)
 	if err != nil {
 		report.Capabilities.GAIEResources = BindingInspectionCapabilityPartial
 		i.addFindingForError(report, err, bindingInspectionBindingTargetRef(binding), findingInvalidRef)
-		return identity.RenderedIdentity{}, false
+		return identity.Plan{}, false
 	}
 	report.Resolved.PoolRef = poolRefToReportRef(poolRef, schema.GroupVersionKind{Kind: "InferencePool"})
 
@@ -323,7 +323,7 @@ func (i *bindingInspector) inspectRenderedIdentity(
 	if err != nil {
 		report.Capabilities.GAIEResources = BindingInspectionCapabilityPartial
 		i.addFindingForError(report, err, *report.Resolved.PoolRef, "")
-		return identity.RenderedIdentity{}, false
+		return identity.Plan{}, false
 	}
 	report.Resolved.PoolRef = poolRefToReportRef(poolRef, pool.GroupVersionKind())
 
@@ -335,7 +335,7 @@ func (i *bindingInspector) inspectRenderedIdentity(
 			Reason:        identity.ReasonInvalidPoolSelector,
 			Message:       err.Error(),
 		}, *report.Resolved.PoolRef, "")
-		return identity.RenderedIdentity{}, false
+		return identity.Plan{}, false
 	}
 
 	rendered, err := identity.PlanIdentity(identity.PlanInput{
@@ -351,7 +351,7 @@ func (i *bindingInspector) inspectRenderedIdentity(
 	if err != nil {
 		report.Capabilities.GAIEResources = BindingInspectionCapabilityFull
 		i.addFindingForError(report, err, bindingInspectionBindingTargetRef(binding), "")
-		return identity.RenderedIdentity{}, false
+		return identity.Plan{}, false
 	}
 
 	provenance := selectorProvenance(rendered, target.DerivedSelectors)
@@ -388,7 +388,7 @@ func (i *bindingInspector) inspectRenderedIdentity(
 func (i *bindingInspector) inspectMatchedPods(
 	ctx context.Context,
 	binding *kleymv1alpha1.InferenceIdentityBinding,
-	rendered identity.RenderedIdentity,
+	rendered identity.Plan,
 	renderedReady bool,
 	report *BindingInspectionReport,
 ) {
@@ -442,7 +442,7 @@ func (i *bindingInspector) inspectMatchedPods(
 func (i *bindingInspector) listMatchingPods(
 	ctx context.Context,
 	binding *kleymv1alpha1.InferenceIdentityBinding,
-	rendered identity.RenderedIdentity,
+	rendered identity.Plan,
 ) ([]corev1.Pod, error) {
 	matchLabels, err := podSelectorMatchLabels(rendered.PodSelector)
 	if err != nil {
@@ -792,7 +792,7 @@ func bindingInspectionGVKs(gvks []schema.GroupVersionKind) []BindingInspectionGV
 }
 
 func selectorProvenance(
-	rendered identity.RenderedIdentity,
+	rendered identity.Plan,
 	poolDerivedSelectors []string,
 ) BindingInspectionSelectorProvenance {
 	poolDerived := setFromStrings(poolDerivedSelectors)

--- a/internal/spirecm/clusterspiffeid.go
+++ b/internal/spirecm/clusterspiffeid.go
@@ -18,7 +18,6 @@ package spirecm
 import (
 	"crypto/sha1"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -53,13 +52,6 @@ var clusterSPIFFEIDGVK = schema.GroupVersionKind{
 	Group:   "spire.spiffe.io",
 	Version: "v1alpha1",
 	Kind:    "ClusterSPIFFEID",
-}
-
-// DriftEntry summarizes one desired-versus-observed ClusterSPIFFEID mismatch.
-type DriftEntry struct {
-	Field    string
-	Desired  string
-	Observed string
 }
 
 // ClusterSPIFFEIDGVK returns the SPIRE Controller Manager ClusterSPIFFEID GVK.
@@ -192,39 +184,6 @@ func MergeDesiredClusterSPIFFEID(current *unstructured.Unstructured, desired *un
 	current.SetLabels(labels)
 }
 
-// DriftEntries compares desired and observed ClusterSPIFFEID fields relevant to Kleym.
-func DriftEntries(desired *unstructured.Unstructured, observed *unstructured.Unstructured) []DriftEntry {
-	entries := []DriftEntry{}
-	if desired.GetName() != observed.GetName() {
-		entries = append(entries, DriftEntry{
-			Field:    "metadata.name",
-			Desired:  desired.GetName(),
-			Observed: observed.GetName(),
-		})
-	}
-
-	desiredSpec, _, _ := unstructured.NestedMap(desired.Object, "spec")
-	observedSpec, _, _ := unstructured.NestedMap(observed.Object, "spec")
-	for _, field := range []string{
-		"spiffeIDTemplate",
-		"podSelector",
-		"workloadSelectorTemplates",
-		"hint",
-		"fallback",
-		"className",
-	} {
-		if reflect.DeepEqual(desiredSpec[field], observedSpec[field]) {
-			continue
-		}
-		entries = append(entries, DriftEntry{
-			Field:    "spec." + field,
-			Desired:  stableValueString(desiredSpec[field]),
-			Observed: stableValueString(observedSpec[field]),
-		})
-	}
-	return entries
-}
-
 func sanitizeDNSLabel(input string) string {
 	lower := strings.ToLower(strings.TrimSpace(input))
 	if lower == "" {
@@ -252,25 +211,4 @@ func sanitizeDNSLabel(input string) string {
 	}
 
 	return sanitized
-}
-
-func stableValueString(value any) string {
-	if value == nil {
-		return ""
-	}
-	switch typed := value.(type) {
-	case string:
-		return typed
-	case bool:
-		if typed {
-			return "true"
-		}
-		return "false"
-	default:
-		data, err := json.Marshal(typed)
-		if err != nil {
-			return fmt.Sprint(typed)
-		}
-		return string(data)
-	}
 }


### PR DESCRIPTION
## Summary

- Remove unused compatibility scaffolding from the operator and identity packages.

## What I Changed And Why

- Delete the unused ClusterSPIFFEID drift-reporting types and formatter.
- Remove the unread reconciler `Scheme` field and its obsolete setup/test assignments.
- Use `identity.Plan` directly and remove the temporary `RenderedIdentity` alias.

## Related Issue

- Closes #286

## Scope Check

- Implements the behavior-preserving cleanup requested by #286. Reconciliation, identity rendering, selectors, status, finalizers, and CLI behavior are unchanged.
- No adjacent refactors were included.

## Spec And Docs

- Operator Spec (`docs/spec/operator.md`): not needed because the operator contract is unchanged.
- CLI Spec (`docs/spec/cli.md`): not needed because CLI behavior is unchanged.
- Other docs: not needed because this removes internal dead code only.

## Follow-Up Work

- Proposed follow-up issue(s), if any: none.

## Verification

- Commands run: `make test`; `make lint`; `git diff --check`.
- Tests not run and why: none.

## Security Review

- No GitHub Actions, CI, release automation, credentials, or trust boundaries are changed.